### PR TITLE
Remove dead post_import app.toml field

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -280,7 +280,6 @@ func (tc *TaskConfig) ResolvedMaxConcurrent() int {
 
 type AppConfig struct {
 	Name         string                    `toml:"name"`
-	PostImport   string                    `toml:"post_import,omitempty"`
 	EnvVars      []AppEnvVar               `toml:"env,omitempty"`
 	Concurrency  *int                      `toml:"concurrency,omitempty"`
 	Services     map[string]*ServiceConfig `toml:"services,omitempty"`

--- a/appconfig/configerror.go
+++ b/appconfig/configerror.go
@@ -347,7 +347,7 @@ func validFieldsForPath(path string) ([]string, bool) {
 
 // validFields maps section paths to their valid field names.
 var validFields = map[string][]string{
-	"":                       {"name", "post_import", "env", "concurrency", "services", "tasks", "web", "build", "include", "addons", "aliases", "workload_role"},
+	"":                       {"name", "env", "concurrency", "services", "tasks", "web", "build", "include", "addons", "aliases", "workload_role"},
 	"services.*":             {"command", "port", "port_name", "port_type", "ports", "image", "env", "concurrency", "disks", "port_timeout"},
 	"services.*.concurrency": {"mode", "requests_per_instance", "scale_down_delay", "num_instances", "shutdown_timeout"},
 	"services.*.disks":       {"name", "provider", "mount_path", "read_only", "size_gb", "filesystem", "lease_timeout"},

--- a/appconfig/schema_test.go
+++ b/appconfig/schema_test.go
@@ -35,9 +35,7 @@ func TestPublishedSchemaFieldsMatchConfig(t *testing.T) {
 		got    map[string]any
 		skip   map[string]bool
 	}{
-		// post_import is intentionally absent: it is legacy dead config that is
-		// parsed but never used. Keep the public schema from advertising a no-op.
-		{name: "root", typeOf: reflect.TypeFor[AppConfig](), got: schema.Properties, skip: map[string]bool{"post_import": true}},
+		{name: "root", typeOf: reflect.TypeFor[AppConfig](), got: schema.Properties},
 		{name: "env", typeOf: reflect.TypeFor[AppEnvVar](), got: schema.Defs["env"].Properties},
 		{name: "build", typeOf: reflect.TypeFor[BuildConfig](), got: schema.Defs["build"].Properties},
 		{name: "service", typeOf: reflect.TypeFor[ServiceConfig](), got: schema.Defs["service"].Properties},

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -11,6 +11,9 @@ All notable changes to Miren Runtime will be documented in this file.
 ## Unreleased
 *main*
 
+**Improvements**
+- **`post_import` is gone from app.toml** - The key was parsed and validated but never read by anything, so a deploy that set it reported success while the command silently never ran. It came out of the docs in [#884](https://github.com/mirendev/runtime/pull/884); now it's out of the config itself. If your `app.toml` still has a `post_import` line, delete it — unknown keys are a parse error, so it will now fail validation instead of being quietly ignored. Move the work to a [deploy task](/tasks).
+
 ---
 
 ## v0.14.0

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -11,9 +11,6 @@ All notable changes to Miren Runtime will be documented in this file.
 ## Unreleased
 *main*
 
-**Improvements**
-- **`post_import` is gone from app.toml** - The key was parsed and validated but never read by anything, so a deploy that set it reported success while the command silently never ran. It came out of the docs in [#884](https://github.com/mirendev/runtime/pull/884); now it's out of the config itself. If your `app.toml` still has a `post_import` line, delete it — unknown keys are a parse error, so it will now fail validation instead of being quietly ignored. Move the work to a [deploy task](/tasks).
-
 ---
 
 ## v0.14.0


### PR DESCRIPTION
`AppConfig.PostImport` was still parsed and validated even though nothing in the runtime ever read it. #884 took it out of the docs so we stopped advertising a step that silently did nothing; this takes it out of the config.

- drop the field from `AppConfig`
- drop `post_import` from the root `validFields` list that drives "did you mean?" suggestions
- drop the explicit schema-test exclusion added in MIR-1047, since there is no longer a field to hide from the published JSON Schema

One thing worth a second pair of eyes: unknown keys are a hard parse error, not a warning. So an `app.toml` that still carries a `post_import` line goes from "quietly ignored" to "fails validation". That seems right — the value never did anything, and failing loudly is better than the current silence — but it is a visible change, so there is a changelog entry saying to delete the line and use a deploy task instead.

`go build ./...` and `go test ./appconfig/...` pass.

Closes MIR-1624