### PR TITLE
Shard the distributed blackbox suite in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -466,33 +466,81 @@ jobs:
       if: always()
       run: make dev-stop || true
 
-  test-blackbox-distributed:
-    # Exercises the multi-node distributed runner topology (a coordinator plus a
-    # separate runner peer) with distributedrunners enabled, running the whole
-    # blackbox suite against it. Setup is heavy (iso peers, a binary build on
-    # each peer, the join dance), so it runs on main/release builds rather than
-    # every PR push: release.yml (push to main and tags) calls this workflow via
-    # workflow_call, where github.event_name is the caller's event ('push'), so
-    # excluding 'pull_request' runs it there while skipping PRs. It would also
-    # run in a merge queue if one were enabled ('merge_group').
+  blackbox-groups-distributed:
+    # Builds the shard matrix for the distributed suite and owns the decision of
+    # *whether* that suite runs at all — the shard jobs below gate on this job's
+    # result, so the condition lives here in one place.
     #
-    # On a PR it runs when the diff touches code that can break the multi-node
-    # topology, or when someone labels the PR `ci:distributed` to ask for it
-    # explicitly. This job is the only place a second node exists, so a bug
-    # there is invisible until it is already on main blocking a release, which
-    # is exactly how MIR-1469 got in.
+    # The distributed suite exercises the multi-node topology (a coordinator plus
+    # a separate runner peer) with distributedrunners enabled. Setup is heavy
+    # (iso peers, a binary build, the join dance) and it's the only place a
+    # second node exists, so a bug there is invisible until it's already on main
+    # blocking a release (exactly how MIR-1469 got in). It therefore runs on
+    # main/release builds rather than every PR push: release.yml (push to main
+    # and tags) calls this workflow via workflow_call, where github.event_name is
+    # the caller's event ('push'), so excluding 'pull_request' runs it there
+    # while skipping PRs. It would also run in a merge queue ('merge_group'). On
+    # a PR it runs when the diff touches code that can break the topology, or
+    # when someone labels the PR `ci:distributed`.
     #
-    # `!cancelled()` rather than a plain condition: it keeps the non-PR clause
-    # authoritative even if the `changes` job fails. A failed dependency would
-    # otherwise skip this job on main and tags, quietly dropping the release
-    # coverage this whole gate exists to protect.
+    # `!cancelled()` rather than a plain condition keeps the non-PR clause
+    # authoritative even if the `changes` job fails — a failed dependency would
+    # otherwise skip this on main and tags, quietly dropping the release coverage
+    # this whole gate exists to protect.
     needs: [changes]
     if: >-
       !cancelled() && (
       github.event_name != 'pull_request' ||
       needs.changes.outputs.distributed == 'true' ||
       contains(github.event.pull_request.labels.*.name, 'ci:distributed') )
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set distributed blackbox shard matrix
+      id: set-matrix
+      run: |
+        # Discover all blackbox test functions by scanning source (no compile,
+        # no cluster) so a newly added test is never silently left unrun.
+        ALL_TESTS=$(grep -rhoE '^func Test[A-Za-z0-9_]+' blackbox --include='*_test.go' \
+          | sed -E 's/^func //' | sort -u)
+
+        # Tests already assigned to a shard in the checked-in manifest.
+        GROUPED=$(jq -r '.groups[].tests[]' hack/blackbox-groups-distributed.json | sort -u)
+
+        # The cloud-backed tests run in their own job (test-blackbox-pop): they
+        # need the cloud repo and restart the server. Never shard them.
+        UNGROUPED=$(comm -23 <(echo "$ALL_TESTS") <(echo "$GROUPED") | grep -vxE 'TestPOP|TestRPCViaCloud|TestDeployViaCloud' || true)
+
+        MATRIX=$(jq -c '.groups' hack/blackbox-groups-distributed.json)
+
+        if [ -n "$UNGROUPED" ]; then
+          echo "::warning::Distributed blackbox tests not in blackbox-groups-distributed.json (running in extra shard, regenerate with 'make blackbox-groups-distributed'): $(echo $UNGROUPED | tr '\n' ' ')"
+          EXTRA=$(echo "$UNGROUPED" | jq -R -s 'split("\n") | map(select(. != ""))')
+          MATRIX=$(echo "$MATRIX" | jq -c --argjson tests "$EXTRA" '. + [{"shard": (length + 1), "estimated_s": 0, "tests": $tests}]')
+        fi
+
+        echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
+  test-blackbox-distributed:
+    name: test-blackbox-distributed (shard ${{ matrix.group.shard }})
+    # Each shard boots its own coordinator+runner topology on its own runner and
+    # runs only its assigned subset of the suite. Sharding turns a ~20-minute
+    # serial run into parallel ~6-minute shards. The gate on
+    # blackbox-groups-distributed's result carries the whole run-or-skip decision
+    # (see that job): if the builder skipped, every shard skips with it.
+    needs: [blackbox-groups-distributed]
+    if: >-
+      !cancelled() && needs.blackbox-groups-distributed.result == 'success'
     runs-on: depot-ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{ fromJson(needs.blackbox-groups-distributed.outputs.matrix) }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -545,16 +593,21 @@ jobs:
     - name: Start distributed environment
       run: ISO_CACHE_DIR=/tmp/iso-cache make dev-distributed
 
