### PR TITLE
Make `miren app runs` easier to scan

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -2121,6 +2121,7 @@ type runInfoData struct {
 	EndedAt   *int64  `cbor:"9,keyasint,omitempty" json:"ended_at,omitempty"`
 	Sandbox   *string `cbor:"10,keyasint,omitempty" json:"sandbox,omitempty"`
 	Version   *string `cbor:"11,keyasint,omitempty" json:"version,omitempty"`
+	ShortId   *string `cbor:"12,keyasint,omitempty" json:"short_id,omitempty"`
 }
 
 type RunInfo struct {
@@ -2290,6 +2291,21 @@ func (v *RunInfo) Version() string {
 
 func (v *RunInfo) SetVersion(version string) {
 	v.data.Version = &version
+}
+
+func (v *RunInfo) HasShortId() bool {
+	return v.data.ShortId != nil
+}
+
+func (v *RunInfo) ShortId() string {
+	if v.data.ShortId == nil {
+		return ""
+	}
+	return *v.data.ShortId
+}
+
+func (v *RunInfo) SetShortId(short_id string) {
+	v.data.ShortId = &short_id
 }
 
 func (v *RunInfo) MarshalCBOR() ([]byte, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -470,6 +470,10 @@ types:
       - name: version
         type: string
         index: 11
+      - name: short_id
+        type: string
+        index: 12
+        doc: Short, human-typeable form of the run id; empty for runs recorded before short-ids
 
 interfaces:
   - name: Crud

--- a/cli/commands/app_runs.go
+++ b/cli/commands/app_runs.go
@@ -106,7 +106,7 @@ func AppRuns(ctx *Context, opts struct {
 		}
 
 		rows = append(rows, ui.Row{
-			ui.CleanEntityID(r.Id()),
+			ui.DisplayShortID(r.ShortId(), r.Id()),
 			r.Task(),
 			r.Trigger(),
 			r.Status(),

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -11,9 +11,6 @@ All notable changes to Miren Runtime will be documented in this file.
 ## Unreleased
 *main*
 
-**Improvements**
-- **`miren app runs` is easier to scan** - The table now shows each run's short id instead of its full entity id, and every run is ordered newest-started first. Failures used to be pulled to the top, which meant the run you had just triggered could sit halfway down the list depending on how older ones ended. `--format json` still carries full ids.
-
 ---
 
 ## v0.14.0

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -11,6 +11,9 @@ All notable changes to Miren Runtime will be documented in this file.
 ## Unreleased
 *main*
 
+**Improvements**
+- **`miren app runs` is easier to scan** - The table now shows each run's short id instead of its full entity id, and every run is ordered newest-started first. Failures used to be pulled to the top, which meant the run you had just triggered could sit halfway down the list depending on how older ones ended. `--format json` still carries full ids.
+
 ---
 
 ## v0.14.0

--- a/servers/app/runs.go
+++ b/servers/app/runs.go
@@ -212,21 +212,18 @@ func (r *AppInfo) ListRuns(ctx context.Context, state *app_v1alpha.RunsListRuns)
 		if args.Task() != "" && run.Task != args.Task() {
 			continue
 		}
-		runs = append(runs, runInfo(&run))
+		runs = append(runs, runInfo(&run, results.Entity().ShortId()))
 	}
 
-	// Failures first, then newest. The reason someone opens this list is almost
-	// always a failure, and a list where they are buried under successful
-	// console sessions is a list nobody reads.
+	// Newest first, with no special place for failures. Grouping failures ahead
+	// of everything else made the most recent run's position depend on the
+	// outcome of older ones, so the row someone had just triggered could sit
+	// halfway down the table. One consistent order is easier to scan, and the
+	// status column already says which runs failed.
+	//
+	// cmp.Compare rather than subtraction: these are Unix milliseconds, and
+	// their difference does not fit an int on a 32-bit build.
 	slices.SortStableFunc(runs, func(a, b *app_v1alpha.RunInfo) int {
-		if af, bf := isFailure(a.Status()), isFailure(b.Status()); af != bf {
-			if af {
-				return -1
-			}
-			return 1
-		}
-		// cmp.Compare rather than subtraction: these are Unix milliseconds, and
-		// their difference does not fit an int on a 32-bit build.
 		return cmp.Compare(b.StartedAt(), a.StartedAt())
 	})
 
@@ -247,7 +244,7 @@ func (r *AppInfo) GetRun(ctx context.Context, state *app_v1alpha.RunsGetRun) err
 		return err
 	}
 
-	state.Results().SetRun(runInfo(run))
+	state.Results().SetRun(runInfo(run, r.runShortId(ctx, run.ID)))
 	return nil
 }
 
@@ -309,6 +306,17 @@ func (r *AppInfo) authorizeRun(ctx context.Context, run *run_v1alpha.Run) error 
 		return rpc.AppAccessError(ctx, md.Name)
 	}
 	return nil
+}
+
+// runShortId looks up one run's short-id, for the single-run paths that do not
+// already hold the entity. Returns empty when the run has none.
+func (r *AppInfo) runShortId(ctx context.Context, id entity.Id) string {
+	var run run_v1alpha.Run
+	ent, err := r.EC.GetByIdWithEntity(ctx, id, &run)
+	if err != nil {
+		return ""
+	}
+	return shortIDFromEntity(ent)
 }
 
 func (r *AppInfo) lookupRun(ctx context.Context, id string) (*run_v1alpha.Run, entity.Id, error) {
@@ -407,9 +415,14 @@ func shellQuote(args []string) string {
 	return strings.Join(quoted, " ")
 }
 
-func runInfo(run *run_v1alpha.Run) *app_v1alpha.RunInfo {
+// runInfo renders a run for the wire. shortId is the run entity's short-id,
+// empty for a run recorded before short-ids existed; it is passed in rather than
+// looked up because the list path already has the entity in hand and a
+// per-row lookup would be a query per run.
+func runInfo(run *run_v1alpha.Run, shortId string) *app_v1alpha.RunInfo {
 	var info app_v1alpha.RunInfo
 	info.SetId(run.ID.String())
+	info.SetShortId(shortId)
 	info.SetTask(run.Task)
 	info.SetTrigger(strings.TrimPrefix(string(run.Trigger), "trigger."))
 	info.SetStatus(strings.TrimPrefix(string(run.Status), "status."))
@@ -471,14 +484,6 @@ func reportsExitCode(s run_v1alpha.RunStatus) bool {
 	case run_v1alpha.PENDING, run_v1alpha.RUNNING, run_v1alpha.TIMED_OUT,
 		run_v1alpha.CANCELED, run_v1alpha.SKIPPED:
 		return false
-	}
-	return false
-}
-
-func isFailure(status string) bool {
-	switch status {
-	case "failed", "timed_out", "canceled":
-		return true
 	}
 	return false
 }

--- a/servers/app/runs.go
+++ b/servers/app/runs.go
@@ -236,7 +236,7 @@ func (r *AppInfo) ListRuns(ctx context.Context, state *app_v1alpha.RunsListRuns)
 }
 
 func (r *AppInfo) GetRun(ctx context.Context, state *app_v1alpha.RunsGetRun) error {
-	run, _, err := r.lookupRun(ctx, state.Args().Id())
+	run, shortId, err := r.lookupRun(ctx, state.Args().Id())
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func (r *AppInfo) GetRun(ctx context.Context, state *app_v1alpha.RunsGetRun) err
 		return err
 	}
 
-	state.Results().SetRun(runInfo(run, r.runShortId(ctx, run.ID)))
+	state.Results().SetRun(runInfo(run, shortId))
 	return nil
 }
 
@@ -308,33 +308,27 @@ func (r *AppInfo) authorizeRun(ctx context.Context, run *run_v1alpha.Run) error 
 	return nil
 }
 
