### PR TITLE
Deploy configured images without BuildKit

### DIFF
--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -23,6 +23,8 @@ type StatusUpdate interface {
 	SetLog(*LogEntry)
 	Deployment() *DeploymentProgress
 	SetDeployment(*DeploymentProgress)
+	Image() string
+	SetImage(string)
 }
 
 type statusUpdate struct {
@@ -31,6 +33,7 @@ type statusUpdate struct {
 	U_Error      *string              `cbor:"3,keyasint,omitempty" json:"error,omitempty"`
 	U_Log        **LogEntry           `cbor:"4,keyasint,omitempty" json:"log,omitempty"`
 	U_Deployment **DeploymentProgress `cbor:"5,keyasint,omitempty" json:"deployment,omitempty"`
+	U_Image      *string              `cbor:"6,keyasint,omitempty" json:"image,omitempty"`
 }
 
 func (v *statusUpdate) Which() string {
@@ -49,6 +52,9 @@ func (v *statusUpdate) Which() string {
 	if v.U_Deployment != nil {
 		return "deployment"
 	}
+	if v.U_Image != nil {
+		return "image"
+	}
 	return ""
 }
 
@@ -64,6 +70,7 @@ func (v *statusUpdate) SetMessage(val string) {
 	v.U_Error = nil
 	v.U_Log = nil
 	v.U_Deployment = nil
+	v.U_Image = nil
 	v.U_Message = &val
 }
 
@@ -79,6 +86,7 @@ func (v *statusUpdate) SetBuildkit(val []byte) {
 	v.U_Error = nil
 	v.U_Log = nil
 	v.U_Deployment = nil
+	v.U_Image = nil
 	v.U_Buildkit = &val
 }
 
@@ -94,6 +102,7 @@ func (v *statusUpdate) SetError(val string) {
 	v.U_Buildkit = nil
 	v.U_Log = nil
 	v.U_Deployment = nil
+	v.U_Image = nil
 	v.U_Error = &val
 }
 
@@ -109,6 +118,7 @@ func (v *statusUpdate) SetLog(val *LogEntry) {
 	v.U_Buildkit = nil
 	v.U_Error = nil
 	v.U_Deployment = nil
+	v.U_Image = nil
 	v.U_Log = &val
 }
 
@@ -124,7 +134,24 @@ func (v *statusUpdate) SetDeployment(val *DeploymentProgress) {
 	v.U_Buildkit = nil
 	v.U_Error = nil
 	v.U_Log = nil
+	v.U_Image = nil
 	v.U_Deployment = &val
+}
+
+func (v *statusUpdate) Image() string {
+	if v.U_Image == nil {
+		return ""
+	}
+	return *v.U_Image
+}
+
+func (v *statusUpdate) SetImage(val string) {
+	v.U_Message = nil
+	v.U_Buildkit = nil
+	v.U_Error = nil
+	v.U_Log = nil
+	v.U_Deployment = nil
+	v.U_Image = &val
 }
 
 type statusData struct {

--- a/api/build/rpc.yml
+++ b/api/build/rpc.yml
@@ -33,6 +33,12 @@ types:
           - name: deployment
             type: DeploymentProgress
             index: 5
+          - name: image
+            type: string
+            index: 6
+            doc: >
+              Normalized upstream image reference selected for a direct-image
+              deploy. No image was built or pushed by Miren.
 
   - type: DeploymentProgress
     doc: >
@@ -393,4 +399,3 @@ interfaces:
             doc: Information about how to access the deployed app
           - name: version_short_id
             type: string
-

--- a/blackbox/image_source_test.go
+++ b/blackbox/image_source_test.go
@@ -1,0 +1,42 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+// TestDeployImageOnlyNoDockerfile proves a service image can be the app's
+// primary source. The fixture has only app.toml: no Dockerfile, Procfile, or
+// language stack for the builder to detect.
+func TestDeployImageOnlyNoDockerfile(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{Testdata: "image-only"})
+
+	r := m.MustRun("sandbox", "list", "--format", "json")
+	var sandboxes []struct {
+		ID   string `json:"id"`
+		Spec struct {
+			Container []struct {
+				Image string `json:"image"`
+			} `json:"container"`
+		} `json:"spec"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(r.Stdout), &sandboxes))
+
+	for _, sb := range sandboxes {
+		if len(sb.Spec.Container) > 0 && sb.Spec.Container[0].Image == "docker.io/library/nginx:alpine" {
+			assert.Contains(t, sb.ID, name)
+			return
+		}
+	}
+	t.Fatal("no sandbox is running the direct nginx image")
+}

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -481,6 +481,22 @@ func Deploy(ctx *Context, opts struct {
 		ctx.Log.Info("Server-owned deployment", "deployment_id", id, "phase", phase)
 	}
 
+	// The build status stream announces a normalized upstream image when the
+	// server bypasses BuildKit. Keep that semantic signal separate from the
+	// free-form progress text so the TUI can render a truthful phase summary.
+	var directImage atomic.Pointer[string]
+	onImage := func(image string) {
+		if image != "" {
+			directImage.Store(&image)
+		}
+	}
+	selectedImage := func() string {
+		if image := directImage.Load(); image != nil {
+			return *image
+		}
+		return ""
+	}
+
 	// Parse environment variables to pass to build server
 	var envVars []*build_v1alpha.EnvironmentVariable
 	if len(opts.Env) > 0 || len(opts.Sensitive) > 0 {
@@ -794,7 +810,7 @@ func Deploy(ctx *Context, opts struct {
 			return safeStatus.Send(buildCtx, status)
 		}
 
-		cb = createBuildStatusCallback(buildCtx, nil, nil, &buildStateMu, &buildErrors, nil, &deployWarnings, progressHandler, onDeployment)
+		cb = createBuildStatusCallback(buildCtx, nil, nil, &buildStateMu, &buildErrors, nil, &deployWarnings, progressHandler, onDeployment, onImage)
 
 		results, err = buildCall(buildCtx, r, cb)
 		if err != nil {
@@ -842,6 +858,12 @@ func Deploy(ctx *Context, opts struct {
 			uploadSpan.End()
 			return pw.Err()
 		}
+		if image := selectedImage(); image != "" {
+			// A direct-image deploy emits no BuildKit status for the explain
+			// printer to render. Clear any in-place upload line and state the
+			// actual operation before health waiting begins.
+			fmt.Fprintf(os.Stderr, "\r\033[K%s\n", renderPhaseSummary(buildPhaseSummary(image, 0, 0)))
+		}
 	} else {
 		var (
 			updateCh         = make(chan string, 1)
@@ -884,7 +906,7 @@ func Deploy(ctx *Context, opts struct {
 			return nil
 		}
 
-		cb = createBuildStatusCallback(deployCtx, updateCh, buildCh, &buildStateMu, &buildErrors, &buildLogs, &deployWarnings, progressHandler, onDeployment)
+		cb = createBuildStatusCallback(deployCtx, updateCh, buildCh, &buildStateMu, &buildErrors, &buildLogs, &deployWarnings, progressHandler, onDeployment, onImage)
 
 		results, err = buildCall(deployCtx, r, cb)
 
@@ -936,7 +958,7 @@ func Deploy(ctx *Context, opts struct {
 		// Build succeeded: fold the build phase into the model and keep the
 		// program alive, so the activate + health steps render as continuations
 		// of the same TUI rather than flat text printed below it.
-		buildProg.Send(buildDoneMsg{})
+		buildProg.Send(buildDoneMsg{image: selectedImage()})
 		updateDeploymentPhase("pushing")
 	}
 
@@ -1274,12 +1296,24 @@ func createBuildStatusCallback(
 	deployWarnings *[]*build_v1alpha.LogEntry,
 	progressHandler func(*client.SolveStatus) error,
 	onDeployment func(deploymentID, phase string),
+	onImage func(image string),
 ) stream.SendStream[*build_v1alpha.Status] {
 	vertices := map[string]bool{} // digest → completed
 	return stream.Callback(func(su *build_v1alpha.Status) error {
 		update := su.Update()
 
 		switch update.Which() {
+		case "image":
+			image := update.Image()
+			if onImage != nil {
+				onImage(image)
+			}
+			if updateCh != nil {
+				select {
+				case updateCh <- fmt.Sprintf("Using image %s", image):
+				default:
+				}
+			}
 		case "deployment":
 			// The server-owned deployment record announced itself. This arm only
 			// ever arrives when the server was handed a DeployRequest (an older

--- a/cli/commands/deploy_test.go
+++ b/cli/commands/deploy_test.go
@@ -8,6 +8,33 @@ import (
 	"miren.dev/runtime/pkg/progress/upload"
 )
 
+func TestBuildPhaseSummary(t *testing.T) {
+	duration := 250 * time.Millisecond
+
+	t.Run("direct image names the upstream reference", func(t *testing.T) {
+		got := buildPhaseSummary("docker.io/library/nginx:alpine", 0, duration)
+		if got.name != "Use image" {
+			t.Errorf("name = %q, want %q", got.name, "Use image")
+		}
+		if got.details != "docker.io/library/nginx:alpine" {
+			t.Errorf("details = %q, want normalized image reference", got.details)
+		}
+		if got.duration != duration {
+			t.Errorf("duration = %s, want %s", got.duration, duration)
+		}
+	})
+
+	t.Run("source build retains build summary", func(t *testing.T) {
+		got := buildPhaseSummary("", 3, duration)
+		if got.name != "Build & push image" {
+			t.Errorf("name = %q, want %q", got.name, "Build & push image")
+		}
+		if got.details != "3 steps completed" {
+			t.Errorf("details = %q, want %q", got.details, "3 steps completed")
+		}
+	})
+}
+
 func TestEnrichUploadProgress(t *testing.T) {
 	const total int64 = 1_000_000
 

--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -78,10 +78,10 @@ type updateMsg struct {
 	msg string
 }
 
-// buildDoneMsg tells the model the build finished: it finalizes the build
-// phase from its own step state and shows an "activating" spinner until the
-// health phase begins. Sent instead of quitting the program after the build.
-type buildDoneMsg struct{}
+// buildDoneMsg tells the model preparation finished. image is populated when
+// Miren selected an upstream image directly, allowing the summary to describe
+// what actually happened rather than treating a zero-step build as cached.
+type buildDoneMsg struct{ image string }
 
 // healthWaitMsg sets the in-progress label for the health phase (e.g.
 // "Waiting for version X to become healthy" or "1/3 instances ready").
@@ -370,13 +370,13 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.phaseStart = time.Now()
 		}
 
-		// Commit the build phase, then show an "activating" spinner until the
-		// health phase reports in.
-		phasePrints = append(phasePrints, m.completePhase(phaseSummary{
-			name:     "Build & push image",
-			duration: time.Since(m.phaseStart),
-			details:  buildStepsSummary(m.buildSteps),
-		}))
+		// Commit the build or direct-image phase, then show an "activating"
+		// spinner until the health phase reports in.
+		phasePrints = append(phasePrints, m.completePhase(buildPhaseSummary(
+			msg.image,
+			m.buildSteps,
+			time.Since(m.phaseStart),
+		)))
 		cmds = append(cmds, tea.Sequence(phasePrints...))
 
 		m.isUploading = false
@@ -489,4 +489,19 @@ func renderPhaseSummary(phase phaseSummary) string {
 		return fmt.Sprintf("%s %s - %s", phaseStr, timeStr, phase.details)
 	}
 	return fmt.Sprintf("%s %s", phaseStr, timeStr)
+}
+
+func buildPhaseSummary(image string, steps int, duration time.Duration) phaseSummary {
+	if image != "" {
+		return phaseSummary{
+			name:     "Use image",
+			duration: duration,
+			details:  image,
+		}
+	}
+	return phaseSummary{
+		name:     "Build & push image",
+		duration: duration,
+		details:  buildStepsSummary(steps),
+	}
 }

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -86,6 +86,7 @@ Create `.miren/app.toml` when you need to:
 - **Set environment variables** — configuration your app reads at runtime
 - **Tune scaling** — adjust concurrency thresholds or use fixed instance counts
 - **Attach persistent disks** — for databases or file storage
+- **Run an existing image** — deploy a prebuilt container without a Dockerfile or source build
 - **Customize builds** — specify a Dockerfile, language version, or extra build steps
 - **Configure addons** — managed databases and other backing services (see [Addons](/addons))
 
@@ -115,6 +116,14 @@ command = "node server.js"
 
 [services.worker]
 command = "node worker.js"
+```
+
+To deploy an existing image as the app, set `image` on the `web` service. Miren uses it directly when no Dockerfile is configured:
+
+```toml
+[services.web]
+image = "ghcr.io/example/myapp:latest"
+port = 8080
 ```
 
 See [Services](/services) for patterns like running databases alongside your app.

--- a/docs/docs/app-toml.md
+++ b/docs/docs/app-toml.md
@@ -208,13 +208,17 @@ image = "postgres:16"
 | `port_type` | string | `"http"` or `"tcp"` (single-port shorthand) | `"http"` |
 | `ports` | [[port]](#ports) | Multi-port configuration array | — |
 | `port_timeout` | duration | Time to wait for the service to bind its port at startup (e.g. `"60s"`, `"2m"`) | `"15s"` |
-| `image` | string | Container image to use instead of the app's built image | App's built image |
+| `image` | string | Container image to use. On `services.web`, this selects the app's primary image unless `[build].dockerfile` is set or `Dockerfile.miren` exists | App's built image |
 | `env` | [[env]](#env) | Service-specific environment variables (same schema as global `[[env]]`) | — |
 | `concurrency` | [concurrency](#concurrency) | Scaling configuration | See defaults below |
 | `disks` | [[disk]](#disks) | Persistent disk attachments | — |
 
 :::note[Validation]
 You cannot mix the single-port fields (`port`, `port_name`, `port_type`) with the `ports` array on the same service.
+:::
+
+:::note[Image selection]
+When `services.web.image` is set and neither `[build].dockerfile` nor `Dockerfile.miren` selects a Dockerfile, Miren launches that image directly instead of auto-detecting and building the project source. Images on other services do not suppress source detection. If detection finds no buildable source, a lone service image can act as the fallback; with several service images, set `services.web.image` to choose the primary one.
 :::
 
 ### `[services.<name>.concurrency]` — Scaling {#concurrency}

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment
-description: How miren deploy works — uploading code, building images, and activating new versions.
+description: How miren deploy uploads an app, selects or builds an image, and activates new versions.
 keywords: [deploy, build, rollback, versions, container image]
 ---
 
@@ -8,7 +8,7 @@ import CliCommand from '@site/src/components/CliCommand';
 
 # Deployment
 
-Deployment is the core workflow of Miren — it takes your application code, builds a container image, and runs it on your server.
+Deployment is the core workflow of Miren. It takes your application source or configured container image and runs it on your server.
 
 ## Minimum working example
 
@@ -26,8 +26,8 @@ That's the whole thing — Miren detects your language, builds the image on the 
 
 When you run `miren deploy`, Miren:
 
-1. **Uploads your files** — sends your source code to the server (after your first deploy, only changed files are transferred)
-2. **Detects and builds on the server** — the server inspects your source code to detect the [language, framework](/guides), and [services](/services), then builds a container image using the detected stack (or your Dockerfile)
+1. **Uploads your files** — sends your project files and app configuration to the server (after your first deploy, only changed files are transferred)
+2. **Selects or builds an image** — uses a configured web image directly, or inspects your source to build an image from a detected [language or framework](/guides) or your Dockerfile
 3. **Activates the new version** — rolls out the new version, replacing the previous one
 
 Each deployment is a tracked object with its own ID, a status, and the git commit it came from. A successful deployment produces a new version (identified by a version ID); a failed one produces no version but stays in history as a record of the attempt. You can inspect, roll back, or redeploy any previous version at any time.
@@ -82,6 +82,24 @@ You'll see the detected stack, services, entrypoint, and what files and framewor
 If a build fails, Miren displays the build errors and the deployment is marked as failed in history (visible via `miren app history`).
 
 Use `--explain` (or `-x`) to watch each build step as it runs. This is the default in non-interactive environments; in interactive terminals, Miren shows a compact progress UI instead.
+
+### Deploying an existing image
+
+If your app is already packaged as a container image, set it on the `web` service:
+
+```toml title=".miren/app.toml"
+name = "myapp"
+
+[services.web]
+image = "ghcr.io/example/myapp:latest"
+port = 8080
+```
+
+Miren normalizes the reference and launches that image directly. It does not run BuildKit, push a derived image, or create a build artifact. When `command` is unset, the container uses the image's default entrypoint and command.
+
+:::note[Image selection]
+A Dockerfile selected by `[build].dockerfile` or discovered as `Dockerfile.miren` takes precedence over `services.web.image`. Without one, the web image takes precedence over automatic source detection, even if the project directory also contains recognizable source files. Images on other services do not suppress source detection. If detection finds no buildable source, Miren uses a lone service image as the fallback; with several service images, set `services.web.image` to choose the primary one.
+:::
 
 ## Deploy-Time Environment Variables
 

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -134,7 +134,23 @@ command = "celery -A myapp worker --loglevel=info"
 command = "celery -A myapp beat --loglevel=info"
 ```
 
-### Different Images
+### Existing and Different Images
+
+If your web app already exists as a container image, you can deploy it without source detection or a Dockerfile:
+
+```toml
+name = "myapp"
+
+[services.web]
+image = "ghcr.io/example/myapp:latest"
+port = 8080
+```
+
+:::note[Image selection]
+Without a Dockerfile, `services.web.image` selects the app's primary image and Miren launches it directly. This explicit image wins over automatic source detection. A `[build].dockerfile` setting or a discovered `Dockerfile.miren` still wins over both.
+
+An image on another service does not override a buildable source stack. This keeps database and cache sidecars from changing how the web app is built. Only when source detection finds no buildable stack can a lone service image become the fallback; with several service images, set `services.web.image` to choose the primary one.
+:::
 
 :::tip[Use addons for databases]
 If you just need a PostgreSQL database, consider using an [addon](/addons) instead of running it as a service. Addons are fully managed — Miren provisions the database, injects credentials, and handles cleanup. Use a service when you need full control over the database configuration.
@@ -160,7 +176,7 @@ mode = "fixed"
 num_instances = 1
 ```
 
-When you specify an `image`, Miren pulls that container image instead of using your app's built image. This lets you run standard database images alongside your application code.
+When you specify an `image` on a sidecar service, Miren pulls that container image instead of using your app's built image. This lets you run standard database images alongside your application code.
 
 #### Example: Full Stack with PostgreSQL and Redis
 

--- a/docs/static/app-toml.schema.json
+++ b/docs/static/app-toml.schema.json
@@ -109,7 +109,7 @@
         "port_type": {"type": "string", "enum": ["http", "tcp"]},
         "ports": {"type": "array", "items": {"$ref": "#/$defs/port"}},
         "port_timeout": {"$ref": "#/$defs/duration"},
-        "image": {"type": "string"},
+        "image": {"type": "string", "description": "Container image to use. On services.web, this also selects the app's primary image when no Dockerfile is configured."},
         "env": {"type": "array", "items": {"$ref": "#/$defs/env"}},
         "concurrency": {"$ref": "#/$defs/concurrency"},
         "disks": {"type": "array", "items": {"$ref": "#/$defs/disk"}}

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -35,6 +35,7 @@ import (
 	"miren.dev/runtime/components/netresolve"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
 	ephemeralx "miren.dev/runtime/pkg/ephemeral"
@@ -1337,7 +1338,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 
 	if status != nil {
-		so.Update().SetMessage("Launching builder")
+		so.Update().SetMessage("Preparing deployment")
 		_, _ = status.Send(ctx, so)
 	}
 
@@ -1489,7 +1490,7 @@ func (b *Builder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.Bu
 
 	if status != nil {
 		so := new(build_v1alpha.Status)
-		so.Update().SetMessage("Launching builder")
+		so.Update().SetMessage("Preparing deployment")
 		_, _ = status.Send(ctx, so)
 	}
 
@@ -1585,46 +1586,55 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 		return nil, err
 	}
 
-	buildLog := &buildLogWriter{
-		log:      b.Log,
-		writer:   b.LogWriter,
-		entityID: appRec.ID.String(),
-		version:  mrv.Version,
-	}
+	var res *BuildResult
+	var artifactName string
+	if buildStack.Stack == "image" {
+		mrv.ImageUrl = containerdx.NormalizeImageReference(buildStack.Input)
+		NewRPCStatusSender(status, b.Log).SendImage(mrv.ImageUrl)
+		b.Log.Info("using upstream image directly", "app", name, "image", mrv.ImageUrl)
+	} else {
+		buildLog := &buildLogWriter{
+			log:      b.Log,
+			writer:   b.LogWriter,
+			entityID: appRec.ID.String(),
+			version:  mrv.Version,
+		}
 
-	deploy.setPhase(ctx, deploylifecycle.PhaseBuilding)
+		deploy.setPhase(ctx, deploylifecycle.PhaseBuilding)
 
-	// runBuildkitBuild is also the saga action's implementation, so the
-	// span structure (buildkit + locate_artifact bundled together) is
-	// slightly coarser than the pre-saga code's two separate spans.
-	// Trace continuity matters more than the extra granularity.
-	bkCtx, bkSpan := buildTracer.Start(ctx, "build.buildkit",
-		trace.WithAttributes(attribute.String("miren.build.image", mrv.ImageUrl)))
-	statusSender := NewRPCStatusSender(status, b.Log)
-	res, artifactID, finalURL, err := b.runBuildkitBuild(bkCtx, runBuildkitBuildInputs{
-		SourceDir:      path,
-		AppName:        name,
-		VersionName:    mrv.Version,
-		ImageURL:       mrv.ImageUrl,
-		BuildStack:     buildStack,
-		AppConfig:      ac,
-		ExistingConfig: existingCfg,
-		CLIEnvVars:     envVars,
-	}, statusSender, buildLog)
-	if err != nil {
-		bkSpan.RecordError(err)
-		bkSpan.SetStatus(codes.Error, err.Error())
+		// runBuildkitBuild is also the saga action's implementation, so the
+		// span structure (buildkit + locate_artifact bundled together) is
+		// slightly coarser than the pre-saga code's two separate spans.
+		// Trace continuity matters more than the extra granularity.
+		bkCtx, bkSpan := buildTracer.Start(ctx, "build.buildkit",
+			trace.WithAttributes(attribute.String("miren.build.image", mrv.ImageUrl)))
+		statusSender := NewRPCStatusSender(status, b.Log)
+		var artifactID, finalURL string
+		res, artifactID, finalURL, err = b.runBuildkitBuild(bkCtx, runBuildkitBuildInputs{
+			SourceDir:      path,
+			AppName:        name,
+			VersionName:    mrv.Version,
+			ImageURL:       mrv.ImageUrl,
+			BuildStack:     buildStack,
+			AppConfig:      ac,
+			ExistingConfig: existingCfg,
+			CLIEnvVars:     envVars,
+		}, statusSender, buildLog)
+		if err != nil {
+			bkSpan.RecordError(err)
+			bkSpan.SetStatus(codes.Error, err.Error())
+			bkSpan.End()
+			return nil, err
+		}
 		bkSpan.End()
-		return nil, err
+
+		deploy.setPhase(ctx, deploylifecycle.PhasePushing)
+
+		mrv.Artifact = entity.Id(artifactID)
+		mrv.ImageUrl = finalURL
+		artifactName = strings.TrimPrefix(artifactID, "artifact/")
+		b.Log.Debug("build complete", "image", mrv.ImageUrl)
 	}
-	bkSpan.End()
-
-	deploy.setPhase(ctx, deploylifecycle.PhasePushing)
-
-	mrv.Artifact = entity.Id(artifactID)
-	mrv.ImageUrl = finalURL
-	artifactName := strings.TrimPrefix(artifactID, "artifact/")
-	b.Log.Debug("build complete", "image", mrv.ImageUrl)
 
 	procfileServices, err := b.readProcFile(tr)
 	if err != nil {
@@ -1842,7 +1852,7 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 	}
 
 	// Log the deployment to the app's logs
-	b.logDeployment(ctx, name, mrv.Version, artifactName)
+	b.logDeployment(ctx, name, mrv.Version, artifactName, mrv.ImageUrl)
 
 	var ephLabel string
 	if ephemeral != nil {
@@ -2040,7 +2050,7 @@ func (b *Builder) provisionAddons(ctx context.Context, appName string, ac *appco
 	return nil
 }
 
-func (b *Builder) logDeployment(ctx context.Context, appName, version, artifact string) {
+func (b *Builder) logDeployment(ctx context.Context, appName, version, artifact, image string) {
 	if b.LogWriter == nil {
 		return
 	}
@@ -2053,18 +2063,26 @@ func (b *Builder) logDeployment(ctx context.Context, appName, version, artifact 
 		return
 	}
 
-	// Format in Heroku logfmt style
+	// Format in Heroku logfmt style. Source builds name their stored artifact;
+	// direct-image deploys have no Artifact entity, so record the upstream image
+	// rather than emitting a misleading empty artifact field.
 	logMsg := fmt.Sprintf("version=%s artifact=%s status=deployed", version, artifact)
+	attrs := map[string]string{
+		"source":  "build",
+		"version": version,
+	}
+	if artifact != "" {
+		attrs["artifact"] = artifact
+	} else {
+		logMsg = fmt.Sprintf("version=%s image=%s status=deployed", version, image)
+		attrs["image"] = image
+	}
 
 	err = b.LogWriter.WriteEntry(appRec.ID.String(), observability.LogEntry{
-		Timestamp: time.Now(),
-		Stream:    observability.UserOOB,
-		Body:      logMsg,
-		Attributes: map[string]string{
-			"source":   "build",
-			"version":  version,
-			"artifact": artifact,
-		},
+		Timestamp:  time.Now(),
+		Stream:     observability.UserOOB,
+		Body:       logMsg,
+		Attributes: attrs,
 	})
 	if err != nil {
 		b.Log.Error("failed to write deployment log entry", "error", err, "app", appName)
@@ -2140,51 +2158,52 @@ func (b *Builder) AnalyzeApp(ctx context.Context, state *build_v1alpha.BuilderAn
 			result.SetEnvVars(&envKeys)
 		}
 
-		// Check for explicit dockerfile in build config
-		if ac.Build != nil && ac.Build.Dockerfile != "" {
-			result.SetBuildDockerfile(ac.Build.Dockerfile)
-		}
 	}
 
 	// Detect stack and build a BuildResult to use with buildVersionConfig
 	var stackName string
 	var buildResult BuildResult
 	var detectedStack stackbuild.Stack
-	var hasDockerfile bool
+	var directImage bool
 
-	// Check for Dockerfile.miren first
-	if f, err := tr.Open("Dockerfile.miren"); err == nil {
-		f.Close()
-		hasDockerfile = true
-		stackName = "dockerfile"
-		result.SetBuildDockerfile("Dockerfile.miren")
-	} else if ac != nil && ac.Build != nil && ac.Build.Dockerfile != "" {
-		hasDockerfile = true
-		stackName = "dockerfile"
-	}
-
-	// Always try to detect stack for analysis (env vars, events, etc.)
-	// even when dockerfile is present
-	var detectOpts stackbuild.BuildOptions
-	detectOpts.Log = b.Log
+	detectOpts := stackbuild.BuildOptions{Log: b.Log}
 	if ac != nil {
 		detectOpts.Name = ac.Name
 	}
-	stack, err := stackbuild.DetectStack(path, detectOpts)
+	recordDirectImage := func(image string) {
+		stackName = "image"
+		directImage = true
+		var event build_v1alpha.DetectionEvent
+		event.SetKind("source")
+		event.SetName("image")
+		event.SetMessage(fmt.Sprintf("Using service image %s directly", image))
+		events = append(events, event)
+	}
+
+	resolution, err := b.resolveBuildSource(path, ac, detectOpts.Name)
 	if err != nil {
-		b.Log.Debug("no stack detected", "error", err)
-		if !hasDockerfile {
+		return err
+	}
+	switch resolution.BuildStack.Stack {
+	case "dockerfile":
+		stackName = "dockerfile"
+		result.SetBuildDockerfile(resolution.BuildStack.Input)
+		// Stack detection is supplementary for Dockerfile apps: it contributes
+		// framework events and required env vars without changing the source.
+		detectedStack, _ = stackbuild.DetectStack(path, detectOpts)
+	case "image":
+		recordDirectImage(resolution.BuildStack.Input)
+	case "auto":
+		detectedStack = resolution.DetectedStack
+		if detectedStack == nil {
+			b.Log.Debug("no stack detected", "error", resolution.DetectionErr)
 			stackName = "unknown"
+			break
 		}
-	} else {
-		detectedStack = stack
-		// Only use detected stack name/config if no dockerfile
-		if !hasDockerfile {
-			stackName = stack.Name()
-			buildResult.Entrypoint = stack.Entrypoint()
-			buildResult.Command = stack.WebCommand()
-			buildResult.WorkingDir = stack.Image().Config.WorkingDir
-		}
+		stackName = detectedStack.Name()
+		buildResult.Entrypoint = detectedStack.Entrypoint()
+		buildResult.Command = detectedStack.WebCommand()
+		buildResult.WorkingDir = detectedStack.Image().Config.WorkingDir
 	}
 
 	result.SetStack(stackName)
@@ -2258,8 +2277,12 @@ func (b *Builder) AnalyzeApp(ctx context.Context, state *build_v1alpha.BuilderAn
 	}
 
 	// Use buildVersionConfig to compute services - same logic as BuildFromTar
+	configBuildResult := &buildResult
+	if directImage {
+		configBuildResult = nil
+	}
 	spec := buildVersionConfig(ConfigInputs{
-		BuildResult:      &buildResult,
+		BuildResult:      configBuildResult,
 		AppConfig:        ac,
 		ProcfileServices: procfileServices,
 	})
@@ -2286,7 +2309,7 @@ func (b *Builder) AnalyzeApp(ctx context.Context, state *build_v1alpha.BuilderAn
 		if svc.Command != "" {
 			svcInfo.SetCommand(svc.Command)
 			// Determine source for this service
-			source := determineServiceSource(svc.Name, svc.Command, ac, procfileServices, &buildResult)
+			source := determineServiceSource(svc.Name, svc.Command, ac, procfileServices, configBuildResult)
 			svcInfo.SetSource(source)
 
 			// Add event when we inject a synthetic web service from stack detection

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -98,7 +99,7 @@ func receiveTar(ctx context.Context, in receiveTarIn) (receiveTarOut, error) {
 		}
 	}
 
-	status.SendMessage("Launching builder")
+	status.SendMessage("Preparing deployment")
 	return receiveTarOut{SourceDir: path}, nil
 }
 
@@ -442,7 +443,7 @@ type createVersionIn struct {
 	AppID              string `json:"app_id" saga:"app_id"`
 	VersionName        string `json:"version_name" saga:"version_name"`
 	FinalImageURL      string `json:"final_image_url" saga:"final_image_url"`
-	ArtifactID         string `json:"artifact_id" saga:"artifact_id"`
+	ArtifactID         string `json:"artifact_id" saga:"artifact_id,optional"`
 	AdminToken         string `json:"admin_token" saga:"admin_token"`
 	ConfigVersionID    string `json:"config_version_id" saga:"config_version_id"`
 	EphemeralLabel     string `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
@@ -674,7 +675,8 @@ type finalizeIn struct {
 	StreamID       string    `json:"stream_id" saga:"stream_id"`
 	AppID          string    `json:"app_id" saga:"app_id"`
 	VersionName    string    `json:"version_name" saga:"version_name"`
-	ArtifactID     string    `json:"artifact_id" saga:"artifact_id"`
+	ArtifactID     string    `json:"artifact_id,omitempty" saga:"artifact_id,optional"`
+	FinalImageURL  string    `json:"final_image_url" saga:"final_image_url"`
 	ConfigSpec     string    `json:"config_spec_json" saga:"config_spec_json"`
 	EphemeralLabel string    `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
 	ActiveReady    saga.Edge `saga:"set_active_skipped"`
@@ -696,7 +698,7 @@ func finalize(ctx context.Context, in finalizeIn) (finalizeOut, error) {
 	}
 
 	artifactName := strings.TrimPrefix(in.ArtifactID, "artifact/")
-	b.logDeployment(ctx, in.AppName, in.VersionName, artifactName)
+	b.logDeployment(ctx, in.AppName, in.VersionName, artifactName, in.FinalImageURL)
 
 	if err := deps.streams.Cleanup(in.StreamID); err != nil {
 		b.Log.Warn("cleanup staged tar", "stream", in.StreamID, "error", err)
@@ -857,12 +859,20 @@ func undoActivateDeployment(_ context.Context, _ activateDeploymentIn, _ activat
 	return nil
 }
 
-// detectBuildStack assembles the BuildStack the same way buildFromDir
-// does (app.toml.build > Dockerfile.miren > auto) and performs the
-// supported-stack check for auto so the saga can fail fast rather than
-// waste a buildkit launch. Extracted here so the saga action and the
-// pre-saga path share one source of truth.
-func (b *Builder) detectBuildStack(path string, ac *appconfig.AppConfig, name string, _ fsutil.FS) (BuildStack, error) {
+// buildSourceResolution is the shared source-selection result for deploy and
+// analyze. DetectionErr is populated only when no buildable source or fallback
+// image was found: deploy turns that into an error, while analyze reports the
+// source as unknown.
+type buildSourceResolution struct {
+	BuildStack    BuildStack
+	DetectedStack stackbuild.Stack
+	DetectionErr  error
+}
+
+// resolveBuildSource owns the source-precedence policy shared by deploy and
+// analyze: configured Dockerfile, discovered Dockerfile.miren, explicit web
+// image, detected source, then a lone non-web image fallback.
+func (b *Builder) resolveBuildSource(path string, ac *appconfig.AppConfig, name string) (buildSourceResolution, error) {
 	var stack BuildStack
 	stack.CodeDir = path
 
@@ -875,36 +885,111 @@ func (b *Builder) detectBuildStack(path string, ac *appconfig.AppConfig, name st
 			stack.Stack = "dockerfile"
 			stack.Input = ac.Build.Dockerfile
 			b.Log.Info("using dockerfile from app config", "dockerfile", ac.Build.Dockerfile)
+			return buildSourceResolution{BuildStack: stack}, nil
 		}
 	}
 
-	if stack.Stack == "" {
-		// Look on disk rather than through fsutil so test/error paths
-		// don't have to fabricate an fsutil.FS just to peek for a file.
-		if _, err := osStat(path, "Dockerfile.miren"); err == nil {
-			stack.Stack = "dockerfile"
-			stack.Input = "Dockerfile.miren"
-		} else {
-			stack.Stack = "auto"
-		}
+	// Look on disk rather than through fsutil so test/error paths don't have to
+	// fabricate an fsutil.FS just to peek for a file.
+	if _, err := osStat(path, "Dockerfile.miren"); err == nil {
+		stack.Stack = "dockerfile"
+		stack.Input = "Dockerfile.miren"
+		return buildSourceResolution{BuildStack: stack}, nil
+	}
+	stack.Stack = "auto"
+
+	if image := webImageSource(ac); image != "" {
+		stack.Stack = "image"
+		stack.Input = image
+		b.Log.Info("using explicitly configured web image as build source", "image", image, "app", name)
+		return buildSourceResolution{BuildStack: stack}, nil
 	}
 
-	if stack.Stack == "auto" {
-		detectOpts := stackbuild.BuildOptions{
-			Log:         b.Log,
-			Name:        name,
-			OnBuild:     stack.OnBuild,
-			Version:     stack.Version,
-			AlpineImage: stack.AlpineImage,
-		}
-		if _, err := stackbuild.DetectStack(stack.CodeDir, detectOpts); err != nil {
-			b.Log.Error("stack detection failed", "error", err, "app", name, "codeDir", stack.CodeDir)
-			return stack, fmt.Errorf("no supported stack detected for app %s: %w", name, err)
-		}
+	detectOpts := stackbuild.BuildOptions{
+		Log:         b.Log,
+		Name:        name,
+		OnBuild:     stack.OnBuild,
+		Version:     stack.Version,
+		AlpineImage: stack.AlpineImage,
+	}
+	detected, detectErr := stackbuild.DetectStack(stack.CodeDir, detectOpts)
+	if detectErr == nil {
 		b.Log.Debug("stack detection successful")
+		return buildSourceResolution{BuildStack: stack, DetectedStack: detected}, nil
 	}
 
-	return stack, nil
+	image, imageErr := fallbackImageSource(ac)
+	if imageErr != nil {
+		return buildSourceResolution{BuildStack: stack, DetectionErr: detectErr}, imageErr
+	}
+	if image != "" {
+		stack.Stack = "image"
+		stack.Input = image
+		b.Log.Info("using service image as build source", "image", image, "app", name)
+		return buildSourceResolution{BuildStack: stack}, nil
+	}
+
+	return buildSourceResolution{BuildStack: stack, DetectionErr: detectErr}, nil
+}
+
+// detectBuildStack adapts the shared source resolution to deploy's fail-fast
+// contract. Analyze uses the same resolution but may report an unknown stack.
+func (b *Builder) detectBuildStack(path string, ac *appconfig.AppConfig, name string, _ fsutil.FS) (BuildStack, error) {
+	resolution, err := b.resolveBuildSource(path, ac, name)
+	if err != nil {
+		return resolution.BuildStack, err
+	}
+	if resolution.DetectionErr != nil {
+		b.Log.Error("stack detection failed", "error", resolution.DetectionErr, "app", name, "codeDir", path)
+		return resolution.BuildStack, fmt.Errorf("no supported stack detected for app %s: %w", name, resolution.DetectionErr)
+	}
+	return resolution.BuildStack, nil
+}
+
+// webImageSource captures explicit primary-image intent. Unlike a non-web
+// service image, it outranks auto-detection: a user who names what web should
+// run should not have an incidental package.json or main.go turn that request
+// into a source build whose artifact is never used by web.
+func webImageSource(ac *appconfig.AppConfig) string {
+	if ac == nil {
+		return ""
+	}
+	if web := ac.Services["web"]; web != nil && web.Image != "" {
+		return web.Image
+	}
+	return ""
+}
+
+// fallbackImageSource chooses an image only after auto-detection found no
+// buildable source. This is what lets a worker-only image app deploy without
+// allowing a database sidecar image to suppress a perfectly good source build.
+// Refuse to guess among several images: map iteration order is not a
+// source-selection policy.
+func fallbackImageSource(ac *appconfig.AppConfig) (string, error) {
+	if ac == nil {
+		return "", nil
+	}
+	images := make(map[string]struct{})
+	for _, svc := range ac.Services {
+		if svc != nil && svc.Image != "" {
+			images[svc.Image] = struct{}{}
+		}
+	}
+	if len(images) == 0 {
+		return "", nil
+	}
+	if len(images) == 1 {
+		for image := range images {
+			return image, nil
+		}
+	}
+
+	refs := make([]string, 0, len(images))
+	for image := range images {
+		refs = append(refs, image)
+	}
+	slices.Sort(refs)
+	return "", fmt.Errorf("app has no buildable source and declares multiple service images (%s); set services.web.image to choose the app's primary image", strings.Join(refs, ", "))
 }
 
 // registerBuildSaga assembles the build-from-tar saga definition with all

--- a/servers/build/build_saga_buildkit.go
+++ b/servers/build/build_saga_buildkit.go
@@ -11,6 +11,7 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/saga"
@@ -64,6 +65,12 @@ func buildImage(ctx context.Context, in buildImageIn) (buildImageOut, error) {
 	deps := saga.Get[*buildSagaDeps](ctx)
 	b := deps.builder
 	status := deps.statuses.SenderFor(in.StreamID)
+
+	if in.BuildStack.Stack == "image" {
+		image := containerdx.NormalizeImageReference(in.BuildStack.Input)
+		status.SendImage(image)
+		return buildImageOut{FinalImageURL: image}, nil
+	}
 
 	if b.BuildKit == nil {
 		status.SendError("BuildKit not configured - ensure server is running with BuildKit enabled")

--- a/servers/build/build_saga_deploy_test.go
+++ b/servers/build/build_saga_deploy_test.go
@@ -120,6 +120,50 @@ func TestBuildSaga_Tracked_CreatesAndActivatesDeployment(t *testing.T) {
 	assert.Nil(t, blocking, "an activated deployment must not keep the lock")
 }
 
+// A direct-image deploy has no build or push phase to report, but it must still
+// carry the server-owned deployment record through activation and release its
+// lock. This also exercises the production image branch with BuildKit absent.
+func TestBuildSaga_TrackedImage_ActivatesWithoutBuildPhases(t *testing.T) {
+	ctx := context.Background()
+
+	h := newDeploySagaHarness(t)
+	h.streams.Register("stream-image", makeTar(t, imageOnlyTarball(t)))
+
+	sender := &recordingSender{}
+	h.statuses.Register("stream-image", sender)
+	t.Cleanup(func() { h.statuses.Unregister("stream-image") })
+
+	err := h.executor.Start(sagaBuildFromTar).
+		Input("app_name", "demo").
+		Input("stream_id", "stream-image").
+		Input("deploy_cluster_id", "prod").
+		WithID("test-tracked-image").
+		Execute(ctx)
+	require.NoError(t, err)
+
+	records, err := h.builder.deploy.Store().List(ctx, deploylifecycle.Query{AppName: "demo"})
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	rec := records[0]
+	assert.Equal(t, deploylifecycle.StatusActive, rec.Status())
+	assert.Equal(t, string(deploylifecycle.PhaseActivating), rec.Deployment.Phase)
+	assert.NotEmpty(t, rec.AppVersion(), "the direct-image version must be recorded")
+
+	var phases []string
+	for _, deployment := range sender.Deployments {
+		phases = append(phases, deployment.Phase)
+	}
+	assert.Equal(t, []string{
+		string(deploylifecycle.PhasePreparing),
+		string(deploylifecycle.PhaseActivating),
+	}, phases, "a direct-image deploy must not report build or push work")
+
+	blocking, err := h.builder.deploy.Locks().Blocking(ctx, "demo")
+	require.NoError(t, err)
+	assert.Nil(t, blocking, "an activated direct-image deployment must not keep the lock")
+}
+
 // The deployment ID must reach the client over the status stream so it can
 // display and cancel a deployment it did not create.
 func TestBuildSaga_Tracked_EmitsDeploymentProgress(t *testing.T) {

--- a/servers/build/build_saga_test.go
+++ b/servers/build/build_saga_test.go
@@ -10,10 +10,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
@@ -107,6 +111,14 @@ func newSagaTestHarness(t *testing.T) *sagaTestHarness {
 // real action would have walked finds something. Real buildImage is
 // exercised by blackbox tests under iso.
 func stubBuildImage(ctx context.Context, in buildImageIn) (buildImageOut, error) {
+	// Exercise the production direct-image action through the saga context. It
+	// needs no BuildKit or Artifact fixture, which is precisely the contract
+	// image-only deploys rely on. Source builds continue through the deterministic
+	// stub below.
+	if in.BuildStack.Stack == "image" {
+		return buildImage(ctx, in)
+	}
+
 	deps := saga.Get[*buildSagaDeps](ctx)
 
 	digest := "sha256:" + in.VersionName + "-digest"
@@ -150,6 +162,18 @@ func dockerfileTarball(t *testing.T) map[string]string {
 	}
 }
 
+func imageOnlyTarball(t *testing.T) map[string]string {
+	t.Helper()
+	return map[string]string{
+		".miren/app.toml": `name = "demo"
+
+[services.web]
+image = "nginx:alpine"
+port = 80
+`,
+	}
+}
+
 func TestBuildSaga_HappyPath_RunsFullPipeline(t *testing.T) {
 	ctx := context.Background()
 
@@ -182,6 +206,164 @@ func TestBuildSaga_HappyPath_RunsFullPipeline(t *testing.T) {
 	}
 }
 
+func TestBuildSaga_ImageOnly_SkipsBuildKitAndCreatesVersion(t *testing.T) {
+	ctx := context.Background()
+
+	h := newSagaTestHarness(t)
+	h.streams.Register("stream-image", makeTar(t, imageOnlyTarball(t)))
+
+	rec := &recordingSender{}
+	h.statuses.Register("stream-image", rec)
+	t.Cleanup(func() { h.statuses.Unregister("stream-image") })
+
+	err := h.executor.Start(sagaBuildFromTar).
+		Input("app_name", "demo").
+		Input("stream_id", "stream-image").
+		WithID("test-image-only").
+		Execute(ctx)
+	require.NoError(t, err)
+
+	var application core_v1alpha.App
+	require.NoError(t, h.builder.ec.Get(ctx, "demo", &application))
+	require.NotEmpty(t, application.ActiveVersion)
+
+	var version core_v1alpha.AppVersion
+	require.NoError(t, h.builder.ec.GetById(ctx, application.ActiveVersion, &version))
+	assert.Equal(t, "docker.io/library/nginx:alpine", version.ImageUrl)
+	assert.Empty(t, version.Artifact, "direct-image versions do not invent an Artifact")
+
+	var configVersion core_v1alpha.ConfigVersion
+	require.NoError(t, h.builder.ec.GetById(ctx, version.ConfigVersion, &configVersion))
+	require.Len(t, configVersion.Spec.Services, 1)
+	assert.Equal(t, "web", configVersion.Spec.Services[0].Name)
+	assert.Equal(t, "nginx:alpine", configVersion.Spec.Services[0].Image)
+	assert.Empty(t, configVersion.Spec.Services[0].Command)
+	assert.Contains(t, rec.Images, "docker.io/library/nginx:alpine")
+}
+
+func TestImageSourceSelection(t *testing.T) {
+	t.Run("web image captures explicit intent", func(t *testing.T) {
+		ac := &appconfig.AppConfig{Services: map[string]*appconfig.ServiceConfig{
+			"web": {Image: "example/web:v1"},
+			"db":  {Image: "example/db:v1"},
+		}}
+		assert.Equal(t, "example/web:v1", webImageSource(ac))
+		assert.Empty(t, webImageSource(nil))
+	})
+
+	tests := []struct {
+		name    string
+		config  *appconfig.AppConfig
+		want    string
+		wantErr string
+	}{
+		{name: "no config"},
+		{
+			name: "one non-web image is unambiguous",
+			config: &appconfig.AppConfig{Services: map[string]*appconfig.ServiceConfig{
+				"worker": {Image: "example/worker:v1"},
+			}},
+			want: "example/worker:v1",
+		},
+		{
+			name: "several non-web images are ambiguous",
+			config: &appconfig.AppConfig{Services: map[string]*appconfig.ServiceConfig{
+				"worker": {Image: "example/worker:v1"},
+				"cron":   {Image: "example/cron:v1"},
+			}},
+			wantErr: "set services.web.image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fallbackImageSource(tt.config)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDetectBuildStack_ImagePrecedence(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	b := &Builder{Log: log}
+	webImage := &appconfig.AppConfig{Services: map[string]*appconfig.ServiceConfig{
+		"web": {Image: "nginx:alpine"},
+	}}
+	sidecarImage := &appconfig.AppConfig{Services: map[string]*appconfig.ServiceConfig{
+		"db": {Image: "postgres:alpine"},
+	}}
+	writeNodeSource := func(t *testing.T, dir string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "index.js"), []byte("console.log('hello')\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"start":"node index.js"}}`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(`{"lockfileVersion":3}`), 0o644))
+	}
+
+	t.Run("web image when source is not buildable", func(t *testing.T) {
+		stack, err := b.detectBuildStack(t.TempDir(), webImage, "demo", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "image", stack.Stack)
+		assert.Equal(t, "nginx:alpine", stack.Input)
+	})
+
+	t.Run("web image beats detected source", func(t *testing.T) {
+		dir := t.TempDir()
+		writeNodeSource(t, dir)
+		stack, err := b.detectBuildStack(dir, webImage, "demo", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "image", stack.Stack)
+		assert.Equal(t, "nginx:alpine", stack.Input)
+	})
+
+	t.Run("sidecar image does not suppress detected source", func(t *testing.T) {
+		dir := t.TempDir()
+		writeNodeSource(t, dir)
+		stack, err := b.detectBuildStack(dir, sidecarImage, "demo", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "auto", stack.Stack)
+		assert.Empty(t, stack.Input)
+	})
+
+	t.Run("one non-web image is a fallback", func(t *testing.T) {
+		stack, err := b.detectBuildStack(t.TempDir(), sidecarImage, "demo", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "image", stack.Stack)
+		assert.Equal(t, "postgres:alpine", stack.Input)
+	})
+
+	t.Run("dockerfile retains precedence", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile.miren"), []byte("FROM alpine\n"), 0o644))
+		stack, err := b.detectBuildStack(dir, webImage, "demo", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "dockerfile", stack.Stack)
+		assert.Equal(t, "Dockerfile.miren", stack.Input)
+	})
+
+	t.Run("configured dockerfile beats discovered default", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile.miren"), []byte("FROM alpine\n"), 0o644))
+		config := &appconfig.AppConfig{
+			Build:    &appconfig.BuildConfig{Dockerfile: "Dockerfile.production"},
+			Services: webImage.Services,
+		}
+		stack, err := b.detectBuildStack(dir, config, "demo", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "dockerfile", stack.Stack)
+		assert.Equal(t, "Dockerfile.production", stack.Input)
+	})
+
+	t.Run("no source and no image keeps the existing error", func(t *testing.T) {
+		_, err := b.detectBuildStack(t.TempDir(), &appconfig.AppConfig{}, "demo", nil)
+		require.ErrorContains(t, err, "no supported stack detected for app demo")
+	})
+}
+
 func TestBuildSaga_ReceiveTar_EmitsStatusUpdates(t *testing.T) {
 	ctx := context.Background()
 
@@ -205,7 +387,7 @@ func TestBuildSaga_ReceiveTar_EmitsStatusUpdates(t *testing.T) {
 	// the staging work. We don't pin exact equality on the entire slice
 	// (later actions might emit too as the saga grows) — just verify
 	// these two appeared in order.
-	wantInOrder := []string{"Reading application data", "Launching builder"}
+	wantInOrder := []string{"Reading application data", "Preparing deployment"}
 	if !containsInOrder(rec.Messages, wantInOrder) {
 		t.Errorf("missing expected messages in order: got %v, want subsequence %v", rec.Messages, wantInOrder)
 	}

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -300,7 +300,9 @@ func (b *Buildkit) Transform(ctx context.Context, dfs fsutil.FS, tos ...Transfor
 type BuildStack struct {
 	Stack   string
 	CodeDir string
-	Input   string
+	// Input is the Dockerfile path for dockerfile builds and the upstream image
+	// reference for direct-image deploys.
+	Input string
 
 	Version     string
 	OnBuild     []string

--- a/servers/build/status_registry.go
+++ b/servers/build/status_registry.go
@@ -22,12 +22,16 @@ import (
 // progress when the original CLI invocation is long gone.
 type StatusSender interface {
 	// SendMessage emits a free-form progress message ("Reading
-	// application data", "Launching builder", etc.).
+	// application data", "Preparing deployment", etc.).
 	SendMessage(msg string)
 
 	// SendPhase translates a buildkit phase name into a user-facing
 	// progress message, matching the mapping the pre-saga path used.
 	SendPhase(phase string)
+
+	// SendImage announces that the deploy will use this normalized upstream
+	// image directly, without a Miren build or registry push.
+	SendImage(image string)
 
 	// SendBuildkit emits the raw buildkit JSON status payload so the
 	// CLI can render live vertex/log output.
@@ -54,6 +58,7 @@ type noopStatusSender struct{}
 
 func (noopStatusSender) SendMessage(string)                                 {}
 func (noopStatusSender) SendPhase(string)                                   {}
+func (noopStatusSender) SendImage(string)                                   {}
 func (noopStatusSender) SendBuildkit([]byte)                                {}
 func (noopStatusSender) SendError(string, ...any)                           {}
 func (noopStatusSender) SendLog(string, string, ...*build_v1alpha.LogField) {}
@@ -108,6 +113,12 @@ func (r *rpcStatusSender) SendPhase(phase string) {
 		msg = phase
 	}
 	r.SendMessage(msg)
+}
+
+func (r *rpcStatusSender) SendImage(image string) {
+	so := new(build_v1alpha.Status)
+	so.Update().SetImage(image)
+	r.send(so)
 }
 
 func (r *rpcStatusSender) SendBuildkit(payload []byte) {

--- a/servers/build/status_registry_test.go
+++ b/servers/build/status_registry_test.go
@@ -14,6 +14,7 @@ type recordingSender struct {
 	mu          sync.Mutex
 	Messages    []string
 	Phases      []string
+	Images      []string
 	Buildkit    [][]byte
 	Errors      []string
 	Logs        []recordedLog
@@ -41,6 +42,12 @@ func (r *recordingSender) SendPhase(phase string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.Phases = append(r.Phases, phase)
+}
+
+func (r *recordingSender) SendImage(image string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Images = append(r.Images, image)
 }
 
 func (r *recordingSender) SendBuildkit(payload []byte) {
@@ -75,6 +82,7 @@ func TestStatusRegistry_UnregisteredIDReturnsNoop(t *testing.T) {
 	// Calling every method should not panic.
 	sender.SendMessage("hi")
 	sender.SendPhase("solving")
+	sender.SendImage("example/app:v1")
 	sender.SendBuildkit([]byte("x"))
 	sender.SendError("oops")
 	sender.SendLog("info", "text")
@@ -88,6 +96,7 @@ func TestStatusRegistry_RegisteredSenderReceives(t *testing.T) {
 	sender := reg.SenderFor("s1")
 	sender.SendMessage("hello")
 	sender.SendPhase("solving")
+	sender.SendImage("example/app:v1")
 	sender.SendBuildkit([]byte("payload"))
 	sender.SendError("bad %s", "thing")
 
@@ -96,6 +105,9 @@ func TestStatusRegistry_RegisteredSenderReceives(t *testing.T) {
 	}
 	if got, want := rec.Phases, []string{"solving"}; !equalStringSlice(got, want) {
 		t.Errorf("Phases = %v, want %v", got, want)
+	}
+	if got, want := rec.Images, []string{"example/app:v1"}; !equalStringSlice(got, want) {
+		t.Errorf("Images = %v, want %v", got, want)
 	}
 	if len(rec.Buildkit) != 1 || string(rec.Buildkit[0]) != "payload" {
 		t.Errorf("Buildkit = %v, want one entry with payload bytes", rec.Buildkit)

--- a/testdata/image-only/.miren/app.toml
+++ b/testdata/image-only/.miren/app.toml
@@ -1,0 +1,7 @@
+name = "image-only"
+
+[services.web]
+image = "nginx:alpine"
+# MIR-1445 owns inheriting EXPOSE. Keep this fixture focused on using the image
+# as the source without a Dockerfile or stack build.
+port = 80


### PR DESCRIPTION
An app can already configure `services.web.image`, but deploying one still tried to detect source and launch BuildKit unless a Dockerfile was present. That made a complete runnable image insufficient on its own.

This treats an explicit web image as build-source intent and runs it directly. Dockerfiles still win, while a lone non-web service image remains a fallback after source detection so a database sidecar cannot hijack a normal source build. Direct-image versions reference the normalized upstream image and have no synthetic Artifact.

Analyze and deploy now report `image` and `Use image` rather than pretending a zero-step build was cached. The deployment, service, and `app.toml` docs spell out the same precedence. Both saga and legacy paths are covered, with a config-only nginx blackbox deploy exercising the full path.

Closes MIR-1452
Closes MIR-1684