-    - name: Run distributed blackbox tests
-      run: make test-blackbox-distributed
+    - name: Run distributed blackbox tests (shard ${{ matrix.group.shard }})
+      # Each shard runs only its assigned subset, built into a -run regex from
+      # the matrix and passed through BLACKBOX_RUN. -skip '^TestPOP$' stays in
+      # the make target.
+      run: |
+        RUN=$(echo '${{ toJson(matrix.group.tests) }}' | jq -r 'join("|")')
+        make test-blackbox-distributed BLACKBOX_RUN="$RUN"
 
     - name: Peer logs on failure
       if: failure()
       run: |
-        # The whole suite runs serially against one cluster, so a failure early
-        # on is thousands of lines from the end by the time we get here. A tail
-        # window reliably misses it (MIR-1469 was diagnosed twice from logs that
-        # started five minutes after the failure), so dump the logs whole.
+        # A shard runs its subset serially against one cluster, so a failure
+        # early on is far from the end of the log by the time we get here. A
+        # tail window reliably misses it (MIR-1469 was diagnosed twice from logs
+        # that started five minutes after the failure), so dump the logs whole.
         echo "=== Coordinator server logs ==="
         iso peers exec coordinator -- cat /tmp/miren-server.log 2>&1 || true
         echo "=== Runner logs ==="
@@ -572,7 +625,7 @@ jobs:
   # that passes only when every matrix runner and blackbox tests succeed.
   test:
     if: always()
-    needs: [changes, test-runner, blackbox-groups, test-blackbox, test-blackbox-pop, test-blackbox-distributed]
+    needs: [changes, test-runner, blackbox-groups, test-blackbox, test-blackbox-pop, blackbox-groups-distributed, test-blackbox-distributed]
     runs-on: ubuntu-latest
     steps:
     - name: Check results
@@ -581,6 +634,7 @@ jobs:
         echo "blackbox-groups result: ${{ needs.blackbox-groups.result }}"
         echo "test-blackbox result: ${{ needs.test-blackbox.result }}"
         echo "test-blackbox-pop result: ${{ needs.test-blackbox-pop.result }}"
+        echo "blackbox-groups-distributed result: ${{ needs.blackbox-groups-distributed.result }}"
         echo "test-blackbox-distributed result: ${{ needs.test-blackbox-distributed.result }}"
         echo "changes result: ${{ needs.changes.result }}"
 
@@ -608,8 +662,16 @@ jobs:
         if [[ "${{ needs.test-blackbox-pop.result }}" != "success" && "${{ needs.test-blackbox-pop.result }}" != "skipped" ]]; then
           exit 1
         fi
+        # blackbox-groups-distributed builds the distributed shard matrix and
+        # gates whether the suite runs. It's skipped on PRs without
+        # distributed-relevant changes (accepted), but a failure would skip the
+        # shards too — which would look benign in the check below — so a run that
+        # neither succeeded nor was skipped fails the gate outright.
+        if [[ "${{ needs.blackbox-groups-distributed.result }}" != "success" && "${{ needs.blackbox-groups-distributed.result }}" != "skipped" ]]; then
+          exit 1
+        fi
         # Distributed suite is skipped on PRs (merge-queue / main only), so
-        # skipped is acceptable here; a real run must pass.
+        # skipped is acceptable here; a real run (every shard) must pass.
         if [[ "${{ needs.test-blackbox-distributed.result }}" != "success" && "${{ needs.test-blackbox-distributed.result }}" != "skipped" ]]; then
           exit 1
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
         # The code paths that can break the multi-node topology, plus this
         # workflow itself so a change to the gating is exercised by the PR
         # that makes it.
-        if echo "$changed" | grep -qE '^(controllers/disk/|components/diskio/|components/runner/|blackbox/|hack/dev-distributed|\.iso/peers\.yml|\.github/workflows/test\.yml)'; then
+        if echo "$changed" | grep -qE '^(controllers/disk/|components/diskio/|components/runner/|blackbox/|hack/dev-distributed|hack/blackbox-groups-distributed\.json|\.iso/peers\.yml|\.github/workflows/test\.yml)'; then
           echo "distributed-relevant changes found"
           echo "distributed=true" >> "$GITHUB_OUTPUT"
         else

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,12 @@ blackbox-groups: ## Rebalance hack/blackbox-groups.json from measured blackbox t
 measure-blackbox-times: ## Re-measure per-test blackbox times into hack/blackbox-test-times.json (requires `make dev` running)
 	python3 hack/measure-blackbox-times.py -o hack/blackbox-test-times.json
 
+blackbox-groups-distributed: ## Rebalance hack/blackbox-groups-distributed.json from measured peers test times
+	python3 hack/calc-blackbox-groups.py hack/blackbox-test-times.json --env peers -n 4 -o hack/blackbox-groups-distributed.json
+
+measure-blackbox-times-distributed: ## Re-measure per-test blackbox times in the peers topology (requires hack/dev-distributed up)
+	BLACKBOX_MODE=peers python3 hack/measure-blackbox-times.py -o hack/blackbox-test-times.json
+
 test-blackbox: ## Run blackbox tests (requires `make dev` running)
 	# The cloud-backed tests are excluded: each stands up a whole cloud on fixed
 	# ports and restarts the server, which interferes with everything after it.