-// runShortId looks up one run's short-id, for the single-run paths that do not
-// already hold the entity. Returns empty when the run has none.
-func (r *AppInfo) runShortId(ctx context.Context, id entity.Id) string {
-	var run run_v1alpha.Run
-	ent, err := r.EC.GetByIdWithEntity(ctx, id, &run)
-	if err != nil {
-		return ""
-	}
-	return shortIDFromEntity(ent)
-}
-
-func (r *AppInfo) lookupRun(ctx context.Context, id string) (*run_v1alpha.Run, entity.Id, error) {
+// lookupRun resolves a run by full or bare id, and returns its short-id along
+// with it. The short-id rides on the same read rather than being recovered by a
+// second one: GetRun is polled every 250ms while an attach waits for exit
+// status, and re-reading the run to recover metadata the first read already had
+// would double that traffic. Empty for a run recorded before short-ids.
+func (r *AppInfo) lookupRun(ctx context.Context, id string) (*run_v1alpha.Run, string, error) {
 	if id == "" {
 		return nil, "", fmt.Errorf("run id is required")
 	}
 
 	var run run_v1alpha.Run
-	err := r.EC.GetById(ctx, entity.Id(id), &run)
+	ent, err := r.EC.GetByIdWithEntity(ctx, entity.Id(id), &run)
 	if err != nil && errors.Is(err, cond.ErrNotFound{}) && !strings.Contains(id, "/") {
 		// Accept a bare name as well as a full id.
-		err = r.EC.GetById(ctx, entity.Id("run/"+id), &run)
+		ent, err = r.EC.GetByIdWithEntity(ctx, entity.Id("run/"+id), &run)
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("run %s not found: %w", id, err)
 	}
 
-	return &run, run.ID, nil
+	return &run, shortIDFromEntity(ent), nil
 }
 
 // appName resolves the app's metadata name, which is what a run's entity name

--- a/servers/app/runs_test.go
+++ b/servers/app/runs_test.go
@@ -28,20 +28,20 @@ func TestRunInfoOnlyReportsCommandExitCodes(t *testing.T) {
 	}
 
 	t.Run("succeeded reports it", func(t *testing.T) {
-		info := runInfo(base(run_v1alpha.SUCCEEDED))
+		info := runInfo(base(run_v1alpha.SUCCEEDED), "")
 		assert.True(t, info.HasExitCode())
 		assert.Equal(t, int32(2), info.ExitCode())
 	})
 
 	t.Run("failed reports it", func(t *testing.T) {
-		assert.True(t, runInfo(base(run_v1alpha.FAILED)).HasExitCode())
+		assert.True(t, runInfo(base(run_v1alpha.FAILED), "").HasExitCode())
 	})
 
 	for _, status := range []run_v1alpha.RunStatus{
 		run_v1alpha.CANCELED, run_v1alpha.TIMED_OUT, run_v1alpha.SKIPPED,
 	} {
 		t.Run(string(status)+" does not", func(t *testing.T) {
-			assert.False(t, runInfo(base(status)).HasExitCode(),
+			assert.False(t, runInfo(base(status), "").HasExitCode(),
 				"the status carries the meaning; the killed process's code is teardown noise")
 		})
 	}
@@ -53,7 +53,7 @@ func TestRunInfoWithNoObservedExit(t *testing.T) {
 	info := runInfo(&run_v1alpha.Run{
 		ID:     "run/demo-x-1",
 		Status: run_v1alpha.FAILED,
-	})
+	}, "")
 	assert.False(t, info.HasExitCode())
 }
 
