### PR TITLE
Negotiate capabilities before starting uplink tenants

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1650,11 +1650,17 @@ func (c *Coordinator) Start(ctx context.Context) error {
 			cloudURL = DefaultCloudURL
 		}
 
+		var uplinkOptions []uplink.ClientOption
+		if labs.AppVisibility() {
+			uplinkOptions = append(uplinkOptions, uplink.WithSession(version.GetInfo().Version))
+		}
+
 		link := uplink.NewClient(
 			cloudURL,
 			c.authClient,
 			uplink.NewMessageRouter(),
 			c.Log.With("component", "uplink"),
+			uplinkOptions...,
 		)
 		anywhereConn := anywhere.New(anywhere.Config{
 			ClusterXID: c.CloudAuth.ClusterID,

--- a/pkg/anywhere/anywhere.go
+++ b/pkg/anywhere/anywhere.go
@@ -49,6 +49,10 @@ func New(cfg Config) *Connector {
 		log:  log,
 	}
 
+	cfg.Uplink.OfferCapability(uplink.CapabilityOffer{
+		Name:     uplink.CapabilityPopConnect,
+		Versions: []uint{1},
+	})
 	cfg.Uplink.Handle(TypeConnectionRequest, c.handleConnectionRequest)
 
 	// Startup confirmation. Anywhere is otherwise silent until a POP request

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -69,6 +69,7 @@ const (
 // every other tenant is queued behind them — so those go best-effort or not at
 // all.
 type Link interface {
+	OfferCapability(offer uplink.CapabilityOffer)
 	Handle(msgType string, handler uplink.MessageHandler)
 	SendContext(ctx context.Context, env *uplink.Envelope) error
 	Send(env *uplink.Envelope)
@@ -114,6 +115,10 @@ func New(cfg Config) *Server {
 		sessions: make(map[string]*session),
 	}
 
+	cfg.Uplink.OfferCapability(uplink.CapabilityOffer{
+		Name:     uplink.CapabilityRPCRelay,
+		Versions: []uint{1},
+	})
 	cfg.Uplink.Handle(TypeOpen, s.handleOpen)
 	cfg.Uplink.Handle(TypeData, s.handleData)
 	cfg.Uplink.Handle(TypeClose, s.handleClose)

--- a/pkg/cloudrpc/cloudrpc_test.go
+++ b/pkg/cloudrpc/cloudrpc_test.go
@@ -24,6 +24,7 @@ import (
 type fakeLink struct {
 	mu       sync.Mutex
 	handlers map[string]uplink.MessageHandler
+	offers   []uplink.CapabilityOffer
 
 	out chan *uplink.Envelope
 
@@ -39,6 +40,12 @@ func newFakeLink() *fakeLink {
 		// that overflows it is measuring the fake rather than the code.
 		out: make(chan *uplink.Envelope, 4096),
 	}
+}
+
+func (l *fakeLink) OfferCapability(offer uplink.CapabilityOffer) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.offers = append(l.offers, offer)
 }
 
 func (l *fakeLink) Handle(msgType string, h uplink.MessageHandler) {
@@ -146,6 +153,16 @@ func (c *relayConn) Recv() ([]byte, error) {
 }
 
 func (c *relayConn) Close() error { return nil }
+
+func TestRelayOffersItsUplinkCapability(t *testing.T) {
+	link := newFakeLink()
+	cloudrpc.New(cloudrpc.Config{Uplink: link, Log: slog.Default()})
+
+	require.Equal(t, []uplink.CapabilityOffer{{
+		Name:     uplink.CapabilityRPCRelay,
+		Versions: []uint{1},
+	}}, link.offers)
+}
 
 // clusterWithRelay stands up an RPC server exposing iface, fronted by a relay on
 // a fake link, and returns the link.

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -1,4 +1,9 @@
 features:
+  - name: appvisibility
+    predicate: AppVisibility
+    description: Negotiate app visibility protocols over the cloud uplink
+    default: false
+
   - name: distributedrunners
     predicate: DistributedRunners
     description: Schedule jobs across multiple runner nodes

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -11,6 +11,7 @@ import (
 
 // Feature name constants
 const (
+	FeatureAppVisibility      = "appvisibility"
 	FeatureDistributedRunners = "distributedrunners"
 	FeatureSagas              = "sagas"
 )
@@ -18,6 +19,7 @@ const (
 // AllFeatures returns a list of all known feature names
 func AllFeatures() []string {
 	return []string{
+		FeatureAppVisibility,
 		FeatureDistributedRunners,
 		FeatureSagas,
 	}
@@ -26,6 +28,7 @@ func AllFeatures() []string {
 // FeatureDescriptions returns a map of feature names to their descriptions
 func FeatureDescriptions() map[string]string {
 	return map[string]string{
+		FeatureAppVisibility:      "Negotiate app visibility protocols over the cloud uplink",
 		FeatureDistributedRunners: "Schedule jobs across multiple runner nodes",
 		FeatureSagas:              "Use saga-based crash-recoverable workflows",
 	}
@@ -38,6 +41,7 @@ var (
 
 // featureDefaults holds the default state for each feature
 var featureDefaults = map[string]bool{
+	FeatureAppVisibility:      false,
 	FeatureDistributedRunners: true,
 	FeatureSagas:              true,
 }
@@ -134,6 +138,12 @@ func IsEnabled(name string) bool {
 }
 
 // Feature predicate functions
+
+// AppVisibility returns whether the appvisibility feature is enabled.
+// Negotiate app visibility protocols over the cloud uplink
+func AppVisibility() bool {
+	return IsEnabled(FeatureAppVisibility)
+}
 
 // DistributedRunners returns whether the distributedrunners feature is enabled.
 // Schedule jobs across multiple runner nodes

--- a/pkg/uplink/client.go
+++ b/pkg/uplink/client.go
@@ -23,11 +23,12 @@ const (
 	// backpressure does not immediately push the best-effort tenants over their
 	// drop threshold. The two coexist in one queue: a blocked sender waits for
 	// room, while Send discards as soon as there is none.
-	outboxSize     = 256
-	initialBackoff = 1 * time.Second
-	maxBackoff     = 60 * time.Second
-	wsEndpoint     = "/api/v1/cluster-channel/ws"
-	writeTimeout   = 10 * time.Second
+	outboxSize       = 256
+	initialBackoff   = 1 * time.Second
+	maxBackoff       = 60 * time.Second
+	wsEndpoint       = "/api/v1/cluster-channel/ws"
+	writeTimeout     = 10 * time.Second
+	handshakeTimeout = 10 * time.Second
 
 	// backoffJitter is the fraction of a delay that is randomized away.
 	//
@@ -63,42 +64,71 @@ type Client struct {
 	log        *slog.Logger
 	outbox     chan *Envelope
 
-	mu        sync.Mutex
-	onConnect []func(ctx context.Context)
+	mu           sync.Mutex
+	onConnect    []func(ctx context.Context)
+	onSession    []func(ctx context.Context, session Session)
+	capabilities []CapabilityOffer
+	session      *sessionConfig
+
+	// NewClient enables this for production's pre-handshake path. Keeping it
+	// explicit lets narrow package tests construct a Client without also having
+	// to emulate the two legacy bootstrap exchanges.
+	legacyBootstrap bool
 
 	// getToken overrides auth token acquisition for testing.
 	// When nil, authClient.GetToken is used.
 	getToken func(ctx context.Context) (string, error)
 }
 
+type sessionConfig struct {
+	runtimeVersion string
+}
+
+// ClientOption changes how a Client establishes its connections.
+type ClientOption func(*Client)
+
+// WithSession enables the negotiated session handshake. Callers should gate
+// this while the protocol is experimental; cloud must support the handshake
+// before a runtime starts requiring a welcome.
+func WithSession(runtimeVersion string) ClientOption {
+	return func(c *Client) {
+		c.session = &sessionConfig{runtimeVersion: runtimeVersion}
+	}
+}
+
 // NewClient creates a new WebSocket client.
 //
-// The returned client already handles the two exchanges that belong to the link
-// rather than to any tenant: a clock sync and an organization lookup, both
-// issued on every connect. Tenants layer their own handlers and hooks on top.
-func NewClient(cloudURL string, authClient *cloudauth.AuthClient, router *MessageRouter, log *slog.Logger) *Client {
+// Without WithSession, the client preserves the legacy clock-sync and
+// organization-lookup requests on every connection. With it, those link facts
+// arrive in session.welcome instead. Tenants layer their own handlers,
+// capability offers, and hooks on top.
+func NewClient(cloudURL string, authClient *cloudauth.AuthClient, router *MessageRouter, log *slog.Logger, opts ...ClientOption) *Client {
 	c := &Client{
-		cloudURL:   cloudURL,
-		authClient: authClient,
-		router:     router,
-		log:        log,
-		outbox:     make(chan *Envelope, outboxSize),
+		cloudURL:        cloudURL,
+		authClient:      authClient,
+		router:          router,
+		log:             log,
+		outbox:          make(chan *Envelope, outboxSize),
+		legacyBootstrap: true,
+	}
+	for _, opt := range opts {
+		opt(c)
 	}
 
 	router.Handle(TypeTimeResponse, c.handleTimeResponse)
 	router.Handle(TypeOrgInfoResponse, c.handleOrgInfoResponse)
 
-	c.OnConnect(func(ctx context.Context) {
-		c.log.Info("sending initial requests")
-		//nolint:errcheck // best-effort: a dropped request is retried next connect
-		c.SendMessage(TypeTimeRequest, TimeRequest{
-			ClientTransmitTime: time.Now().UTC(),
-		})
-		//nolint:errcheck // best-effort: a dropped request is retried next connect
-		c.SendMessage(TypeOrgInfoRequest, struct{}{})
-	})
-
 	return c
+}
+
+func (c *Client) sendLegacyInitialRequests() {
+	c.log.Info("sending legacy initial requests")
+	//nolint:errcheck // best-effort: a dropped request is retried next connect
+	c.SendMessage(TypeTimeRequest, TimeRequest{
+		ClientTransmitTime: time.Now().UTC(),
+	})
+	//nolint:errcheck // best-effort: a dropped request is retried next connect
+	c.SendMessage(TypeOrgInfoRequest, struct{}{})
 }
 
 // handleTimeResponse computes the clock offset between this cluster and cloud
@@ -160,14 +190,14 @@ func (c *Client) handleOrgInfoResponse(_ context.Context, data json.RawMessage) 
 	return nil
 }
 
-// OnConnect registers a callback invoked each time a WebSocket
-// connection is established. The handler can use Send to queue
-// messages for the new connection.
+// OnConnect registers a callback invoked each time the link is ready. For a
+// negotiated connection that means after session.welcome has been validated;
+// for a legacy connection it means immediately after the WebSocket connects.
+// The handler can use Send to queue messages for the new connection.
 //
-// Callbacks accumulate rather than replace: the connector registers its
-// own for time sync and org info, and feature reporters add theirs on top.
-// They run in registration order on the connection goroutine, so a
-// callback that needs to do real work should hand off to its own.
+// Callbacks accumulate rather than replace, so each tenant can add its own.
+// They run in registration order on the connection goroutine, so a callback
+// that needs to do real work should hand off to its own goroutine.
 //
 // The context is scoped to the connection, so work handed off that way is
 // cancelled when the connection drops. That is the right lifetime for it:
@@ -179,12 +209,49 @@ func (c *Client) OnConnect(fn func(ctx context.Context)) {
 	c.onConnect = append(c.onConnect, fn)
 }
 
+// OfferCapability adds a protocol family to the next session hello. Offers
+// are snapshotted for each connection, so tenants should register before Run.
+func (c *Client) OfferCapability(offer CapabilityOffer) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, existing := range c.capabilities {
+		if existing.Name == offer.Name {
+			panic(fmt.Sprintf("uplink capability %q offered more than once", offer.Name))
+		}
+	}
+	c.capabilities = append(c.capabilities, offer)
+}
+
+// OnSession registers a callback invoked after cloud's welcome has been
+// validated. It is never called for a legacy connection. The context ends with
+// the negotiated session, and the Session value does not change underneath the
+// callback. Callbacks run in registration order before the read and write loops
+// start, so any real work should be handed off to a goroutine.
+func (c *Client) OnSession(fn func(ctx context.Context, session Session)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onSession = append(c.onSession, fn)
+}
+
 // connectCallbacks returns a snapshot of the registered callbacks so they
 // can be invoked without holding the lock.
 func (c *Client) connectCallbacks() []func(ctx context.Context) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return slices.Clone(c.onConnect)
+}
+
+func (c *Client) sessionSnapshot() ([]CapabilityOffer, []func(context.Context, Session)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	offers := make([]CapabilityOffer, len(c.capabilities))
+	for i, offer := range c.capabilities {
+		offers[i] = offer
+		offers[i].Versions = slices.Clone(offer.Versions)
+		offers[i].Offer = slices.Clone(offer.Offer)
+	}
+	return offers, slices.Clone(c.onSession)
 }
 
 // Handle registers a handler for an inbound message type, which is how a
@@ -376,6 +443,24 @@ func (c *Client) runOnce(ctx context.Context) error {
 
 	c.drainOutbox()
 
+	if c.session != nil {
+		session, callbacks, err := c.establishSession(ctx, conn)
+		if err != nil {
+			return fmt.Errorf("establish session: %w", err)
+		}
+		c.log.Info("session established",
+			"session_id", session.ID,
+			"organization_id", session.OrganizationID,
+			"handshake_version", session.HandshakeVersion,
+			"capabilities", len(session.Capabilities),
+			"clock_offset", session.ClockOffset)
+		for _, fn := range callbacks {
+			fn(ctx, session)
+		}
+	} else if c.legacyBootstrap {
+		c.sendLegacyInitialRequests()
+	}
+
 	for _, fn := range c.connectCallbacks() {
 		fn(ctx)
 	}
@@ -389,6 +474,53 @@ func (c *Client) runOnce(ctx context.Context) error {
 	cancel()
 	<-errCh
 	return err
+}
+
+func (c *Client) establishSession(ctx context.Context, conn *websocket.Conn) (Session, []func(context.Context, Session), error) {
+	offers, callbacks := c.sessionSnapshot()
+	hello := SessionHello{
+		HandshakeVersions: []uint{HandshakeVersion1},
+		RuntimeVersion:    c.session.runtimeVersion,
+		ClientTime:        time.Now().UTC(),
+		Capabilities:      offers,
+	}
+	raw, err := json.Marshal(hello)
+	if err != nil {
+		return Session{}, nil, fmt.Errorf("marshal hello: %w", err)
+	}
+
+	handshakeCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
+	defer cancel()
+	if err := wsjson.Write(handshakeCtx, conn, &Envelope{Type: TypeSessionHello, Data: raw}); err != nil {
+		return Session{}, nil, fmt.Errorf("write hello: %w", err)
+	}
+
+	var env Envelope
+	if err := wsjson.Read(handshakeCtx, conn, &env); err != nil {
+		return Session{}, nil, fmt.Errorf("read welcome: %w", err)
+	}
+	receivedAt := time.Now().UTC()
+
+	switch env.Type {
+	case TypeSessionReject:
+		var reject SessionReject
+		if err := json.Unmarshal(env.Data, &reject); err != nil {
+			return Session{}, nil, fmt.Errorf("decode session rejection: %w", err)
+		}
+		return Session{}, nil, fmt.Errorf("cloud rejected session: %s", reject.Reason)
+	case TypeSessionWelcome:
+		var welcome SessionWelcome
+		if err := json.Unmarshal(env.Data, &welcome); err != nil {
+			return Session{}, nil, fmt.Errorf("decode welcome: %w", err)
+		}
+		session, err := validateWelcome(hello, welcome, receivedAt)
+		if err != nil {
+			return Session{}, nil, err
+		}
+		return session, callbacks, nil
+	default:
+		return Session{}, nil, fmt.Errorf("expected %s, received %s", TypeSessionWelcome, env.Type)
+	}
 }
 
 func (c *Client) connect(ctx context.Context) (*websocket.Conn, error) {

--- a/pkg/uplink/client_test.go
+++ b/pkg/uplink/client_test.go
@@ -127,6 +127,60 @@ func TestClientSendsMessages(t *testing.T) {
 	}
 }
 
+func TestOfferCapabilityPanicsOnDuplicateName(t *testing.T) {
+	client := newTestClient("http://unused", "test-token", NewMessageRouter())
+	client.OfferCapability(CapabilityOffer{Name: CapabilityPopConnect, Versions: []uint{1}})
+
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("duplicate capability registration did not panic")
+		}
+	}()
+	client.OfferCapability(CapabilityOffer{Name: CapabilityPopConnect, Versions: []uint{2}})
+}
+
+func TestLegacyClientSendsBootstrapBeforeTenantMessages(t *testing.T) {
+	received := make(chan []Envelope, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+
+		envelopes := make([]Envelope, 3)
+		for i := range envelopes {
+			if err := wsjson.Read(r.Context(), conn, &envelopes[i]); err != nil {
+				return
+			}
+		}
+		received <- envelopes
+	}))
+	defer srv.Close()
+
+	router := NewMessageRouter()
+	client := NewClient(srv.URL, nil, router, slog.Default())
+	client.getToken = func(context.Context) (string, error) { return "test-token", nil }
+	client.OnConnect(func(context.Context) {
+		client.SendMessage("tenant.start", struct{}{}) //nolint:errcheck
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go client.Run(ctx) //nolint:errcheck
+
+	select {
+	case envelopes := <-received:
+		got := []string{envelopes[0].Type, envelopes[1].Type, envelopes[2].Type}
+		want := []string{TypeTimeRequest, TypeOrgInfoRequest, "tenant.start"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("legacy message order = %v, want %v", got, want)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for legacy bootstrap")
+	}
+}
+
 func TestClientReconnects(t *testing.T) {
 	var mu sync.Mutex
 	connectCount := 0
@@ -343,6 +397,139 @@ func TestOnConnectContextCancelledOnDisconnect(t *testing.T) {
 	case <-cancelled:
 	case <-time.After(3 * time.Second):
 		t.Fatal("callback context outlived the connection")
+	}
+}
+
+func TestNegotiatedSessionStartsCallbacksAfterWelcome(t *testing.T) {
+	helloRead := make(chan SessionHello, 1)
+	allowWelcome := make(chan struct{})
+	sessionStarted := make(chan Session, 1)
+	connectStarted := make(chan struct{}, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+
+		var env Envelope
+		if err := wsjson.Read(r.Context(), conn, &env); err != nil {
+			return
+		}
+		if env.Type != TypeSessionHello {
+			t.Errorf("first message = %s, want %s", env.Type, TypeSessionHello)
+			return
+		}
+		var hello SessionHello
+		if err := json.Unmarshal(env.Data, &hello); err != nil {
+			t.Errorf("decode hello: %v", err)
+			return
+		}
+		helloRead <- hello
+		<-allowWelcome
+
+		now := time.Now().UTC()
+		data, err := json.Marshal(SessionWelcome{
+			HandshakeVersion:   HandshakeVersion1,
+			SessionID:          "session-1",
+			OrganizationID:     "org-1",
+			ServerReceiveTime:  now,
+			ServerTransmitTime: now,
+			Capabilities: []CapabilitySelection{{
+				Name:    CapabilityPopConnect,
+				Version: 1,
+			}},
+		})
+		if err != nil {
+			t.Errorf("encode welcome: %v", err)
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, &Envelope{Type: TypeSessionWelcome, Data: data}); err != nil {
+			return
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token", NewMessageRouter())
+	WithSession("v1.2.3")(client)
+	client.OfferCapability(CapabilityOffer{Name: CapabilityPopConnect, Versions: []uint{1}})
+	client.OnSession(func(_ context.Context, session Session) { sessionStarted <- session })
+	client.OnConnect(func(context.Context) { connectStarted <- struct{}{} })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go client.Run(ctx) //nolint:errcheck
+
+	var hello SessionHello
+	select {
+	case hello = <-helloRead:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for session hello")
+	}
+	if hello.RuntimeVersion != "v1.2.3" {
+		t.Fatalf("runtime version = %q, want v1.2.3", hello.RuntimeVersion)
+	}
+	if len(hello.Capabilities) != 1 || hello.Capabilities[0].Name != CapabilityPopConnect {
+		t.Fatalf("capability offers = %+v", hello.Capabilities)
+	}
+	select {
+	case <-sessionStarted:
+		t.Fatal("session callback ran before welcome")
+	case <-connectStarted:
+		t.Fatal("connect callback ran before welcome")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(allowWelcome)
+	select {
+	case session := <-sessionStarted:
+		if _, ok := session.Capability(CapabilityPopConnect); !ok {
+			t.Fatalf("session lacks pop-connect selection: %+v", session)
+		}
+	case <-ctx.Done():
+		t.Fatal("session callback did not run")
+	}
+	select {
+	case <-connectStarted:
+	case <-ctx.Done():
+		t.Fatal("connect callback did not run after welcome")
+	}
+}
+
+func TestNegotiatedSessionRejectDoesNotStartTenants(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+
+		var hello Envelope
+		if err := wsjson.Read(r.Context(), conn, &hello); err != nil {
+			return
+		}
+		data, _ := json.Marshal(SessionReject{
+			Reason:                     "no common handshake version",
+			SupportedHandshakeVersions: []uint{1},
+		})
+		_ = wsjson.Write(r.Context(), conn, &Envelope{Type: TypeSessionReject, Data: data})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token", NewMessageRouter())
+	WithSession("test")(client)
+	started := false
+	client.OnSession(func(context.Context, Session) { started = true })
+	client.OnConnect(func(context.Context) { started = true })
+
+	err := client.runOnce(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "no common handshake version") {
+		t.Fatalf("runOnce error = %v", err)
+	}
+	if started {
+		t.Fatal("tenant callback ran for rejected session")
 	}
 }
 

--- a/pkg/uplink/session.go
+++ b/pkg/uplink/session.go
@@ -1,0 +1,141 @@
+package uplink
+
+// This file is the runtime half of the bootstrap wire contract. Its cloud
+// counterpart is mirendev/cloud/services/cluster_channel/session.go. Keep the
+// JSON shapes in lockstep until the uplink has a shared schema home.
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"time"
+)
+
+const (
+	TypeSessionHello   = "session.hello"
+	TypeSessionWelcome = "session.welcome"
+	TypeSessionReject  = "session.reject"
+
+	HandshakeVersion1 uint = 1
+
+	CapabilityPopConnect = "pop-connect"
+	CapabilityRPCRelay   = "rpc-relay"
+)
+
+// CapabilityOffer describes one protocol family the runtime can speak. The
+// session layer negotiates the version but leaves Offer to the capability. For
+// example, entity sync will use it to offer export-schema digests without
+// teaching the uplink what an entity is.
+type CapabilityOffer struct {
+	Name     string          `json:"name"`
+	Versions []uint          `json:"versions"`
+	Offer    json.RawMessage `json:"offer,omitempty"`
+}
+
+// CapabilitySelection is cloud's choice for one offered capability. Config is
+// owned and decoded by that capability, not by the session layer.
+type CapabilitySelection struct {
+	Name    string          `json:"name"`
+	Version uint            `json:"version"`
+	Config  json.RawMessage `json:"config,omitempty"`
+}
+
+// SessionHello is the first envelope sent on a negotiated uplink connection.
+// The bootstrap shape is deliberately small: future protocol families evolve
+// behind capabilities rather than adding their state directly here.
+type SessionHello struct {
+	HandshakeVersions []uint            `json:"handshake_versions"`
+	RuntimeVersion    string            `json:"runtime_version"`
+	ClientTime        time.Time         `json:"client_time"`
+	Capabilities      []CapabilityOffer `json:"capabilities"`
+}
+
+// SessionWelcome establishes the session and selects the protocol families
+// both peers will use for this connection.
+type SessionWelcome struct {
+	HandshakeVersion   uint                  `json:"handshake_version"`
+	SessionID          string                `json:"session_id"`
+	OrganizationID     string                `json:"organization_id"`
+	ServerReceiveTime  time.Time             `json:"server_receive_time"`
+	ServerTransmitTime time.Time             `json:"server_transmit_time"`
+	Capabilities       []CapabilitySelection `json:"capabilities"`
+}
+
+// SessionReject explains why cloud could not establish a negotiated session.
+// It is a bootstrap message, so it must remain decodable by every handshake
+// version.
+type SessionReject struct {
+	Reason                     string `json:"reason"`
+	SupportedHandshakeVersions []uint `json:"supported_handshake_versions,omitempty"`
+}
+
+// Session is immutable negotiated state scoped to one WebSocket connection.
+type Session struct {
+	ID               string
+	HandshakeVersion uint
+	RuntimeVersion   string
+	OrganizationID   string
+	ClockOffset      time.Duration
+	Capabilities     []CapabilitySelection
+}
+
+// Capability returns the selected capability with the given name.
+func (s Session) Capability(name string) (CapabilitySelection, bool) {
+	for _, capability := range s.Capabilities {
+		if capability.Name == name {
+			return capability, true
+		}
+	}
+	return CapabilitySelection{}, false
+}
+
+func validateWelcome(hello SessionHello, welcome SessionWelcome, receivedAt time.Time) (Session, error) {
+	if welcome.SessionID == "" {
+		return Session{}, fmt.Errorf("session welcome has no session id")
+	}
+	if welcome.OrganizationID == "" {
+		return Session{}, fmt.Errorf("session welcome has no organization")
+	}
+	if !slices.Contains(hello.HandshakeVersions, welcome.HandshakeVersion) {
+		return Session{}, fmt.Errorf("cloud selected unoffered handshake version %d", welcome.HandshakeVersion)
+	}
+	if hello.ClientTime.IsZero() || welcome.ServerReceiveTime.IsZero() || welcome.ServerTransmitTime.IsZero() {
+		return Session{}, fmt.Errorf("session welcome has incomplete clock timestamps")
+	}
+
+	offered := make(map[string]CapabilityOffer, len(hello.Capabilities))
+	for _, capability := range hello.Capabilities {
+		if capability.Name == "" {
+			return Session{}, fmt.Errorf("session hello contains unnamed capability")
+		}
+		if _, exists := offered[capability.Name]; exists {
+			return Session{}, fmt.Errorf("session hello contains duplicate capability %q", capability.Name)
+		}
+		offered[capability.Name] = capability
+	}
+
+	selected := make(map[string]struct{}, len(welcome.Capabilities))
+	for _, capability := range welcome.Capabilities {
+		offer, ok := offered[capability.Name]
+		if !ok {
+			return Session{}, fmt.Errorf("cloud selected unoffered capability %q", capability.Name)
+		}
+		if _, exists := selected[capability.Name]; exists {
+			return Session{}, fmt.Errorf("cloud selected capability %q more than once", capability.Name)
+		}
+		if !slices.Contains(offer.Versions, capability.Version) {
+			return Session{}, fmt.Errorf("cloud selected unoffered %s version %d", capability.Name, capability.Version)
+		}
+		selected[capability.Name] = struct{}{}
+	}
+
+	offset := (welcome.ServerReceiveTime.Sub(hello.ClientTime) + welcome.ServerTransmitTime.Sub(receivedAt)) / 2
+	return Session{
+		ID:               welcome.SessionID,
+		HandshakeVersion: welcome.HandshakeVersion,
+		RuntimeVersion:   hello.RuntimeVersion,
+		OrganizationID:   welcome.OrganizationID,
+		ClockOffset:      offset,
+		Capabilities:     slices.Clone(welcome.Capabilities),
+	}, nil
+}

--- a/pkg/uplink/session_test.go
+++ b/pkg/uplink/session_test.go
@@ -1,0 +1,92 @@
+package uplink
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestValidateWelcomeBuildsNegotiatedSession(t *testing.T) {
+	t1 := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	hello := SessionHello{
+		HandshakeVersions: []uint{HandshakeVersion1},
+		RuntimeVersion:    "v1.2.3",
+		ClientTime:        t1,
+		Capabilities: []CapabilityOffer{{
+			Name:     CapabilityPopConnect,
+			Versions: []uint{1},
+		}},
+	}
+	welcome := SessionWelcome{
+		HandshakeVersion:   HandshakeVersion1,
+		SessionID:          "session-1",
+		OrganizationID:     "org-1",
+		ServerReceiveTime:  t1.Add(12 * time.Millisecond),
+		ServerTransmitTime: t1.Add(14 * time.Millisecond),
+		Capabilities: []CapabilitySelection{{
+			Name:    CapabilityPopConnect,
+			Version: 1,
+			Config:  json.RawMessage(`{"max_connections":8}`),
+		}},
+	}
+
+	session, err := validateWelcome(hello, welcome, t1.Add(22*time.Millisecond))
+	if err != nil {
+		t.Fatalf("validate welcome: %v", err)
+	}
+	if session.ID != "session-1" || session.OrganizationID != "org-1" {
+		t.Fatalf("unexpected session identity: %+v", session)
+	}
+	if session.ClockOffset != 2*time.Millisecond {
+		t.Fatalf("clock offset = %v, want 2ms", session.ClockOffset)
+	}
+	capability, ok := session.Capability(CapabilityPopConnect)
+	if !ok || capability.Version != 1 {
+		t.Fatalf("pop-connect selection = %+v, %v", capability, ok)
+	}
+}
+
+func TestValidateWelcomeRejectsInvalidSelections(t *testing.T) {
+	now := time.Now().UTC()
+	hello := SessionHello{
+		HandshakeVersions: []uint{1},
+		RuntimeVersion:    "test",
+		ClientTime:        now,
+		Capabilities: []CapabilityOffer{{
+			Name:     CapabilityPopConnect,
+			Versions: []uint{1},
+		}},
+	}
+	valid := SessionWelcome{
+		HandshakeVersion:   1,
+		SessionID:          "session-1",
+		OrganizationID:     "org-1",
+		ServerReceiveTime:  now,
+		ServerTransmitTime: now,
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*SessionWelcome)
+	}{
+		{"unoffered handshake", func(w *SessionWelcome) { w.HandshakeVersion = 2 }},
+		{"missing session id", func(w *SessionWelcome) { w.SessionID = "" }},
+		{"missing organization", func(w *SessionWelcome) { w.OrganizationID = "" }},
+		{"unoffered capability", func(w *SessionWelcome) {
+			w.Capabilities = []CapabilitySelection{{Name: "entity-sync", Version: 1}}
+		}},
+		{"unoffered capability version", func(w *SessionWelcome) {
+			w.Capabilities = []CapabilitySelection{{Name: CapabilityPopConnect, Version: 2}}
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			welcome := valid
+			tt.mutate(&welcome)
+			if _, err := validateWelcome(hello, welcome, now); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
The runtime currently starts uplink tenants as soon as the WebSocket opens, before cloud has supplied identity, time, or a reliable statement of what the connection supports.

This adds the runtime half of the RFD-112 hello/welcome handshake. Capability offers stay owned by their tenants: Miren Anywhere offers POP connect and the cloud RPC package offers the relay, while future entity sync can carry its schema offer and config without widening the bootstrap.

The negotiated path stays behind the disabled `appvisibility` labs flag, and the default path preserves the existing time and organization requests. That lets cloud support deploy first and gives us an internal rollout before any runtime requires a welcome.

Part of MIR-1587