@@ -200,15 +206,21 @@ test-blackbox-pop: ## Run cloud-backed blackbox tests (requires `make dev` and c
 	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestDeployViaCloud$$' ./blackbox/...
 
 test-blackbox-distributed: ## Run blackbox tests against distributed environment (requires hack/dev-distributed up)
-	# Runs the whole blackbox suite (not just the distributed-specific tests)
-	# against the coordinator+runner topology, so a labs flag that breaks basic
-	# functionality is caught here too. Serial and unsharded, so it needs a
-	# larger timeout than the sharded plain suite. TestPOP is skipped: it's the
-	# Miren Anywhere cloud path (orthogonal to distributed runners) and restarts
-	# the server mid-run; it has its own dedicated job.
-	BLACKBOX_MODE=peers go test -tags blackbox -timeout 20m -v -count=1 -p 1 -skip '^TestPOP$$' ./blackbox/...
+	# Runs the blackbox suite (not just the distributed-specific tests) against
+	# the coordinator+runner topology, so a labs flag that breaks basic
+	# functionality is caught here too. TestPOP is skipped: it's the Miren
+	# Anywhere cloud path (orthogonal to distributed runners) and restarts the
+	# server mid-run; it has its own dedicated job.
+	#
+	# BLACKBOX_RUN restricts the run to a subset (a go -run alternation like
+	# 'TestA|TestB'); the sharded CI matrix sets it to one shard's tests. Unset,
+	# the whole suite runs, which is what local use wants. The timeout is a
+	# generous upper bound for the whole-suite local case; a shard finishes well
+	# inside it.
+	BLACKBOX_MODE=peers go test -tags blackbox -timeout 20m -v -count=1 -p 1 \
+		$(if $(BLACKBOX_RUN),-run '^($(BLACKBOX_RUN))$$') -skip '^TestPOP$$' ./blackbox/...
 
-.PHONY: test test-shell test-blackbox test-blackbox-pop build-cloud-test test-blackbox-distributed test-coverage test-coverage-ci coverage-report coverage-percent coverage-by-package coverage-pr test-groups update-test-groups blackbox-groups measure-blackbox-times
+.PHONY: test test-shell test-blackbox test-blackbox-pop build-cloud-test test-blackbox-distributed test-coverage test-coverage-ci coverage-report coverage-percent coverage-by-package coverage-pr test-groups update-test-groups blackbox-groups measure-blackbox-times blackbox-groups-distributed measure-blackbox-times-distributed
 
 #
 # Building

--- a/Makefile
+++ b/Makefile
@@ -216,9 +216,11 @@ test-blackbox-distributed: ## Run blackbox tests against distributed environment
 	# 'TestA|TestB'); the sharded CI matrix sets it to one shard's tests. Unset,
 	# the whole suite runs, which is what local use wants. The timeout is a
 	# generous upper bound for the whole-suite local case; a shard finishes well
-	# inside it.
+	# inside it. The cloud-backed tests are skipped (same set as test-blackbox):
+	# unset BLACKBOX_RUN would otherwise run them here, and they need the cloud
+	# repo and restart the server.
 	BLACKBOX_MODE=peers go test -tags blackbox -timeout 20m -v -count=1 -p 1 \
-		$(if $(BLACKBOX_RUN),-run '^($(BLACKBOX_RUN))$$') -skip '^TestPOP$$' ./blackbox/...
+		$(if $(BLACKBOX_RUN),-run '^($(BLACKBOX_RUN))$$') -skip '^(TestPOP|TestRPCViaCloud|TestDeployViaCloud)$$' ./blackbox/...
 
 .PHONY: test test-shell test-blackbox test-blackbox-pop build-cloud-test test-blackbox-distributed test-coverage test-coverage-ci coverage-report coverage-percent coverage-by-package coverage-pr test-groups update-test-groups blackbox-groups measure-blackbox-times blackbox-groups-distributed measure-blackbox-times-distributed
 