@@ -64,7 +64,7 @@ func TestRunInfoReportsAZeroExitCode(t *testing.T) {
 		ID:     "run/demo-x-1",
 		Status: run_v1alpha.SUCCEEDED,
 		Result: run_v1alpha.Result{Code: 0, At: time.Now()},
-	})
+	}, "")
 	assert.True(t, info.HasExitCode())
 	assert.Equal(t, int32(0), info.ExitCode())
 }
@@ -78,7 +78,7 @@ func TestRunInfoSaturatesRatherThanWrapping(t *testing.T) {
 		Status:  run_v1alpha.FAILED,
 		Attempt: math.MaxInt32 + 1,
 		Result:  run_v1alpha.Result{Code: math.MaxInt32 + 1, At: time.Now()},
-	})
+	}, "")
 
 	assert.Equal(t, int32(math.MaxInt32), info.Attempt(), "must not wrap to a negative attempt")
 	assert.Equal(t, int32(math.MaxInt32), info.ExitCode(), "must not wrap to a small exit code")
@@ -88,7 +88,7 @@ func TestRunInfoSaturatesRatherThanWrapping(t *testing.T) {
 		Status:  run_v1alpha.FAILED,
 		Attempt: math.MinInt32 - 1,
 		Result:  run_v1alpha.Result{Code: math.MinInt32 - 1, At: time.Now()},
-	})
+	}, "")
 	assert.Equal(t, int32(math.MinInt32), info.ExitCode())
 }
 


### PR DESCRIPTION
Two small changes to the run history table.

**Short ids in the table.** `RunInfo` now carries the run entity's `short_id`, and the CLI renders `ui.DisplayShortID(short, full)` the way `app history` and `app status` already do. `--format json` is untouched and still emits full ids, since that is what scripts pass back to `app runs cancel`.

The list path reads the short id straight off the entity it already has (`results.Entity().ShortId()`), so this costs no extra queries per row. `getRun` has no entity in hand, so it does one lookup — worth it to keep the two paths from disagreeing about what a run's id looks like.

**One consistent order.** Runs are now sorted by `started_at` descending, full stop. The old sort pulled failures to the front, which meant the position of the run you just triggered depended on how older, unrelated runs ended — you could trigger something and find it halfway down the table. The status column already says which runs failed.

A run recorded before short-ids existed has none; those fall back to the full id rather than rendering blank.

`go build ./...` and `go test ./servers/app/... ./cli/commands/...` pass. The two `...Etcd` failures in `servers/app` are the pre-existing ones that need `make dev` for etcd, unrelated to this change.

Closes MIR-1656