--- a/hack/blackbox-groups-distributed.json
+++ b/hack/blackbox-groups-distributed.json
@@ -1,0 +1,100 @@
+{
+  "environment": "peers",
+  "n_shards": 4,
+  "makespan_s": 257.15,
+  "groups": [
+    {
+      "shard": 1,
+      "estimated_s": 257.02,
+      "tests": [
+        "TestRunCarriesDeclaredTaskEnv",
+        "TestMysqlAddonDeployWithAppToml",
+        "TestSqliteAddonReplication",
+        "TestValkeyAddonCreateListDestroy",
+        "TestSecretRevocationFailsClosed",
+        "TestZeroDowntimeDeploy",
+        "TestAddonDeployWithVersionInAppToml",
+        "TestDistributedRunnerNodePort",
+        "TestSandboxExec",
+        "TestRouteWafEnableDisable",
+        "TestRouteWafInvalidLevel",
+        "TestRouteMaintenance",
+        "TestRunLogsAreReadableByRunID",
+        "TestTaskOnlyAppDeploys",
+        "TestRoutePasswordProviderLifecycle",
+        "TestSecretStoreAndRotate",
+        "TestAddonVariants",
+        "TestAddonListAvailable",
+        "TestDebugSagaShowUnknownID",
+        "TestDistributedRunnerList",
+        "TestConcurrentDeployBlockedByLock",
+        "TestServerUnregister"
+      ]
+    },
+    {
+      "shard": 2,
+      "estimated_s": 257.14,
+      "tests": [
+        "TestAttachedRunWaitsForTheCommand",
+        "TestAttachedRunPropagatesExitCode",
+        "TestEnvSetGetList",
+        "TestLocalDiskPersistence",
+        "TestAddonDeployWithAppToml",
+        "TestRabbitmqAddonCreateListDestroy",
+        "TestAddonCreateListDestroy",
+        "TestDeployAndRollback",
+        "TestRouteWafBlocksMaliciousRequest",
+        "TestDeployGoServer",
+        "TestRouteWafDefaultRoute",
+        "TestDistributedRunnerMetrics",
+        "TestDeployImageEntrypointNoCommand",
+        "TestDetachedRunSucceeds"
+      ]
+    },
+    {
+      "shard": 3,
+      "estimated_s": 257.01,
+      "tests": [
+        "TestRunPreservesArgumentBoundaries",
+        "TestMemcacheAddonCreateListDestroy",
+        "TestSecretReferencedByApp",
+        "TestRabbitmqAddonDeployWithAppToml",
+        "TestValkeyAddonDeployWithAppToml",
+        "TestAddonRotateSharedPostgresSuperuser",
+        "TestMysqlAddonCreateListDestroy",
+        "TestAddonUnknownAddon",
+        "TestDistributedRunnerDrain",
+        "TestSandboxList",
+        "TestDeployHistoryRecordsActiveVersion",
+        "TestRouteSetListRemove",
+        "TestDeployTaskGatesTheDeploy",
+        "TestRunCancellation",
+        "TestDiskUndelete",
+        "TestDistributedRunnerCordon",
+        "TestRouteDownDefaultNeedsConfirmation"
+      ]
+    },
+    {
+      "shard": 4,
+      "estimated_s": 257.15,
+      "tests": [
+        "TestAddonRotateValkey",
+        "TestAddonEnvSurvivesDeployVersion",
+        "TestAddonRotateSharedPostgresUser",
+        "TestCrashLoop",
+        "TestMemcacheAddonDeployWithAppToml",
+        "TestBadCommand",
+        "TestEphemeralDeploy",
+        "TestRouteTimeoutSetShowClear",
+        "TestRoutePasswordProtection",
+        "TestRouteTimeoutDefaultRoute",
+        "TestRouteWafJsonOutput",
+        "TestDistributedRunnerLogs",
+        "TestDistributedOverlayEncryption",
+        "TestFailingRunRecordsItsExitCode",
+        "TestBareRunOpensAConsole",
+        "TestFailedBuildLeavesFailedRecord"
+      ]
+    }
+  ]
+}

--- a/hack/blackbox-test-times.json
+++ b/hack/blackbox-test-times.json
@@ -1,10 +1,419 @@
 {
   "summary": {
-    "total_test_time_s": 526.23,
-    "test_count": 33,
-    "source": "CI run 29856793428 job 88723011745 (green merge of PR #946)"
+    "standalone": {
+      "total_test_time_s": 526.23,
+      "test_count": 33,
+      "source": "CI run 29856793428 job 88723011745 (green merge of PR #946)"
+    },
+    "peers": {
+      "total_test_time_s": 1028.3,
+      "test_count": 67,
+      "source": "CI run 32993856200 job 98265119043 (green, mir-1580 branch)"
+    }
   },
   "tests": [
+    {
+      "name": "TestRunCarriesDeclaredTaskEnv",
+      "environment": "peers",
+      "elapsed_s": 60.01,
+      "status": "pass"
+    },
+    {
+      "name": "TestAttachedRunWaitsForTheCommand",
+      "environment": "peers",
+      "elapsed_s": 60.0,
+      "status": "pass"
+    },
+    {
+      "name": "TestRunPreservesArgumentBoundaries",
+      "environment": "peers",
+      "elapsed_s": 58.12,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonRotateValkey",
+      "environment": "peers",
+      "elapsed_s": 40.71,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonEnvSurvivesDeployVersion",
+      "environment": "peers",
+      "elapsed_s": 39.53,
+      "status": "pass"
+    },
+    {
+      "name": "TestMemcacheAddonCreateListDestroy",
+      "environment": "peers",
+      "elapsed_s": 35.24,
+      "status": "pass"
+    },
+    {
+      "name": "TestAttachedRunPropagatesExitCode",
+      "environment": "peers",
+      "elapsed_s": 34.15,
+      "status": "pass"
+    },
+    {
+      "name": "TestMysqlAddonDeployWithAppToml",
+      "environment": "peers",
+      "elapsed_s": 32.57,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonRotateSharedPostgresUser",
+      "environment": "peers",
+      "elapsed_s": 31.36,
+      "status": "pass"
+    },
+    {
+      "name": "TestSqliteAddonReplication",
+      "environment": "peers",
+      "elapsed_s": 30.29,
+      "status": "pass"
+    },
+    {
+      "name": "TestSecretReferencedByApp",
+      "environment": "peers",
+      "elapsed_s": 30.13,
+      "status": "pass"
+    },
+    {
+      "name": "TestEnvSetGetList",
+      "environment": "peers",
+      "elapsed_s": 28.94,
+      "status": "pass"
+    },
+    {
+      "name": "TestCrashLoop",
+      "environment": "peers",
+      "elapsed_s": 22.88,
+      "status": "pass"
+    },
+    {
+      "name": "TestValkeyAddonCreateListDestroy",
+      "environment": "peers",
+      "elapsed_s": 22.41,
+      "status": "pass"
+    },
+    {
+      "name": "TestLocalDiskPersistence",
+      "environment": "peers",
+      "elapsed_s": 20.88,
+      "status": "pass"
+    },
+    {
+      "name": "TestRabbitmqAddonDeployWithAppToml",
+      "environment": "peers",
+      "elapsed_s": 20.51,
+      "status": "pass"
+    },
+    {
+      "name": "TestMemcacheAddonDeployWithAppToml",
+      "environment": "peers",
+      "elapsed_s": 20.34,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonDeployWithAppToml",
+      "environment": "peers",
+      "elapsed_s": 20.14,
+      "status": "pass"
+    },
+    {
+      "name": "TestValkeyAddonDeployWithAppToml",
+      "environment": "peers",
+      "elapsed_s": 20.13,
+      "status": "pass"
+    },
+    {
+      "name": "TestSecretRevocationFailsClosed",
+      "environment": "peers",
+      "elapsed_s": 20.12,
+      "status": "pass"
+    },
+    {
+      "name": "TestBadCommand",
+      "environment": "peers",
+      "elapsed_s": 19.99,
+      "status": "pass"
+    },
+    {
+      "name": "TestRabbitmqAddonCreateListDestroy",
+      "environment": "peers",
+      "elapsed_s": 19.5,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonRotateSharedPostgresSuperuser",
+      "environment": "peers",
+      "elapsed_s": 19.3,
+      "status": "pass"
+    },
+    {
+      "name": "TestZeroDowntimeDeploy",
+      "environment": "peers",
+      "elapsed_s": 18.6,
+      "status": "pass"
+    },
+    {
+      "name": "TestEphemeralDeploy",
+      "environment": "peers",
+      "elapsed_s": 18.05,
+      "status": "pass"
+    },
+    {
+      "name": "TestMysqlAddonCreateListDestroy",
+      "environment": "peers",
+      "elapsed_s": 17.41,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonCreateListDestroy",
+      "environment": "peers",
+      "elapsed_s": 17.15,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonDeployWithVersionInAppToml",
+      "environment": "peers",
+      "elapsed_s": 17.1,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteTimeoutSetShowClear",
+      "environment": "peers",
+      "elapsed_s": 12.06,
+      "status": "pass"
+    },
+    {
+      "name": "TestDeployAndRollback",
+      "environment": "peers",
+      "elapsed_s": 11.54,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonUnknownAddon",
+      "environment": "peers",
+      "elapsed_s": 11.48,
+      "status": "pass"
+    },
+    {
+      "name": "TestDistributedRunnerNodePort",
+      "environment": "peers",
+      "elapsed_s": 10.79,
+      "status": "pass"
+    },
+    {
+      "name": "TestRoutePasswordProtection",
+      "environment": "peers",
+      "elapsed_s": 10.1,
+      "status": "pass"
+    },
+    {
+      "name": "TestSandboxExec",
+      "environment": "peers",
+      "elapsed_s": 10.04,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafBlocksMaliciousRequest",
+      "environment": "peers",
+      "elapsed_s": 9.94,
+      "status": "pass"
+    },
+    {
+      "name": "TestDistributedRunnerDrain",
+      "environment": "peers",
+      "elapsed_s": 9.87,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteTimeoutDefaultRoute",
+      "environment": "peers",
+      "elapsed_s": 9.82,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafEnableDisable",
+      "environment": "peers",
+      "elapsed_s": 9.82,
+      "status": "pass"
+    },
+    {
+      "name": "TestSandboxList",
+      "environment": "peers",
+      "elapsed_s": 9.78,
+      "status": "pass"
+    },
+    {
+      "name": "TestDeployGoServer",
+      "environment": "peers",
+      "elapsed_s": 9.72,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafJsonOutput",
+      "environment": "peers",
+      "elapsed_s": 9.72,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafInvalidLevel",
+      "environment": "peers",
+      "elapsed_s": 9.69,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafDefaultRoute",
+      "environment": "peers",
+      "elapsed_s": 9.65,
+      "status": "pass"
+    },
+    {
+      "name": "TestDeployHistoryRecordsActiveVersion",
+      "environment": "peers",
+      "elapsed_s": 9.59,
+      "status": "pass"
+    },
+    {
+      "name": "TestDistributedRunnerLogs",
+      "environment": "peers",
+      "elapsed_s": 9.55,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteMaintenance",
+      "environment": "peers",
+      "elapsed_s": 8.54,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteSetListRemove",
+      "environment": "peers",
+      "elapsed_s": 7.88,
+      "status": "pass"
+    },
+    {
+      "name": "TestDistributedRunnerMetrics",
+      "environment": "peers",
+      "elapsed_s": 7.61,
+      "status": "pass"
+    },
+    {
+      "name": "TestDistributedOverlayEncryption",
+      "environment": "peers",
+      "elapsed_s": 5.58,
+      "status": "pass"
+    },
+    {
+      "name": "TestDeployImageEntrypointNoCommand",
+      "environment": "peers",
+      "elapsed_s": 4.24,
+      "status": "pass"
+    },
+    {
+      "name": "TestDeployTaskGatesTheDeploy",
+      "environment": "peers",
+      "elapsed_s": 4.15,
+      "status": "pass"
+    },
+    {
+      "name": "TestFailingRunRecordsItsExitCode",
+      "environment": "peers",
+      "elapsed_s": 4.05,
+      "status": "pass"
+    },
+    {
+      "name": "TestRunLogsAreReadableByRunID",
+      "environment": "peers",
+      "elapsed_s": 3.7,
+      "status": "pass"
+    },
+    {
+      "name": "TestDetachedRunSucceeds",
+      "environment": "peers",
+      "elapsed_s": 3.68,
+      "status": "pass"
+    },
+    {
+      "name": "TestRunCancellation",
+      "environment": "peers",
+      "elapsed_s": 2.18,
+      "status": "pass"
+    },
+    {
+      "name": "TestTaskOnlyAppDeploys",
+      "environment": "peers",
+      "elapsed_s": 2.16,
+      "status": "pass"
+    },
+    {
+      "name": "TestBareRunOpensAConsole",
+      "environment": "peers",
+      "elapsed_s": 1.85,
+      "status": "pass"
+    },
+    {
+      "name": "TestFailedBuildLeavesFailedRecord",
+      "environment": "peers",
+      "elapsed_s": 1.56,
+      "status": "pass"
+    },
+    {
+      "name": "TestDiskUndelete",
+      "environment": "peers",
+      "elapsed_s": 0.94,
+      "status": "pass"
+    },
+    {
+      "name": "TestRoutePasswordProviderLifecycle",
+      "environment": "peers",
+      "elapsed_s": 0.44,
+      "status": "pass"
+    },
+    {
+      "name": "TestSecretStoreAndRotate",
+      "environment": "peers",
+      "elapsed_s": 0.28,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonVariants",
+      "environment": "peers",
+      "elapsed_s": 0.26,
+      "status": "pass"
+    },
+    {
+      "name": "TestDistributedRunnerCordon",
+      "environment": "peers",
+      "elapsed_s": 0.25,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonListAvailable",
+      "environment": "peers",
+      "elapsed_s": 0.08,
+      "status": "pass"
+    },
+    {
+      "name": "TestDebugSagaShowUnknownID",
+      "environment": "peers",
+      "elapsed_s": 0.05,
+      "status": "pass"
+    },
+    {
+      "name": "TestDistributedRunnerList",
+      "environment": "peers",
+      "elapsed_s": 0.05,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteDownDefaultNeedsConfirmation",
+      "environment": "peers",
+      "elapsed_s": 0.05,
+      "status": "pass"
+    },
     {
       "name": "TestAddonDeployWithVersionInAppToml",
       "environment": "standalone",

--- a/hack/calc-blackbox-groups.py
+++ b/hack/calc-blackbox-groups.py
@@ -27,9 +27,13 @@ import json
 import subprocess
 import sys
 
-# Tests that never participate in the sharded standalone job. TestPOP runs in
-# its own CI job (different environment: cloud repo + secret + server restart).
-ALWAYS_SKIP = {"TestPOP"}
+# Cloud-backed tests never participate in any sharded job, in either
+# environment: they need the cloud repo + secret and restart the server
+# mid-run, so they run in their own CI job (test-blackbox-pop). This mirrors the
+# `-skip` list in the Makefile and the ungrouped-test filter in
+# .github/workflows/test.yml; without it, `-list` discovery would fold them into
+# the lightest shard as untimed tests.
+ALWAYS_SKIP = {"TestPOP", "TestRPCViaCloud", "TestDeployViaCloud"}
 
 
 def load_times(path):

--- a/hack/measure-blackbox-times.py
+++ b/hack/measure-blackbox-times.py
@@ -73,12 +73,25 @@ def parse_log(lines, environment):
     return sorted(tests.values(), key=lambda t: -t["elapsed_s"])
 
 
-def run_suite():
-    """Run the full blackbox suite with -v and stream its output back."""
+def run_suite(environment):
+    """Run the full blackbox suite with -v and stream its output back.
+
+    The subprocess topology is driven by `environment` so the tests actually
+    run where their timings are recorded: peers sets BLACKBOX_MODE=peers,
+    standalone clears it. The cloud-backed tests are excluded (same set as the
+    `test-blackbox` target): they need the cloud repo and restart the server.
+    """
     cmd = ["go", "test", "-tags", "blackbox", "-timeout", "15m", "-v",
-           "-count=1", "-p", "1", "-skip", "^TestPOP$", "./blackbox/..."]
+           "-count=1", "-p", "1",
+           "-skip", "^(TestPOP|TestRPCViaCloud|TestDeployViaCloud)$",
+           "./blackbox/..."]
+    env = os.environ.copy()
+    if environment == "peers":
+        env["BLACKBOX_MODE"] = "peers"
+    else:
+        env.pop("BLACKBOX_MODE", None)
     print(f"Running: {' '.join(cmd)}\n", file=sys.stderr)
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
     sys.stderr.write(proc.stderr)
     if proc.returncode != 0:
         print(f"\nWarning: suite exited {proc.returncode}; timing data may be "
@@ -123,7 +136,7 @@ def main():
             lines = f.read().splitlines()
         source = args.source or f"parsed from {args.from_log}"
     else:
-        lines = run_suite()
+        lines = run_suite(args.env)
         source = args.source or "local `go test -tags blackbox -v` run"
 
     tests = parse_log(lines, args.env)

--- a/hack/measure-blackbox-times.py
+++ b/hack/measure-blackbox-times.py
@@ -9,42 +9,64 @@ with -v and parses the `--- PASS/FAIL/SKIP: TestName (N.NNs)` lines that
 (hack/calc-blackbox-groups.py) to consume.
 
 Requires a running dev environment (make dev) since the tests exercise a real
-cluster. TestPOP and the distributed-runner tests are excluded: they run in
-different environments and self-skip here.
+cluster. TestPOP is always excluded (its own CI job).
+
+Times are tagged with the environment they were measured in (`standalone` or
+`peers`), and rows for that one environment are replaced on each run while rows
+for other environments are preserved, so a single times file holds both pools
+for hack/calc-blackbox-groups.py to shard by `--env`. The environment defaults
+to `peers` when BLACKBOX_MODE=peers is set (matching the distributed suite),
+else `standalone`; override with `--env`.
 
 You can also parse an existing `go test -v` log instead of running the suite,
 which is handy for seeding from a CI run:
 
   ./hack/measure-blackbox-times.py --from-log blackbox.log
   ./hack/measure-blackbox-times.py                 # runs the suite itself
+  BLACKBOX_MODE=peers ./hack/measure-blackbox-times.py --from-log dist-ci.log
 """
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 
-RESULT_RE = re.compile(r'^\s*--- (PASS|FAIL|SKIP): (Test\w+) \(([\d.]+)s\)')
+# Matched anywhere in a line, not anchored at the start, so a raw `go test -v`
+# log ("    --- PASS: TestX (1.2s)") and a `gh run view --log` dump (each line
+# prefixed with "job\tUNKNOWN STEP\ttimestamp ") both parse.
+RESULT_RE = re.compile(r'--- (PASS|FAIL|SKIP): (Test\w+) \(([\d.]+)s\)')
 
-# Excluded from the standalone timing set: TestPOP runs in its own job, and the
-# distributed-runner tests self-skip outside the peers topology.
-EXCLUDE_PREFIXES = ("TestPOP", "TestDistributedRunner")
+# TestPOP always runs in its own CI job, so it's excluded from every
+# environment's timing set. The TestDistributed* tests self-skip outside the
+# peers topology: in standalone they're noise (a 0s skip), but in peers they're
+# real work and must be timed, so they're only excluded for standalone.
+def excluded_prefixes(environment):
+    if environment == "peers":
+        return ("TestPOP",)
+    return ("TestPOP", "TestDistributed")
 
 
-def parse_log(lines):
+def parse_log(lines, environment):
+    exclude = excluded_prefixes(environment)
     tests = {}
     for line in lines:
-        m = RESULT_RE.match(line)
+        m = RESULT_RE.search(line)
         if not m:
             continue
         status, name, elapsed = m.group(1), m.group(2), float(m.group(3))
-        if name.startswith(EXCLUDE_PREFIXES):
+        if name.startswith(exclude):
+            continue
+        # A skip carries no timing signal; the shard packer assigns untimed
+        # tests to the lightest shard anyway, so drop skips rather than pin them
+        # at 0s.
+        if status == "SKIP":
             continue
         # Keep the last observation if a name somehow repeats.
         tests[name] = {
             "name": name,
-            "environment": "standalone",
+            "environment": environment,
             "elapsed_s": elapsed,
             "status": status.lower(),
         }
@@ -64,10 +86,32 @@ def run_suite():
     return proc.stdout.splitlines()
 
 
+def load_existing(path):
+    """Load the times file if present, tolerating the old flat-summary shape.
+
+    Older files stored a single `summary` object (implicitly standalone); newer
+    ones key `summary` by environment. Normalize to the keyed shape so merging
+    is uniform.
+    """
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return {"summary": {}, "tests": []}
+    summary = data.get("summary", {})
+    if summary and "total_test_time_s" in summary:
+        summary = {"standalone": summary}
+    return {"summary": summary, "tests": data.get("tests", [])}
+
+
 def main():
+    default_env = "peers" if os.environ.get("BLACKBOX_MODE") == "peers" else "standalone"
     parser = argparse.ArgumentParser(description="Measure blackbox per-test times")
     parser.add_argument("-o", "--output", default="hack/blackbox-test-times.json",
                         help="Output file (default: hack/blackbox-test-times.json)")
+    parser.add_argument("--env", default=default_env, choices=["standalone", "peers"],
+                        help="Environment the times are measured in "
+                             f"(default: {default_env}, from BLACKBOX_MODE)")
     parser.add_argument("--from-log", metavar="FILE",
                         help="Parse an existing `go test -v` log instead of running")
     parser.add_argument("--source", default=None,
@@ -82,25 +126,33 @@ def main():
         lines = run_suite()
         source = args.source or "local `go test -tags blackbox -v` run"
 
-    tests = parse_log(lines)
+    tests = parse_log(lines, args.env)
     if not tests:
         print("Error: no test timings found in output.", file=sys.stderr)
         sys.exit(1)
 
-    out = {
-        "summary": {
-            "total_test_time_s": round(sum(t["elapsed_s"] for t in tests), 2),
-            "test_count": len(tests),
-            "source": source,
-        },
-        "tests": tests,
+    # Replace only this environment's rows; preserve the other environments'
+    # timings so one file holds every shard pool.
+    existing = load_existing(args.output)
+    kept = [t for t in existing["tests"]
+            if t.get("environment", "standalone") != args.env]
+    merged = sorted(kept + tests,
+                    key=lambda t: (t.get("environment", "standalone"), -t["elapsed_s"]))
+
+    summary = existing["summary"]
+    summary[args.env] = {
+        "total_test_time_s": round(sum(t["elapsed_s"] for t in tests), 2),
+        "test_count": len(tests),
+        "source": source,
     }
+
+    out = {"summary": summary, "tests": merged}
     with open(args.output, "w") as f:
         json.dump(out, f, indent=2)
         f.write("\n")
 
-    print(f"Wrote {len(tests)} test timings "
-          f"({out['summary']['total_test_time_s']:.1f}s total) to {args.output}",
+    print(f"Wrote {len(tests)} {args.env} test timings "
+          f"({summary[args.env]['total_test_time_s']:.1f}s total) to {args.output}",
           file=sys.stderr)
 
 


### PR DESCRIPTION
## Why

`test-blackbox-distributed` runs the whole blackbox suite serially against a coordinator+runner topology in a single job — ~20 minutes, right at the edge of its timeout, and it gates every release.

Measuring a green run (CI run 32993856200) showed where the time actually goes:

| Phase | Time | Share |
|-------|------|-------|
| Infra setup (checkout, Go, iso, cache restore, docker load) | ~61s | 5% |
| `make dev-distributed` (peers up + build + join) | ~53s | 4% |
| **Serial test execution — 67 tests, `-p 1`** | **~1028s** | **~87%** |

So the wall clock is almost entirely serial test execution. The fix is to shard the suite across parallel jobs, the same way the standalone blackbox suite already does — the sharding tooling was written with a `peers` environment dimension for exactly this.

## What changed

- **`hack/measure-blackbox-times.py`** — peers-mode timing (`BLACKBOX_MODE=peers` / `--env`), rows tagged by environment and **merged** rather than overwritten so one file holds both the standalone and peers pools. Also parses `gh run --log` dumps, so timings can be seeded straight from a CI run.
- **`hack/blackbox-test-times.json`** — seeded with 67 peers timings from a green distributed run (33 standalone rows preserved).
- **`hack/calc-blackbox-groups.py`** — exclude the cloud-backed tests (`TestRPCViaCloud`, `TestDeployViaCloud`) in every environment, matching the `-skip` list; `-list` discovery would otherwise fold them into a shard.
- **`hack/blackbox-groups-distributed.json`** (new) — four balanced shards, ~257s each. No duplicate assignments; zero ungrouped tests.
- **`Makefile`** — `test-blackbox-distributed` takes a `BLACKBOX_RUN` subset (whole suite locally, one shard's subset in CI); adds `blackbox-groups-distributed` and `measure-blackbox-times-distributed`.
- **`.github/workflows/test.yml`** — a `blackbox-groups-distributed` builder job owns the run/skip gate (preserving the `!cancelled()` release-coverage guarantee and the `ci:distributed` opt-in), `test-blackbox-distributed` fans out over its shard matrix, and the all-green gate is updated so neither a builder failure nor a shard failure slips through.

**Projected ~20 min → ~6 min per shard (N=4), full suite coverage preserved.**

## Testing this PR

The `changes` filter already flags this PR as distributed-relevant (it touches `test.yml`), and the `ci:distributed` label is applied — so the sharded distributed job runs here. Watching for: the matrix fans out to four shards, each green, each well under the old 20-minute wall clock.

## Follow-ups (not in this PR)

- Build the miren binary once per `dev-distributed` bring-up instead of once per peer. Marginal per the measurement above (setup is a small slice of the job) and needs a live peers env to verify `/src` sharing and the `rebuild` path, so it's left as a separate change.
- Cache the compiled binary across shards; auto-refresh peers timings from CI.