### PR TITLE
Canonicalize deployment records around immutable attempts

### DIFF
--- a/api/app/client.go
+++ b/api/app/client.go
@@ -111,23 +111,6 @@ func (c *Client) SetHost(ctx context.Context, appName, host string) error {
 	return nil
 }
 
-// SetActiveVersion updates the active version of an app
-func (c *Client) SetActiveVersion(ctx context.Context, appName, versionID string) error {
-	app, err := c.GetByName(ctx, appName)
-	if err != nil {
-		return fmt.Errorf("failed to get app %s: %w", appName, err)
-	}
-
-	app.ActiveVersion = entity.Id(versionID)
-
-	err = c.entityClient.Update(ctx, app)
-	if err != nil {
-		return fmt.Errorf("failed to update app %s: %w", appName, err)
-	}
-
-	return nil
-}
-
 // List returns all apps
 func (c *Client) List(ctx context.Context) ([]*core_v1alpha.App, error) {
 	// List would need to be implemented using the List method on entityClient

--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -41,6 +41,12 @@ type DeleteResult struct {
 	DeletedSources []string
 }
 
+// VersionActivator commits a newly minted AppVersion. Deployment-aware RPC
+// paths supply an activator that records the version on an attempt and swings
+// both app pointers together. The legacy wrappers below retain their original
+// single-pointer behavior for internal callers during the downgrade window.
+type VersionActivator func(context.Context, *core_v1alpha.App, int64, entity.Id) error
+
 // envMutateMaxAttempts is a live-lock backstop for the optimistic-concurrency
 // retry loop shared by SetEnvVars and DeleteEnvVars — it is not an expected
 // limit. Each conflict just means another writer swung the app's active version
@@ -72,6 +78,11 @@ var testHookAfterResolve func()
 // rather than composing onto the winner.
 func SetEnvVars(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
 	baseVersion *core_v1alpha.AppVersion, vars []EnvVarInput, service string) (*MutateResult, error) {
+	return SetEnvVarsWithActivator(ctx, ec, resolver, appName, baseVersion, vars, service, nil)
+}
+
+func SetEnvVarsWithActivator(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
+	baseVersion *core_v1alpha.AppVersion, vars []EnvVarInput, service string, activate VersionActivator) (*MutateResult, error) {
 
 	for _, v := range vars {
 		if strings.HasPrefix(v.Key, "MIREN_") {
@@ -93,7 +104,7 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, resolver secret.Re
 			testHookAfterResolve()
 		}
 
-		result, err := createNewVersion(ctx, ec, resolver, appName, appVer, spec, appRec, appRev)
+		result, err := createNewVersion(ctx, ec, resolver, appName, appVer, spec, appRec, appRev, activate)
 		if err == nil {
 			return result, nil
 		}
@@ -117,6 +128,11 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, resolver secret.Re
 // only when baseVersion is nil; a pinned baseVersion is re-applied as-is.
 func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
 	baseVersion *core_v1alpha.AppVersion, keys []string, service string) (*DeleteResult, error) {
+	return DeleteEnvVarsWithActivator(ctx, ec, resolver, appName, baseVersion, keys, service, nil)
+}
+
+func DeleteEnvVarsWithActivator(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
+	baseVersion *core_v1alpha.AppVersion, keys []string, service string, activate VersionActivator) (*DeleteResult, error) {
 
 	for range envMutateMaxAttempts {
 		appVer, spec, appRec, appRev, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
@@ -174,7 +190,7 @@ func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, resolver secret
 			}
 		}
 
-		result, err := createNewVersion(ctx, ec, resolver, appName, appVer, spec, appRec, appRev)
+		result, err := createNewVersion(ctx, ec, resolver, appName, appVer, spec, appRec, appRev, activate)
 		if err == nil {
 			return &DeleteResult{
 				MutateResult:   *result,
@@ -428,7 +444,8 @@ func mergeIntoSpec(spec *core_v1alpha.ConfigSpec, vars []EnvVarInput, service st
 // the winner's version instead of silently clobbering it. Returns cond.ErrConflict
 // on a lost race.
 func createNewVersion(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
-	appVer *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, appRec *core_v1alpha.App, appRev int64) (*MutateResult, error) {
+	appVer *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, appRec *core_v1alpha.App, appRev int64,
+	activators ...VersionActivator) (*MutateResult, error) {
 
 	// Freeze every backend-sourced variable to the version it resolves to right
 	// now, so this ConfigVersion records exactly which secret it was built with.
@@ -456,9 +473,16 @@ func createNewVersion(ctx context.Context, ec *entityserver.Client, resolver sec
 	}
 	appVer.ID = avid
 
-	if err := ec.Patch(ctx, appRec.ID, appRev,
-		entity.Ref(core_v1alpha.AppActiveVersionId, avid),
-	); err != nil {
+	var activate VersionActivator
+	if len(activators) > 0 {
+		activate = activators[0]
+	}
+	if activate == nil {
+		activate = func(ctx context.Context, app *core_v1alpha.App, revision int64, version entity.Id) error {
+			return ec.Patch(ctx, app.ID, revision, entity.Ref(core_v1alpha.AppActiveVersionId, version))
+		}
+	}
+	if err := activate(ctx, appRec, appRev, avid); err != nil {
 		if errors.Is(err, cond.ErrConflict{}) {
 			// This attempt lost the race, so the version pair we just minted was
 			// never activated. Best-effort delete it, AppVersion first: only drop

--- a/api/core/core_v1alpha/schema.gen.go
+++ b/api/core/core_v1alpha/schema.gen.go
@@ -1121,24 +1121,34 @@ func (o *ConfigSpecVariables) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 const (
-	AppActiveVersionId = entity.Id("dev.miren.core/app.active_version")
-	AppInitialConfigId = entity.Id("dev.miren.core/app.initial_config")
-	AppProjectId       = entity.Id("dev.miren.core/app.project")
-	AppWorkloadRoleId  = entity.Id("dev.miren.core/app.workload_role")
+	AppActiveDeploymentId = entity.Id("dev.miren.core/app.active_deployment")
+	AppActiveVersionId    = entity.Id("dev.miren.core/app.active_version")
+	AppDeploymentLockId   = entity.Id("dev.miren.core/app.deployment_lock")
+	AppInitialConfigId    = entity.Id("dev.miren.core/app.initial_config")
+	AppProjectId          = entity.Id("dev.miren.core/app.project")
+	AppWorkloadRoleId     = entity.Id("dev.miren.core/app.workload_role")
 )
 
 type App struct {
-	ID            entity.Id `json:"id"`
-	ActiveVersion entity.Id `cbor:"active_version,omitempty" json:"active_version,omitempty"`
-	InitialConfig entity.Id `cbor:"initial_config,omitempty" json:"initial_config,omitempty"`
-	Project       entity.Id `cbor:"project,omitempty" json:"project,omitempty"`
-	WorkloadRole  string    `cbor:"workload_role,omitempty" json:"workload_role,omitempty"`
+	ID               entity.Id      `json:"id"`
+	ActiveDeployment entity.Id      `cbor:"active_deployment,omitempty" json:"active_deployment,omitempty"`
+	ActiveVersion    entity.Id      `cbor:"active_version,omitempty" json:"active_version,omitempty"`
+	DeploymentLock   DeploymentLock `cbor:"deployment_lock,omitempty" json:"deployment_lock"`
+	InitialConfig    entity.Id      `cbor:"initial_config,omitempty" json:"initial_config,omitempty"`
+	Project          entity.Id      `cbor:"project,omitempty" json:"project,omitempty"`
+	WorkloadRole     string         `cbor:"workload_role,omitempty" json:"workload_role,omitempty"`
 }
 
 func (o *App) Decode(e entity.AttrGetter) {
 	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(AppActiveDeploymentId); ok && a.Value.Kind() == entity.KindId {
+		o.ActiveDeployment = a.Value.Id()
+	}
 	if a, ok := e.Get(AppActiveVersionId); ok && a.Value.Kind() == entity.KindId {
 		o.ActiveVersion = a.Value.Id()
+	}
+	if a, ok := e.Get(AppDeploymentLockId); ok && a.Value.Kind() == entity.KindComponent {
+		o.DeploymentLock.Decode(a.Value.Component())
 	}
 	if a, ok := e.Get(AppInitialConfigId); ok && a.Value.Kind() == entity.KindId {
 		o.InitialConfig = a.Value.Id()
@@ -1168,8 +1178,14 @@ func (o *App) EntityId() entity.Id {
 }
 
 func (o *App) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.ActiveDeployment) {
+		attrs = append(attrs, entity.Ref(AppActiveDeploymentId, o.ActiveDeployment))
+	}
 	if !entity.Empty(o.ActiveVersion) {
 		attrs = append(attrs, entity.Ref(AppActiveVersionId, o.ActiveVersion))
+	}
+	if !o.DeploymentLock.Empty() {
+		attrs = append(attrs, entity.Component(AppDeploymentLockId, o.DeploymentLock.Encode()))
 	}
 	if !entity.Empty(o.InitialConfig) {
 		attrs = append(attrs, entity.Ref(AppInitialConfigId, o.InitialConfig))
@@ -1185,7 +1201,13 @@ func (o *App) Encode() (attrs []entity.Attr) {
 }
 
 func (o *App) Empty() bool {
+	if !entity.Empty(o.ActiveDeployment) {
+		return false
+	}
 	if !entity.Empty(o.ActiveVersion) {
+		return false
+	}
+	if !o.DeploymentLock.Empty() {
 		return false
 	}
 	if !entity.Empty(o.InitialConfig) {
@@ -1201,10 +1223,69 @@ func (o *App) Empty() bool {
 }
 
 func (o *App) InitSchema(sb *schema.SchemaBuilder) {
+	sb.Ref("active_deployment", "dev.miren.core/app.active_deployment", schema.Doc("The deployment attempt that made active_version current"))
 	sb.Ref("active_version", "dev.miren.core/app.active_version", schema.Doc("The version of the project that should be used"))
+	sb.Component("deployment_lock", "dev.miren.core/app.deployment_lock", schema.Doc("The expiring lock held by the deployment currently mutating this app"))
+	(&DeploymentLock{}).InitSchema(sb.Builder("app.deployment_lock"))
 	sb.Ref("initial_config", "dev.miren.core/app.initial_config", schema.Doc("Reference to the initial ConfigVersion entity created before the first deploy"))
 	sb.Ref("project", "dev.miren.core/app.project", schema.Doc("The project that the app belongs to"))
 	sb.String("workload_role", "dev.miren.core/app.workload_role", schema.Doc("The authorization role that identity tokens minted for this app's sandboxes authenticate as (see pkg/workloadroles). Empty means the default (app-readonly). Cluster-scoped roles may only be set by an operator, never via app.toml."))
+}
+
+const (
+	DeploymentLockAcquiredAtId   = entity.Id("dev.miren.core/deployment_lock.acquired_at")
+	DeploymentLockDeploymentIdId = entity.Id("dev.miren.core/deployment_lock.deployment_id")
+	DeploymentLockExpiresAtId    = entity.Id("dev.miren.core/deployment_lock.expires_at")
+)
+
+type DeploymentLock struct {
+	AcquiredAt   time.Time `cbor:"acquired_at,omitempty" json:"acquired_at"`
+	DeploymentId string    `cbor:"deployment_id,omitempty" json:"deployment_id,omitempty"`
+	ExpiresAt    time.Time `cbor:"expires_at,omitempty" json:"expires_at"`
+}
+
+func (o *DeploymentLock) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(DeploymentLockAcquiredAtId); ok && a.Value.Kind() == entity.KindTime {
+		o.AcquiredAt = a.Value.Time()
+	}
+	if a, ok := e.Get(DeploymentLockDeploymentIdId); ok && a.Value.Kind() == entity.KindString {
+		o.DeploymentId = a.Value.String()
+	}
+	if a, ok := e.Get(DeploymentLockExpiresAtId); ok && a.Value.Kind() == entity.KindTime {
+		o.ExpiresAt = a.Value.Time()
+	}
+}
+
+func (o *DeploymentLock) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.AcquiredAt) {
+		attrs = append(attrs, entity.Time(DeploymentLockAcquiredAtId, o.AcquiredAt))
+	}
+	if !entity.Empty(o.DeploymentId) {
+		attrs = append(attrs, entity.String(DeploymentLockDeploymentIdId, o.DeploymentId))
+	}
+	if !entity.Empty(o.ExpiresAt) {
+		attrs = append(attrs, entity.Time(DeploymentLockExpiresAtId, o.ExpiresAt))
+	}
+	return
+}
+
+func (o *DeploymentLock) Empty() bool {
+	if !entity.Empty(o.AcquiredAt) {
+		return false
+	}
+	if !entity.Empty(o.DeploymentId) {
+		return false
+	}
+	if !entity.Empty(o.ExpiresAt) {
+		return false
+	}
+	return true
+}
+
+func (o *DeploymentLock) InitSchema(sb *schema.SchemaBuilder) {
+	sb.Time("acquired_at", "dev.miren.core/deployment_lock.acquired_at", schema.Doc("When the lock was taken"))
+	sb.String("deployment_id", "dev.miren.core/deployment_lock.deployment_id", schema.Doc("The deployment attempt that owns the lock"))
+	sb.Time("expires_at", "dev.miren.core/deployment_lock.expires_at", schema.Doc("When another deployment may take over the lock"))
 }
 
 const (
@@ -1219,6 +1300,7 @@ const (
 	AppVersionImageUrlId           = entity.Id("dev.miren.core/app_version.image_url")
 	AppVersionManifestId           = entity.Id("dev.miren.core/app_version.manifest")
 	AppVersionManifestDigestId     = entity.Id("dev.miren.core/app_version.manifest_digest")
+	AppVersionSourceId             = entity.Id("dev.miren.core/app_version.source")
 	AppVersionVersionId            = entity.Id("dev.miren.core/app_version.version")
 )
 
@@ -1235,6 +1317,7 @@ type AppVersion struct {
 	ImageUrl           string    `cbor:"image_url,omitempty" json:"image_url,omitempty"`
 	Manifest           string    `cbor:"manifest,omitempty" json:"manifest,omitempty"`
 	ManifestDigest     string    `cbor:"manifest_digest,omitempty" json:"manifest_digest,omitempty"`
+	Source             Source    `cbor:"source,omitempty" json:"source"`
 	Version            string    `cbor:"version,omitempty" json:"version,omitempty"`
 }
 
@@ -1272,6 +1355,9 @@ func (o *AppVersion) Decode(e entity.AttrGetter) {
 	}
 	if a, ok := e.Get(AppVersionManifestDigestId); ok && a.Value.Kind() == entity.KindString {
 		o.ManifestDigest = a.Value.String()
+	}
+	if a, ok := e.Get(AppVersionSourceId); ok && a.Value.Kind() == entity.KindComponent {
+		o.Source.Decode(a.Value.Component())
 	}
 	if a, ok := e.Get(AppVersionVersionId); ok && a.Value.Kind() == entity.KindString {
 		o.Version = a.Value.String()
@@ -1328,6 +1414,9 @@ func (o *AppVersion) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.ManifestDigest) {
 		attrs = append(attrs, entity.String(AppVersionManifestDigestId, o.ManifestDigest))
 	}
+	if !o.Source.Empty() {
+		attrs = append(attrs, entity.Component(AppVersionSourceId, o.Source.Encode()))
+	}
 	if !entity.Empty(o.Version) {
 		attrs = append(attrs, entity.String(AppVersionVersionId, o.Version))
 	}
@@ -1369,6 +1458,9 @@ func (o *AppVersion) Empty() bool {
 	if !entity.Empty(o.ManifestDigest) {
 		return false
 	}
+	if !o.Source.Empty() {
+		return false
+	}
 	if !entity.Empty(o.Version) {
 		return false
 	}
@@ -1388,6 +1480,8 @@ func (o *AppVersion) InitSchema(sb *schema.SchemaBuilder) {
 	sb.String("image_url", "dev.miren.core/app_version.image_url", schema.Doc("The OCI url for the versions code"))
 	sb.String("manifest", "dev.miren.core/app_version.manifest", schema.Doc("The OCI image manifest for the version"))
 	sb.String("manifest_digest", "dev.miren.core/app_version.manifest_digest", schema.Doc("The digest of the manifest"), schema.Indexed)
+	sb.Component("source", "dev.miren.core/app_version.source", schema.Doc("Sanitized source provenance captured when this version was built"))
+	(&Source{}).InitSchema(sb.Builder("app_version.source"))
 	sb.String("version", "dev.miren.core/app_version.version", schema.Doc("The version of this app"))
 }
 
@@ -2226,6 +2320,62 @@ func (o *Variable) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 const (
+	SourceGitBranchId  = entity.Id("dev.miren.core/source.git_branch")
+	SourceGitShaId     = entity.Id("dev.miren.core/source.git_sha")
+	SourceRepositoryId = entity.Id("dev.miren.core/source.repository")
+)
+
+type Source struct {
+	GitBranch  string `cbor:"git_branch,omitempty" json:"git_branch,omitempty"`
+	GitSha     string `cbor:"git_sha,omitempty" json:"git_sha,omitempty"`
+	Repository string `cbor:"repository,omitempty" json:"repository,omitempty"`
+}
+
+func (o *Source) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(SourceGitBranchId); ok && a.Value.Kind() == entity.KindString {
+		o.GitBranch = a.Value.String()
+	}
+	if a, ok := e.Get(SourceGitShaId); ok && a.Value.Kind() == entity.KindString {
+		o.GitSha = a.Value.String()
+	}
+	if a, ok := e.Get(SourceRepositoryId); ok && a.Value.Kind() == entity.KindString {
+		o.Repository = a.Value.String()
+	}
+}
+
+func (o *Source) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.GitBranch) {
+		attrs = append(attrs, entity.String(SourceGitBranchId, o.GitBranch))
+	}
+	if !entity.Empty(o.GitSha) {
+		attrs = append(attrs, entity.String(SourceGitShaId, o.GitSha))
+	}
+	if !entity.Empty(o.Repository) {
+		attrs = append(attrs, entity.String(SourceRepositoryId, o.Repository))
+	}
+	return
+}
+
+func (o *Source) Empty() bool {
+	if !entity.Empty(o.GitBranch) {
+		return false
+	}
+	if !entity.Empty(o.GitSha) {
+		return false
+	}
+	if !entity.Empty(o.Repository) {
+		return false
+	}
+	return true
+}
+
+func (o *Source) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("git_branch", "dev.miren.core/source.git_branch", schema.Doc("Git branch used to build the version"))
+	sb.String("git_sha", "dev.miren.core/source.git_sha", schema.Doc("Git commit SHA used to build the version"))
+	sb.String("repository", "dev.miren.core/source.repository", schema.Doc("Repository URL without credentials, query parameters, or fragments"))
+}
+
+const (
 	ArtifactAppId            = entity.Id("dev.miren.core/artifact.app")
 	ArtifactManifestId       = entity.Id("dev.miren.core/artifact.manifest")
 	ArtifactManifestDigestId = entity.Id("dev.miren.core/artifact.manifest_digest")
@@ -2390,44 +2540,54 @@ func (o *ConfigVersion) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 const (
+	DeploymentAppId                = entity.Id("dev.miren.core/deployment.app")
 	DeploymentAppNameId            = entity.Id("dev.miren.core/deployment.app_name")
 	DeploymentAppVersionId         = entity.Id("dev.miren.core/deployment.app_version")
-	DeploymentBuildLogsId          = entity.Id("dev.miren.core/deployment.build_logs")
 	DeploymentClusterIdId          = entity.Id("dev.miren.core/deployment.cluster_id")
 	DeploymentCompletedAtId        = entity.Id("dev.miren.core/deployment.completed_at")
 	DeploymentDeployedById         = entity.Id("dev.miren.core/deployment.deployed_by")
 	DeploymentErrorMessageId       = entity.Id("dev.miren.core/deployment.error_message")
 	DeploymentGitInfoId            = entity.Id("dev.miren.core/deployment.git_info")
+	DeploymentOperationId          = entity.Id("dev.miren.core/deployment.operation")
+	DeploymentOutcomeId            = entity.Id("dev.miren.core/deployment.outcome")
+	DeploymentParentDeploymentId   = entity.Id("dev.miren.core/deployment.parent_deployment")
 	DeploymentPhaseId              = entity.Id("dev.miren.core/deployment.phase")
 	DeploymentSourceDeploymentIdId = entity.Id("dev.miren.core/deployment.source_deployment_id")
+	DeploymentStartedAtId          = entity.Id("dev.miren.core/deployment.started_at")
 	DeploymentStatusId             = entity.Id("dev.miren.core/deployment.status")
+	DeploymentVersionId            = entity.Id("dev.miren.core/deployment.version")
 )
 
 type Deployment struct {
 	ID                 entity.Id  `json:"id"`
+	App                entity.Id  `cbor:"app,omitempty" json:"app,omitempty"`
 	AppName            string     `cbor:"app_name,omitempty" json:"app_name,omitempty"`
 	AppVersion         string     `cbor:"app_version,omitempty" json:"app_version,omitempty"`
-	BuildLogs          string     `cbor:"build_logs,omitempty" json:"build_logs,omitempty"`
 	ClusterId          string     `cbor:"cluster_id,omitempty" json:"cluster_id,omitempty"`
 	CompletedAt        string     `cbor:"completed_at,omitempty" json:"completed_at,omitempty"`
 	DeployedBy         DeployedBy `cbor:"deployed_by,omitempty" json:"deployed_by"`
 	ErrorMessage       string     `cbor:"error_message,omitempty" json:"error_message,omitempty"`
 	GitInfo            GitInfo    `cbor:"git_info,omitempty" json:"git_info"`
+	Operation          string     `cbor:"operation,omitempty" json:"operation,omitempty"`
+	Outcome            string     `cbor:"outcome,omitempty" json:"outcome,omitempty"`
+	ParentDeployment   entity.Id  `cbor:"parent_deployment,omitempty" json:"parent_deployment,omitempty"`
 	Phase              string     `cbor:"phase,omitempty" json:"phase,omitempty"`
 	SourceDeploymentId string     `cbor:"source_deployment_id,omitempty" json:"source_deployment_id,omitempty"`
+	StartedAt          time.Time  `cbor:"started_at,omitempty" json:"started_at"`
 	Status             string     `cbor:"status,omitempty" json:"status,omitempty"`
+	Version            entity.Id  `cbor:"version,omitempty" json:"version,omitempty"`
 }
 
 func (o *Deployment) Decode(e entity.AttrGetter) {
 	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(DeploymentAppId); ok && a.Value.Kind() == entity.KindId {
+		o.App = a.Value.Id()
+	}
 	if a, ok := e.Get(DeploymentAppNameId); ok && a.Value.Kind() == entity.KindString {
 		o.AppName = a.Value.String()
 	}
 	if a, ok := e.Get(DeploymentAppVersionId); ok && a.Value.Kind() == entity.KindString {
 		o.AppVersion = a.Value.String()
-	}
-	if a, ok := e.Get(DeploymentBuildLogsId); ok && a.Value.Kind() == entity.KindString {
-		o.BuildLogs = a.Value.String()
 	}
 	if a, ok := e.Get(DeploymentClusterIdId); ok && a.Value.Kind() == entity.KindString {
 		o.ClusterId = a.Value.String()
@@ -2444,14 +2604,29 @@ func (o *Deployment) Decode(e entity.AttrGetter) {
 	if a, ok := e.Get(DeploymentGitInfoId); ok && a.Value.Kind() == entity.KindComponent {
 		o.GitInfo.Decode(a.Value.Component())
 	}
+	if a, ok := e.Get(DeploymentOperationId); ok && a.Value.Kind() == entity.KindString {
+		o.Operation = a.Value.String()
+	}
+	if a, ok := e.Get(DeploymentOutcomeId); ok && a.Value.Kind() == entity.KindString {
+		o.Outcome = a.Value.String()
+	}
+	if a, ok := e.Get(DeploymentParentDeploymentId); ok && a.Value.Kind() == entity.KindId {
+		o.ParentDeployment = a.Value.Id()
+	}
 	if a, ok := e.Get(DeploymentPhaseId); ok && a.Value.Kind() == entity.KindString {
 		o.Phase = a.Value.String()
 	}
 	if a, ok := e.Get(DeploymentSourceDeploymentIdId); ok && a.Value.Kind() == entity.KindString {
 		o.SourceDeploymentId = a.Value.String()
 	}
+	if a, ok := e.Get(DeploymentStartedAtId); ok && a.Value.Kind() == entity.KindTime {
+		o.StartedAt = a.Value.Time()
+	}
 	if a, ok := e.Get(DeploymentStatusId); ok && a.Value.Kind() == entity.KindString {
 		o.Status = a.Value.String()
+	}
+	if a, ok := e.Get(DeploymentVersionId); ok && a.Value.Kind() == entity.KindId {
+		o.Version = a.Value.Id()
 	}
 }
 
@@ -2472,14 +2647,14 @@ func (o *Deployment) EntityId() entity.Id {
 }
 
 func (o *Deployment) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.App) {
+		attrs = append(attrs, entity.Ref(DeploymentAppId, o.App))
+	}
 	if !entity.Empty(o.AppName) {
 		attrs = append(attrs, entity.String(DeploymentAppNameId, o.AppName))
 	}
 	if !entity.Empty(o.AppVersion) {
 		attrs = append(attrs, entity.String(DeploymentAppVersionId, o.AppVersion))
-	}
-	if !entity.Empty(o.BuildLogs) {
-		attrs = append(attrs, entity.String(DeploymentBuildLogsId, o.BuildLogs))
 	}
 	if !entity.Empty(o.ClusterId) {
 		attrs = append(attrs, entity.String(DeploymentClusterIdId, o.ClusterId))
@@ -2496,27 +2671,42 @@ func (o *Deployment) Encode() (attrs []entity.Attr) {
 	if !o.GitInfo.Empty() {
 		attrs = append(attrs, entity.Component(DeploymentGitInfoId, o.GitInfo.Encode()))
 	}
+	if !entity.Empty(o.Operation) {
+		attrs = append(attrs, entity.String(DeploymentOperationId, o.Operation))
+	}
+	if !entity.Empty(o.Outcome) {
+		attrs = append(attrs, entity.String(DeploymentOutcomeId, o.Outcome))
+	}
+	if !entity.Empty(o.ParentDeployment) {
+		attrs = append(attrs, entity.Ref(DeploymentParentDeploymentId, o.ParentDeployment))
+	}
 	if !entity.Empty(o.Phase) {
 		attrs = append(attrs, entity.String(DeploymentPhaseId, o.Phase))
 	}
 	if !entity.Empty(o.SourceDeploymentId) {
 		attrs = append(attrs, entity.String(DeploymentSourceDeploymentIdId, o.SourceDeploymentId))
 	}
+	if !entity.Empty(o.StartedAt) {
+		attrs = append(attrs, entity.Time(DeploymentStartedAtId, o.StartedAt))
+	}
 	if !entity.Empty(o.Status) {
 		attrs = append(attrs, entity.String(DeploymentStatusId, o.Status))
+	}
+	if !entity.Empty(o.Version) {
+		attrs = append(attrs, entity.Ref(DeploymentVersionId, o.Version))
 	}
 	attrs = append(attrs, entity.Ref(entity.EntityKind, KindDeployment))
 	return
 }
 
 func (o *Deployment) Empty() bool {
+	if !entity.Empty(o.App) {
+		return false
+	}
 	if !entity.Empty(o.AppName) {
 		return false
 	}
 	if !entity.Empty(o.AppVersion) {
-		return false
-	}
-	if !entity.Empty(o.BuildLogs) {
 		return false
 	}
 	if !entity.Empty(o.ClusterId) {
@@ -2534,49 +2724,79 @@ func (o *Deployment) Empty() bool {
 	if !o.GitInfo.Empty() {
 		return false
 	}
+	if !entity.Empty(o.Operation) {
+		return false
+	}
+	if !entity.Empty(o.Outcome) {
+		return false
+	}
+	if !entity.Empty(o.ParentDeployment) {
+		return false
+	}
 	if !entity.Empty(o.Phase) {
 		return false
 	}
 	if !entity.Empty(o.SourceDeploymentId) {
 		return false
 	}
+	if !entity.Empty(o.StartedAt) {
+		return false
+	}
 	if !entity.Empty(o.Status) {
+		return false
+	}
+	if !entity.Empty(o.Version) {
 		return false
 	}
 	return true
 }
 
 func (o *Deployment) InitSchema(sb *schema.SchemaBuilder) {
-	sb.String("app_name", "dev.miren.core/deployment.app_name", schema.Doc("The name of the app being deployed"), schema.Indexed)
-	sb.String("app_version", "dev.miren.core/deployment.app_version", schema.Doc("The app version ID or temporary value (pending-build, failed-{id})"))
-	sb.String("build_logs", "dev.miren.core/deployment.build_logs", schema.Doc("Build logs concatenated with newlines (especially useful for failed deployments)"))
-	sb.String("cluster_id", "dev.miren.core/deployment.cluster_id", schema.Doc("The cluster where the deployment is happening"), schema.Indexed)
-	sb.String("completed_at", "dev.miren.core/deployment.completed_at", schema.Doc("When the deployment was completed (RFC3339 format)"))
+	sb.Ref("app", "dev.miren.core/deployment.app", schema.Doc("The app this attempt targeted"), schema.Indexed)
+	sb.String("app_name", "dev.miren.core/deployment.app_name", schema.Doc("[DEPRECATED] Denormalized app name retained for downgrade compatibility; canonical identity is app"), schema.Indexed)
+	sb.String("app_version", "dev.miren.core/deployment.app_version", schema.Doc("[DEPRECATED] Version value retained for downgrade compatibility; use version"))
+	sb.String("cluster_id", "dev.miren.core/deployment.cluster_id", schema.Doc("[DEPRECATED] Client-supplied cluster display value; coordinator storage is cluster-scoped"), schema.Indexed)
+	sb.String("completed_at", "dev.miren.core/deployment.completed_at", schema.Doc("RFC3339 time when the attempt reached a terminal outcome"))
 	sb.Component("deployed_by", "dev.miren.core/deployment.deployed_by", schema.Doc("Information about who initiated the deployment"))
 	(&DeployedBy{}).InitSchema(sb.Builder("deployment.deployed_by"))
-	sb.String("error_message", "dev.miren.core/deployment.error_message", schema.Doc("Error message if deployment failed"))
-	sb.Component("git_info", "dev.miren.core/deployment.git_info", schema.Doc("Git information at time of deployment"))
+	sb.String("error_message", "dev.miren.core/deployment.error_message", schema.Doc("[DEPRECATED] Bounded failure summary retained until lifecycle errors are queryable from the log stream"))
+	sb.Component("git_info", "dev.miren.core/deployment.git_info", schema.Doc("[DEPRECATED] Build provenance retained for compatibility; stable source identity lives on AppVersion.source"))
 	(&GitInfo{}).InitSchema(sb.Builder("deployment.git_info"))
-	sb.String("phase", "dev.miren.core/deployment.phase", schema.Doc("Current phase of deployment (preparing, building, pushing, activating)"))
-	sb.String("source_deployment_id", "dev.miren.core/deployment.source_deployment_id", schema.Doc("ID of the deployment this was based on (for rollback/redeploy provenance)"))
-	sb.String("status", "dev.miren.core/deployment.status", schema.Doc("Deployment status (in_progress, active, failed, rolled_back)"), schema.Indexed)
+	sb.String("operation", "dev.miren.core/deployment.operation", schema.Doc("The intent of this attempt"))
+	sb.String("outcome", "dev.miren.core/deployment.outcome", schema.Doc("Terminal result of this attempt; absent while the attempt is in progress"), schema.Indexed)
+	sb.Ref("parent_deployment", "dev.miren.core/deployment.parent_deployment", schema.Doc("Optional deployment this attempt was based on"))
+	sb.String("phase", "dev.miren.core/deployment.phase", schema.Doc("Last progress phase observed while the attempt was in progress"))
+	sb.String("source_deployment_id", "dev.miren.core/deployment.source_deployment_id", schema.Doc("[DEPRECATED] Lineage ID retained for downgrade compatibility; use parent_deployment"))
+	sb.Time("started_at", "dev.miren.core/deployment.started_at", schema.Doc("When the attempt acquired the deployment lock"))
+	sb.String("status", "dev.miren.core/deployment.status", schema.Doc("[DEPRECATED] Mutable lifecycle status retained for downgrade compatibility; use outcome and app.active_deployment"), schema.Indexed)
+	sb.Ref("version", "dev.miren.core/deployment.version", schema.Doc("The app version produced or selected by this attempt"), schema.Indexed)
 }
 
 const (
-	DeployedByTimestampId = entity.Id("dev.miren.core/deployed_by.timestamp")
-	DeployedByUserEmailId = entity.Id("dev.miren.core/deployed_by.user_email")
-	DeployedByUserIdId    = entity.Id("dev.miren.core/deployed_by.user_id")
-	DeployedByUserNameId  = entity.Id("dev.miren.core/deployed_by.user_name")
+	DeployedByAuthMethodId = entity.Id("dev.miren.core/deployed_by.auth_method")
+	DeployedBySubjectId    = entity.Id("dev.miren.core/deployed_by.subject")
+	DeployedByTimestampId  = entity.Id("dev.miren.core/deployed_by.timestamp")
+	DeployedByUserEmailId  = entity.Id("dev.miren.core/deployed_by.user_email")
+	DeployedByUserIdId     = entity.Id("dev.miren.core/deployed_by.user_id")
+	DeployedByUserNameId   = entity.Id("dev.miren.core/deployed_by.user_name")
 )
 
 type DeployedBy struct {
-	Timestamp string `cbor:"timestamp,omitempty" json:"timestamp,omitempty"`
-	UserEmail string `cbor:"user_email,omitempty" json:"user_email,omitempty"`
-	UserId    string `cbor:"user_id,omitempty" json:"user_id,omitempty"`
-	UserName  string `cbor:"user_name,omitempty" json:"user_name,omitempty"`
+	AuthMethod string `cbor:"auth_method,omitempty" json:"auth_method,omitempty"`
+	Subject    string `cbor:"subject,omitempty" json:"subject,omitempty"`
+	Timestamp  string `cbor:"timestamp,omitempty" json:"timestamp,omitempty"`
+	UserEmail  string `cbor:"user_email,omitempty" json:"user_email,omitempty"`
+	UserId     string `cbor:"user_id,omitempty" json:"user_id,omitempty"`
+	UserName   string `cbor:"user_name,omitempty" json:"user_name,omitempty"`
 }
 
 func (o *DeployedBy) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(DeployedByAuthMethodId); ok && a.Value.Kind() == entity.KindString {
+		o.AuthMethod = a.Value.String()
+	}
+	if a, ok := e.Get(DeployedBySubjectId); ok && a.Value.Kind() == entity.KindString {
+		o.Subject = a.Value.String()
+	}
 	if a, ok := e.Get(DeployedByTimestampId); ok && a.Value.Kind() == entity.KindString {
 		o.Timestamp = a.Value.String()
 	}
@@ -2592,6 +2812,12 @@ func (o *DeployedBy) Decode(e entity.AttrGetter) {
 }
 
 func (o *DeployedBy) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.AuthMethod) {
+		attrs = append(attrs, entity.String(DeployedByAuthMethodId, o.AuthMethod))
+	}
+	if !entity.Empty(o.Subject) {
+		attrs = append(attrs, entity.String(DeployedBySubjectId, o.Subject))
+	}
 	if !entity.Empty(o.Timestamp) {
 		attrs = append(attrs, entity.String(DeployedByTimestampId, o.Timestamp))
 	}
@@ -2608,6 +2834,12 @@ func (o *DeployedBy) Encode() (attrs []entity.Attr) {
 }
 
 func (o *DeployedBy) Empty() bool {
+	if !entity.Empty(o.AuthMethod) {
+		return false
+	}
+	if !entity.Empty(o.Subject) {
+		return false
+	}
 	if !entity.Empty(o.Timestamp) {
 		return false
 	}
@@ -2624,10 +2856,12 @@ func (o *DeployedBy) Empty() bool {
 }
 
 func (o *DeployedBy) InitSchema(sb *schema.SchemaBuilder) {
-	sb.String("timestamp", "dev.miren.core/deployed_by.timestamp", schema.Doc("When the deployment was initiated (RFC3339 format)"))
-	sb.String("user_email", "dev.miren.core/deployed_by.user_email", schema.Doc("The email of the user who deployed"))
-	sb.String("user_id", "dev.miren.core/deployed_by.user_id", schema.Doc("The ID of the user who deployed"))
-	sb.String("user_name", "dev.miren.core/deployed_by.user_name", schema.Doc("The username of the user who deployed"))
+	sb.String("auth_method", "dev.miren.core/deployed_by.auth_method", schema.Doc("Authentication method used by the initiating subject"))
+	sb.String("subject", "dev.miren.core/deployed_by.subject", schema.Doc("Stable subject from the server-authenticated RPC identity"))
+	sb.String("timestamp", "dev.miren.core/deployed_by.timestamp", schema.Doc("[DEPRECATED] RFC3339 start time retained for compatibility; use started_at"))
+	sb.String("user_email", "dev.miren.core/deployed_by.user_email", schema.Doc("[DEPRECATED] Caller-supplied email retained for compatibility"))
+	sb.String("user_id", "dev.miren.core/deployed_by.user_id", schema.Doc("[DEPRECATED] Caller-supplied user ID retained for compatibility"))
+	sb.String("user_name", "dev.miren.core/deployed_by.user_name", schema.Doc("[DEPRECATED] Caller-supplied username retained for compatibility"))
 }
 
 const (
@@ -2754,93 +2988,6 @@ func (o *GitInfo) InitSchema(sb *schema.SchemaBuilder) {
 	sb.String("repository", "dev.miren.core/git_info.repository", schema.Doc("Git repository remote URL"))
 	sb.String("sha", "dev.miren.core/git_info.sha", schema.Doc("Git commit SHA"))
 	sb.String("working_tree_hash", "dev.miren.core/git_info.working_tree_hash", schema.Doc("Hash of working tree if dirty"))
-}
-
-const (
-	DeploymentLockAcquiredAtId   = entity.Id("dev.miren.core/deployment_lock.acquired_at")
-	DeploymentLockAppNameId      = entity.Id("dev.miren.core/deployment_lock.app_name")
-	DeploymentLockDeploymentIdId = entity.Id("dev.miren.core/deployment_lock.deployment_id")
-	DeploymentLockExpiresAtId    = entity.Id("dev.miren.core/deployment_lock.expires_at")
-)
-
-type DeploymentLock struct {
-	ID           entity.Id `json:"id"`
-	AcquiredAt   time.Time `cbor:"acquired_at,omitempty" json:"acquired_at"`
-	AppName      string    `cbor:"app_name,omitempty" json:"app_name,omitempty"`
-	DeploymentId string    `cbor:"deployment_id,omitempty" json:"deployment_id,omitempty"`
-	ExpiresAt    time.Time `cbor:"expires_at,omitempty" json:"expires_at"`
-}
-
-func (o *DeploymentLock) Decode(e entity.AttrGetter) {
-	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
-	if a, ok := e.Get(DeploymentLockAcquiredAtId); ok && a.Value.Kind() == entity.KindTime {
-		o.AcquiredAt = a.Value.Time()
-	}
-	if a, ok := e.Get(DeploymentLockAppNameId); ok && a.Value.Kind() == entity.KindString {
-		o.AppName = a.Value.String()
-	}
-	if a, ok := e.Get(DeploymentLockDeploymentIdId); ok && a.Value.Kind() == entity.KindString {
-		o.DeploymentId = a.Value.String()
-	}
-	if a, ok := e.Get(DeploymentLockExpiresAtId); ok && a.Value.Kind() == entity.KindTime {
-		o.ExpiresAt = a.Value.Time()
-	}
-}
-
-func (o *DeploymentLock) Is(e entity.AttrGetter) bool {
-	return entity.Is(e, KindDeploymentLock)
-}
-
-func (o *DeploymentLock) ShortKind() string {
-	return "deployment_lock"
-}
-
-func (o *DeploymentLock) Kind() entity.Id {
-	return KindDeploymentLock
-}
-
-func (o *DeploymentLock) EntityId() entity.Id {
-	return o.ID
-}
-
-func (o *DeploymentLock) Encode() (attrs []entity.Attr) {
-	if !entity.Empty(o.AcquiredAt) {
-		attrs = append(attrs, entity.Time(DeploymentLockAcquiredAtId, o.AcquiredAt))
-	}
-	if !entity.Empty(o.AppName) {
-		attrs = append(attrs, entity.String(DeploymentLockAppNameId, o.AppName))
-	}
-	if !entity.Empty(o.DeploymentId) {
-		attrs = append(attrs, entity.String(DeploymentLockDeploymentIdId, o.DeploymentId))
-	}
-	if !entity.Empty(o.ExpiresAt) {
-		attrs = append(attrs, entity.Time(DeploymentLockExpiresAtId, o.ExpiresAt))
-	}
-	attrs = append(attrs, entity.Ref(entity.EntityKind, KindDeploymentLock))
-	return
-}
-
-func (o *DeploymentLock) Empty() bool {
-	if !entity.Empty(o.AcquiredAt) {
-		return false
-	}
-	if !entity.Empty(o.AppName) {
-		return false
-	}
-	if !entity.Empty(o.DeploymentId) {
-		return false
-	}
-	if !entity.Empty(o.ExpiresAt) {
-		return false
-	}
-	return true
-}
-
-func (o *DeploymentLock) InitSchema(sb *schema.SchemaBuilder) {
-	sb.Time("acquired_at", "dev.miren.core/deployment_lock.acquired_at", schema.Doc("When the lock was taken"))
-	sb.String("app_name", "dev.miren.core/deployment_lock.app_name", schema.Doc("The app this lock covers. The lock is app-scoped, not app+cluster: a coordinator's store only holds its own cluster's deployments, and the client-supplied cluster_id is unreliable (see MIR-1465).\n"), schema.Indexed)
-	sb.String("deployment_id", "dev.miren.core/deployment_lock.deployment_id", schema.Doc("The deployment currently holding the lock"))
-	sb.Time("expires_at", "dev.miren.core/deployment_lock.expires_at", schema.Doc("When the lock may be stolen by another deployment. A holder whose deployment reached a terminal status is stealable before this too.\n"), schema.Indexed)
 }
 
 const (
@@ -3439,19 +3586,18 @@ func (o *SecretVersion) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 var (
-	KindApp            = entity.Id("dev.miren.core/kind.app")
-	KindAppVersion     = entity.Id("dev.miren.core/kind.app_version")
-	KindArtifact       = entity.Id("dev.miren.core/kind.artifact")
-	KindConfigVersion  = entity.Id("dev.miren.core/kind.config_version")
-	KindDeployment     = entity.Id("dev.miren.core/kind.deployment")
-	KindDeploymentLock = entity.Id("dev.miren.core/kind.deployment_lock")
-	KindKeyRotation    = entity.Id("dev.miren.core/kind.key_rotation")
-	KindMetadata       = entity.Id("dev.miren.core/kind.metadata")
-	KindOidcBinding    = entity.Id("dev.miren.core/kind.oidc_binding")
-	KindProject        = entity.Id("dev.miren.core/kind.project")
-	KindSecret         = entity.Id("dev.miren.core/kind.secret")
-	KindSecretVersion  = entity.Id("dev.miren.core/kind.secret_version")
-	Schema             = entity.Id("dev.miren.core/schema.v1alpha")
+	KindApp           = entity.Id("dev.miren.core/kind.app")
+	KindAppVersion    = entity.Id("dev.miren.core/kind.app_version")
+	KindArtifact      = entity.Id("dev.miren.core/kind.artifact")
+	KindConfigVersion = entity.Id("dev.miren.core/kind.config_version")
+	KindDeployment    = entity.Id("dev.miren.core/kind.deployment")
+	KindKeyRotation   = entity.Id("dev.miren.core/kind.key_rotation")
+	KindMetadata      = entity.Id("dev.miren.core/kind.metadata")
+	KindOidcBinding   = entity.Id("dev.miren.core/kind.oidc_binding")
+	KindProject       = entity.Id("dev.miren.core/kind.project")
+	KindSecret        = entity.Id("dev.miren.core/kind.secret")
+	KindSecretVersion = entity.Id("dev.miren.core/kind.secret_version")
+	Schema            = entity.Id("dev.miren.core/schema.v1alpha")
 )
 
 func init() {
@@ -3462,7 +3608,6 @@ func init() {
 		(&Artifact{}).InitSchema(sb)
 		(&ConfigVersion{}).InitSchema(sb)
 		(&Deployment{}).InitSchema(sb)
-		(&DeploymentLock{}).InitSchema(sb)
 		(&KeyRotation{}).InitSchema(sb)
 		(&Metadata{}).InitSchema(sb)
 		(&OidcBinding{}).InitSchema(sb)
@@ -3470,5 +3615,5 @@ func init() {
 		(&Secret{}).InitSchema(sb)
 		(&SecretVersion{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.core", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xb4\\˲\xf46\x11~\r\x02\x84K\xb8\ap\x12B\x80pIqYPņGpil\xd9\xd6\x19\xdb\xf2/i\xe6\x9ca\xc7\x1d\n\x9e\x82\xff\xfc\xac\xf2z\xb0\xa6\xac\x9b\xa5\xb6,K\x9e\xc3fJ\x92՟d\xa9\xbb\xd5\xea\xee\xf1s=\xa2\x01\x8f5\xbe\x16\x03ax,*\xca0>\x93\xb1\xe6\x9f>\xfa\xad\xefͭ\x05\x9a\xa6\x7fK\x1a\x06\x9e\xa2iRt\xffmj: 2\x02Ц!\xb8\xaf\xf9\x9f^\x9fH\xfd\xf4\xe55q\x81*A\xae\xb8\xbcb\xc6\t\x1dռ@\x9b\xb8M\xf8D\xeaM\b2\x12AP_VtlH\xab @\x9b\v\xf1\xd9\x00\xc4\xc4\xe8\x03\xae\x84\xa4mM\xc5%\xfaR\x80葲sOQ]2\xdacI:\xf8M3@\xc3\x05#c\xdb\xea\x97i\xaf\x1f\xa0~\xeaP?12 v+\xe7ū\xd04\xad\xa6%ם\xe3\x8aa\xa1\x96\xfe\x02:\xa8g)\xab\xff\a\xf9\n_\v\xd2\x17Յ1<\no\a(l\x8c\xad\x9fƙ\x90\xe8$q-K\xa9\xef\xde(\xf2\xa7υ^_\xef\x84z\xff+\xe8\xa1\x1f\xa6,\xc0\xef\xe5\xc4?\x1f\x06(\xe8㈙\x1c\x02\xabb\xea\xdc\r\xa7\xac\x90\x95\xcc0A\x1adf\x0f\xc5\xca<M\x97\x1e\xb8B\x06a\x16N9\xc4\xccFq\xa65\x14\x03\x1aI\x83\xb9\xe2\xf7\xce֜\xf7\x96\xf4\xdfأ/k\xd2\x1a\x18\n\x1b\x1d\xb4\xe7\x19\xed\v[h\\ q\xe1\x12\xa4\xd1噶\xc6\xe3e8\xcf?\xe5\x15\xf5\x17\xcc\xff\xd5(ŰZnE\xa4UI\x87XՑ+^\x0fh\xba\xe9\xe7ѭ\xed\xcc\xec\xc2{;`\x81j$Pxo\xcdӔ\xbd\xfdcpm\fBѣ\x13\xeey=\xa0\xf1\xf6\x1f\xb5B\xbae^!,\xcbA\u07b6\x00R\"\x97\x1f\xb8\xc5_ܢ\x8bi\xc4\xf8\xca\x19\x88\xd5Kɕ\xab\xf1\xd4\xd3ۀG-\x17Oo\x81^K\x87\x94\xe5\xfb\x87|\x8bw61f\xe1(\xed\xebw\xb6\x06\xd7\x01*G\x80\xe0*ǳ\xdb\x00q\xbe\xba\x8ds\xba\x90\xbe.{\xda*V\x7fp\xea\x19(U\x7f\xe1\x02\xb3\x92\xd4\nũC\x94\xafGP\xe80\xf5X\xe0\xbaDj\x8b{\xaf\x05\x8anduT\x11\xd7\xe5\xe9\xa6V\xc7m\x98qȌLG<\x8a\xa5\xa4\xb7\x1e\xc0\x16a\xd8t\r\x19^6\tR\b2`.РT%Y\xaai\x9c\xa0@.\x1c\xb3\x12\x0f\x88\xf4j\xf1\x9d:\x84\t\xb3\xa4\x03\xa37\xb05\x954\x1ep\x00,W\x93\xa5\x9azr=\x18\xb4\xd3-\xa8靝\xc0\x8cQV\x0e\x98s\xd4j+\xc7o\x82\xcc\x12\x11Ɩ\x88\x92\x8c\rU\xc2hk;l\xf2\xce6\x9b\x18\x88\x14\x1e\xf9\xfb됦5\b\x05\xba\x88\x8e*3\xa0\xd1e\xb8%\x9b\xb4'\x86\xc6JY?\x8d.C\xdaoo\xd1Vt\x18\x88(Ր\x0es\xf1\xd0\x03\x88\xfa\xcd\x1dT\x9f\xeb\xa7U+ă\x16\x83\xc5#\xbc\xac\t\x13J\xc6;[\x93\xe7\xf4\x89\xd2>x\x98Xj\x97{\xda\x00\xdf\x04%\xc6R3<QN\x04ej\xf4\a\xa7\x0e1\xa0\x8dd1x\x87\x94\x8d4\x17 շ\xb6\xa8fs\x9e\x8cm)\x18\xc6e\x87\xb8\xda\xe2W\xeb\xe6d\x8b\xb1%bF\x0e.\x97\xc3\xd7S\x87\xb8Z.\xac\x8ap\xca\xc56-\xa7\x17V\xe1ri1\xaaF\x04\x9f챀\x8b\x1c6\xd42\x14\xce\f\xb3zos\xc34\x87\xaa\x16\xfb\xc0=\xcd\xf4H\x11\xf7\x7f\x06\xcf@\a\xa4@\xf5@\xc6R\xd036\a\xbbӰ'\xfb\x1eЖ\x01\xfe\x95\x18\x9160\xb5abj\x9a\xfcy\xe3\xb2kɝ\xcbn\xe3\\r#j\x14\xa0\x15k\xb4\x94e\xfd˛\xd0j(z\xa9u\xd0X\xbb\xf6jg\xdbv\xa6\xf7\xee\xee\xf4,|\xfa\x9d\x17\xb2\x9aA0PJ#\x99ʞql\xa99fWRi}f*\xa9\xa2`W$(n\xfaU\xf1(\xd8m\xa2dT\xfc\xf1\xe0\xd4\xe1,\xa1\x9ch\x84\x892\xa1\xef\xe3si\xa6\xaa\xc8(bۧ\xdf\xc4\xdb>\xdbv\xff\xf6\x19\xa8\xa4\xc3Z\xce\xf3핫A!\x145\xe1gw\x9aX5\xec\xcc\xf1\xfd\xf49\xaa\x11\xd2o \xf0\xfe%ɋ\xfaT6D\xfb\x86ZS\xd9\xe32E:w\xe57.\xf0\xa0\x18\xc0\xa9\uf69a\x12\xa0ǈcy\xd4Ӌb\x84\xc1oJ\x9b\xc7@/\xa3(\xads\xe7\xc1\xa9C\x80\xd5MN\x02\xec\\@!\xf7*\xa2\x98K\xe69\xc4\x19\x8alb\xf4JjM\xd9\xd9ZЛ\xf0\x1a\xf7\xb4B\xfd\n\xc9P\x15\xf21\x96O\xb6;ɶ\x86\xbf\xea\x89\xc0+\xb1\xb2\xbd\xd4\xf3\xe09\xa2&\xce0\xaaK:\xf6\xca\xc2!K\xd57\xb0\xc2\\\xc6\xc9\xefpٞ\xb46\xd2\x15#\xefA\xb3H\xd3Is@\x1f窼w\xeaiB\xf9:Ƭ K5U\x05*q}\x13\x9a\x9a\x15@<^\x1d\x01\xaf\xe6\xea\x8ex\x17\x19\xe2\x8d\xc7k\x8ap\xff5ȣx\xbc\x16'T\xcdf\x82ZtS\xd9[\xbe\x99\xb0Ƽbd\x12֝\xe06\x00\x00\xe8\xf2\x9c\xe9\xcfX1I5\x17\xf6\xecߙ\x80\xe1W\x17°\x9ajgkqΚ\t9\x1e9\x11\xe4\xaao\x99K\xd5'\x85b/I\xf7Y\xeb3\x012)\x99J\xecU1ك\x8e\xc7\xeb\xeb\xe8\x89A\x06s\x01\xc1\xaa\b\xe7\xb3r*\x1a\xca\x1d\x05\xb6I\xb7q\x00\a\xc3\x18\x1e\x91s\xb3_\xaap\xd88\x82ܡ\x05AV\x1d\x84\xf8\xe1:\x93x\x87\xabjx\xc1\xc3U\x02\xa6\xc8ߟ\x83\x1c&\xc9\xf7\xf6e\xa5\x8c\x15\x11\xadqiw\x86,Uo{\xc2\x03nlh\xf0<\xd2\x14\x8c\nZ\xd1ޞG\xaa\x16\xf6nW\xa2\x9aV\x02lh\nQMե\x8et\xb8\xd4Sd\xee\x96!j\xc8\vqE-\xa9\x9fC\x0e\f\xbb\x99\xbaPVtTa\xa3J)(\x1ez\xb0\xc3D\x9fd0Q\x00>\x9d\xa5\xa0\xc3+\x00V\f\xb4\xd6k&K\x90\xc1\xdeO\x80\x98\xb7\x97\x8c\\\xa0q6\xa1\xa5\x11\xe67yl\xf7\xa3\x04\xc4Y\x7fc.x9afqT|0\xfc\xc8\x1b\xe1Ä\x11\xf8l\xf6\x945}\x1c\xcb\x1a\xf7Hm\xe6\xb4j\x85ˑ\x04\xdd]\x84\x84p\xcd\xd2i՚ʝL\x8f\xe1\f\x11\xbfy\x19\xde\t:z\r\x7f\t\xc4DY\x13\x86+\xebr\xa2\xb0\x11\xeaҍ\v\xd5\x151\x82N=v/T\xb6\xed\xfe\v\x95\x81J\xb7d\xa0\x8do\x10\xd2\xcc\x19\xe8ΰ\xd496\xcdJ\x83Y\x94\xa8e\x03\xefɖ*ɼ\x81\xa7\xa5\xa5N\xb4q\xe0\xfe.\xf4\xfb\x86\x0e<\x1a,\xedak\xc7\xf2P<\xb2\xae\xb8$\xe8\xe1\\3\x93\x9f\x81\x01\xda\\\x9f\xd6{\x11(<ux\xc0\f\xf5%~\x9a\b\xc3܄\x97D\xf0\x89:\x8aȠnF\xef&\x01ː\xa7\x12Jظ\xe7\x1c\x0f\x03\n\xd1먆״\x17\x8eq\xc1\xa4AY^\x98\x02\"KuO\x80\\\x90Ę|l\x95r\xc3\xf2A\xef\x81\v\xe8\xf2D\x1b\byF\xf9ύ\x93\xae\xc4W\xfa|\xcf\xf8V2*\x90X\x9c\xbe\xab4\x10\xa7K\xfa\xe9\x0e\xd9\xddE\xc9\nh\x05\xb7\xdeCk\x18\x1dJ\xa3\xb9:[ۋ*z\x18\f?24MZ\x87\x91\xa5Ꙙp\xa3<\x88\xd4\x1c\x8a约\xe3ڷ\xaeS#\xe6gM\x83H\x8f\x03\xf7\x1a\xd5E=\xed\x18\x16d~\xb9\xad$\v\xf3\xfcA\xbf\xcc\xdc\x15\xf2\x80\xedjz\x04\xf9\xd1{MA\xedZ7\xba\x9cʎ\xbd\v\x14\xe6GJ\xea\xaa<\x91\xb1&c\xbb\xc1\x8fn\x97$wy\xf0\xd8uQ\x82\xd1\x03iT|'FU\xf5\x88\f\xb3qU\x93\xf9\x85\xdc\xfbڴz\xb6cj\x80\x81\x8a\xe8@\xe9\xcew\xa8\xed R\xfc\xc0\x87\x16\xfa\x8azBB`\xa6\x95\x93\xa9\xa4r\x03\x95p\vZpHo\x1d\xb2l\x1c\xc8\xc4\x1e\x12\xe1\xfc\xa2}\x94\x8d.\xef\xa9\x1c\x8f>\xe2\xe5\x8cE\x9c=\f~9=\xe0J:r\xed\"Rؘ,Z.\xf4Z\x80g\xd1\xf2\r\n\xcdw\xd02\xf2;\xa53\x1a\xb4\xee|\x9c\xa0\x80\x055*\xa0\xe3\x13\xae\xd4\xfdO\x96v\x84\bn\x99}n\xde}\x06I?\u00a0\x99\x15\x84K\f\x13Im\xf2\xdd$\xc0{B@`\x84\">Bz\f\xf7\xa3\xac\x99\xef\x86\xf6\xe4\xd6\x7f\x9c\x8b\xe9\xfb6\xce\x19>\x8d\x8f\xb3\x96\xa58\xe4\xce\xf8\xe4\xf0\xeb\xecy9~}\x1c9\xcf\xf9\xf1\xdb\xe3\x03\xdd\xe7\x13\xf9\xcd\xf1\x81\x0f\xbaJ\xee\x19\xf1e=(Oo\xab\x11\xe7\x01\xcdx\xcepoB\x8e\x9d\x9d\xd9\x1e\v\xcd~\x98'$\x99\xd1ٟ\x1cx\x85\xb4\xe0m\xa6\xe0e\xc7v\x7fq\x04?;\xf4{\xe8-2\"\xc3б\x99\x84\xbf\xe3\xdf\xcf\xd4\xe0\x89q\xe5\x9f\x1eA=\x12v\xfe\xe5=\x03y\xb1\xe9\xfb\x90\xbc\x00\xf6\xaf\xee\x82r\xa2\xdc?;\x02\x94\x18\x04?$\xcc\xfb1\xf2\x1f\x1f\x82\xddw\xff\x1dZ\x8a\xbb#\xec\x8fk\xbd\xbe\xc4\xdc?țR~$\xfe\x83<m\x9e\x15\x8cϔ\xfb\xe4X}\xe6>\xe5\x86\xf2s\xad\xd8\xddP\x7f&\xbf&g\x02d\x8aWF\xa2@\xe6)\x90\x98G\xf0\xc3|\xd4Î\xf7\xcbZ\xaaL\xe2A\xa6\x95\x14KGx>\xc0.\x03\x16\x8cT\xca\xcanMeGJ?ʓR\x8d\x9a~)ɔ(\x8d_\xe0Q\x86\xc7ԫ\x98\x8a\xcfI\x99\xf6\x8aA&\xa3\xc0\xec\x8at8\xde\xd6\xee\x94,\x83\xbe\xfd\aȻP#Y$\x99Ɗ\x85\xbc\x9cz\xa2<\x1b\x8d.\xdb\xe5\x8d\xdf\x16\xdeZ\xf3\xbf\x06\x95\xf3\xf9^\xde|v\f\xbcL\xb4\xd8Be\xea\x88\xe4$\x9c\xcc=U\xb98\x8eY\xde{-wj\xb6\xe4ğLUu,\x1d(\xf3B\x97\x99\x11\x94y\x94$%\fe\xaa\xab\x9c|\xa2CӍ\xa5\x1beJ\xfe\xd1l\xa4\x9f\xdf3\x8cMY\xba\x0f\xc5\xe45\x1dZÃiO\x01\xebY\xe2ųQ\xd6Dr\xe2\xdfO\x9b\xf8\x91\xb4\x13\x18\f\x0eC\v\x04<2\xaa!3\xff$\x82\x9d\"\xb7\x7f\xcb\xd0\xe9\x12t\u05cf+W\x00\xfe\x0f*\x06x\x7fF\xf1\x0ez\xfa%&\xed\xe0\xb0\xc0y7\x8d\x9cE\u07bdf\xa4١\v\x18e\xa4%j\x92\x8d.\x1f;\xd7\x16ȤkK\x9azX@\x13\xef,\xb9\xaf\x9fpaI\xd3\a\v\xe4\xe1ۊ\xa3\x90\x94\x98\xea\xabJ\xda\rZM`@OK\x06\x9f:\x8eF\xd0\xe6\x9dtia+\x85\xfd\"\xf6\x9f\x82b\xb3\x15\xaa\x83\f\xad\xa9D3\x1fch\xbc\xeap}Ѯ\xdf\xce\xd6\ue660k\xf5\xb5[\x06_\x16 #m\xab]\x8e\xad\xa9\xa4G\xbf}\xce\xc8P\xa5&\xf5\xcc=P\xc8\xd2\xf8\"\n\xd5¥+\xd4\x1f\xe4M>\xcd%\x94\xa6\xa5\x17\xd0\xff\x83\x96^\xc0\xa3Z:M\xa5.`/\xa8R\x17\xd0\x17U\xa9\x0e\xecK\xa9\xd4\x05\xf2\xb0J\xe5\x8b\xe0X\xb4x\x12\x9c3\x81hG\x90r\x19\u03a2P\xdfJ\xdaɢ\xf0;\xa5')\xc1tI\x1f\xa7\xa8\xc8\xd4a&\xf0\x93N5p\xea\xf3\xea\xe1\xd3Mh\x83\x17fB\x00\xa03>\x1b\xc7v\xa3\xcb{\xe9/\x00AU5G\xa8\xb2\x9b\xd6\x01\xf3\x8e \xb5@Bo\xbe*\x86\xe34\xc6\xf5\x14L\x84\xc3\xc6K\xd5Մ\xabn\xabm\x90\xdd\xcccRc.\x18\xbdm|\x96H\xa6P\xab\xe7\x1b\x7fO\xf0^AN\xb1\x1cPeԯ\xa9\u0085\x84\x89\x90\x00G\xe7\x19\x965>+\x85\xe56,\xbb\x1ag\\\x1fs\xb5\xfa\xe0\xab?eO\xab\xb3\xe6\xdcտ\v\xfd^\xe9\x1f~\x81\xf7 \x00T\xa0J)8\x93\x8e|v\x1b\xfc,\xe4\xed/\xa1h\xa8\xb4\xef\t\xc1\xdc=\b\xb3\xfe:\xc3\x10\xff,\x03\xdcI\b\b\x12\xae\x1fBi\xd6q\x9b\x00 \xc2\xceg\xdeQ&\x94\x16\xfc\xb4BӴ\xf5\xa1@\xf3E\xb7\xc8\a\xed\xec\x87\xd3b_}\xdb\xf9\x04\x97y\xba|o*\xfa\xa5.\xf7\x03\x14;\x1f\xa6\xf2\x12\x97\xf7>V\x91\x90V\xea\xf6\xf0S\xe5v\xb3P\x93N\x05\xbf\x0f\x94Ǆ\x83\x04n}\x92\f\xff\x0f\x00\x00\xff\xff\x01\x00\x00\xff\xff\xc0\xf5\xfc\x8dDR\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.core", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xb4\\ے\xf46\x11~\r\x02\x04\bg\x028\t!@8\xa48\\P\xc5\r\x8f\xe0\xd2ز\xad\x1d\xdb\xf2/ifw\xb8\xe3\f\x05T\xf1\fd\x7fn\xf2|pMY'Kmْ<\xcb͖Zr\x7f:u\xb7Z\xad\xdey\xaeG4\xe0\xb1\xc6\xd7b \f\x8fEE\x19\xc6g2\xd6\xfc\x93G\xbf\xf6\x9d\xb9\xb6@\xd3\xf4o\xc9\xc3@+\x9a&\xc5\xf7ߦ\xa6\x03\"#\x00m\x1a\x82\xfb\x9a\xff\xe9\xe3\x13\xa9\x9f\xbe\xbcf.P%\xc8\x15\x975\x9ezz\x1b\xf0(d7\xaf\xd6\xd5\xe26\xe1\x13\xa9%\xd0[\xdb@W\xcc8\xa1\xa3\x9a \xa8\xd3\x10\xcf3\xc4\x17\x03\x10KoeO\xab\xb3Ġ\xb0r\x06!\x15\x1d&:\xe2Q,%\xb5>\x10\xb7\b\xe0\xa6,\xd8\xef\xe5<\xdf\x06\x83\x04@\x05\xaa^]\b\xc3u\x89Բ\x9d݊y\xa0\xb5 \x03\x96Pߊ@94\xa9%\xd8\xe0W\xcdp\r\x17\x8c\x8c\xad\x04\xfcF\x04\x10?M\x84an\x86\xf6\xe0\xd0vd\xadޙ\xf6\xfa\x1e\xea\xa7\x0e\xf5\x13#\x03b\xb7r^\xa1qA\x9c\x0177\x9e\x8cD\x10ԗ\x15\x1d\x1bҪ\x8d\au\xae\xec|:\x0011\xfa\x80+5\xd0\xd6\x10.\xd3\x17\x02L\x8f\x94\x9d{\x8a\xea\x92\xd1\x1e\xab\x15\xf3\xab\x9c\x15\u06ddh\x85\xa6i5,\xa9v\x1cW\fkɺ\x80\x0fT[\x8a,\xfdNN\xe1+A\xfe\xa2\xba06\uf66b7\x14V\ueb5fƙ\x90\xe8$s-K\xa9so\x14\xfb\xd3gB\xd3\xd7;\xa1\xe6\x7f\x05_\xe8Ɣ\x05\xf8\xad\x1c\xf8g\xc3\x00\x05}\x1c1\x93]`UL\x1d\xbb\x91\x94\x15\xb22\x99L\x90\x06\x99\xd1C\xabjZS\x86\xff\a9|\xb8B\x06a\xb60\xb2\x8bY\x8c\xf6\x85\xd6p\fh$\r\xe6J\xde;KA\r\xffZ\x8c\xbf\xacIk`(\xactФ\xc1\xfd\xdc\x16\x1a\x17H\\\xb8\x04itY\x1a\b<^\x86\xf3\xfc\xa7\xbc\xa2\xfe\x82\xf9\xbf\x1ae\xceW˭\x98\xf4\x01\xd0!Vu\xe4\x8a\xd7\x1d\x9a\xcft\xfb\xee\xd6vft\xe1\xbd\x1d\xb0@5\x12(\xbc\xb7\xa65\xc9\xce\a\xd7\xc6 \x14=:\xe1\x9e\xd7\x03\x1ao\xffQ+\xa4k\xe6\x15²\x1c\x94m\v 5r\xf9\x03\xb7\xf8\xf3[|{\x16q\x7f\xe5\f\xc4jRr\xe5\x16\x9b\xae\xcf\xcb76\x8f\x91\x94\xe5\xfb\xa7\x9cś\x9b\x18\xdb\xca\x01\xcf\x7f\x9f\xa7\xb4K\xd6Y\n\xae\x1d4\xa8\x00\xc15\xa8g\xb7\x02\xe2@\xaf\xc8\xc1\xa9\xfa\v\x17\x98\x99\x13\xf9\xc1\xa1!\xcaWwP\xe80\xf5X,nB\xef\xd5@Eݙ\x97*\xe2\xba<\xddԼ܊\x88c\x04`\x8b0l\xba3\x19\x9e\xb0\x04)\xd0Et\xe5\x80EGk\xbd\xfeN\x05\\\xb9\xb0$( ~9-j`\x88\xb4\rT\x00\xb3\x97\xc3\x05\x1a\x94\x14\x92\x85L\x93&\x05rᘕx@\xa4Wb\xe0\xd09\x93\x91lZ\x94ZC\xe4LF\xf2X\xcd \v\x99zb>\x18\xb4\xd3-x\xc282\x81\x19\xa3\xac\x1c0\xe7\xa8\xd5ޕ_\x05\xc5vG\xa1[\"J26T)\xb4\xa52=\xf9\x00`\x8a\xb4\xfe\xf5㐅7\bRT\xa9r?\x1a]\x86[\xb2\xc9{bh\xac\x94\xd7\xd5\xe82\xe4\xfd\xe6\x16oE\x87\x81\x88Ru\xe9\b\x17\x0f5@ԯGP}\xa9\x9fV\xb5\x10\x0fz*\x16\x8f\xf0\xb2&L(k\xd3YJ\xfa\a'J\xfb\xe0!f\xb9]\xe9i\x03r\x13\xd4\x18\xcb\xcd\xf0D9\x11\x94\xa9\xde\x1f\x1c\x1ab@\xdf\xccb\xf0\x0e\xa9\xe3g.\xc4nP\x96k\xbeF\x90\xb1-\x05ø\xec\x10W[\xfcj]\x9d쩶D\xccȲ\xdb/m+\n\x9d0C\u009cZd!\xe1\xd0\xe1=\xccŸ\x88\x8aj\x13\xd1\x1a\"&\x96\x0e\xff\x84\xe4\xd5\x03\x06\x04\xd6\xd5\xeei\x0eE\xc0\xc5\xeb\x10W\xa3\xc1\xaa\b\xc7Rl\xf3rza\x95\x1b\x850\xe6S\x04[2Nv.\x10sN\xe4\a\x87\xf6\xef\xedP5|\x8c\x90㜸O\xae\x7f҂\x8b^\x8a\x11\x9fAV\xebn\x82E\xc6\xd9Ѧ4p\xe76_\xa4\x98\xd0\x7f\x04\x0f|\a\xa4@\xf5@\xc6R\xd036\x0e\x97S\x11\xb3\xa7\x1eЖ\xbf\b\xb5\xc6cҗ\x05\xed0\x1a\xca\r7\x05\x02\x17\x96\xdd\t\\4N\xc0b\xe7hzk\x1dd\x02hI~\xd4\xeb\xd0j(~i\xc9\xd1X\xbbw\x8f\xce\xd6E\x86\xf7vtx\x16>=~\x01E\xcd \x18(%Ȇ\x88]t,7\xc7\xecJ*m\xae\f\x91jW\xed\x8a\x04UUO\x15\x8f\x82\xdd&JF\x13\b[h8J\xa8'\x1aa\xa2L\xe8\xd8\xca\\\x9a\xb9*2\x8a\xbd\xed\xd33\xf1\xb6\xcf\xd6ݿ}\x06*\xc9\x01z\x1d\xba\xa3\x19\x84\xa2&\xfc\xec\x0e\x13\xab\x8a\xc8\x18\xdfM\x1f\xa3\xea!e\xa4\x7f\vޥ%{Q\x9fʆ\xe88_k\x88\x98\x94)\xd6\xf9S~\xe3\x02\x0fJ\x00\x1c:\xea\xbeK\x80\x1e#\x8e\xa5\xfbD/J\x10\x06\xbf*m\x1c\x03\xbd\x8c\xa2\xb4\x81\xba\a\x87\x86\x00\xab[\xb9\x04\x88\x04\x13\xa0\xf4*\xa6\xbd\xf0\xdas\xf0\xf6.\xd9&F\xaf\xa4֜\x9d\xa5\x82\x91\xa1\x8fqO+ԯ\x90\fW!\x9b\xb1l\xd9\xfeH\xd65\xfcUO\x04^\xa9\x95\xfdJ\xb5\a\xcf\x115p\x86Q]ұW^#YH\xdfi\rK\x19'\xbf\xc1e{\xd2\xd6H\x13F߃\xae\xa6\xe6\x93\xee\x88v\x05T9v\xeaiF9\x1d\xe3\u0590\x85L5\x81J]_\x87\x86f\x15\x10\x8fWG\xc1\xab\x99\x8c\xa8w\x91\xa1\xdex\xbc\xa6(\xf7\x9f\x832\x8a\xc7kqB\xd5\xec&\xa8E7Dl\xf9f\xc6\x1a\xf3\x8a\x91\xc9:\xccg\xb7\x02\x00\xc0\xf0\xf5\xcc\x7f\xc6JH\xaa\xb9\x10\xbbS\xcc\f\f\xab\xe7\x1d\xa5\x14\x96ڗ\xac\x99\x91\xe3\x91\x13A\xae\xfa澐>+T{\xc9\x1a\x17\xadO\x05ؤf*\xb5W\xc5\xe4\xd7\x10<^\x83Q=\xbb\xe1d0\x97:\xac\x8ap<\xab\x00\xb1\xe1\x8c\x18\xb0M\xbe\x8d\x038\xe8b{LN\xb4d!cN\xba\x8f whAP\xb7\x83\x05a\xffp\x9dY\xbc\xc3UU\xbc\xe0\xe1*\x01S\xf4\xef\x8fA\t\x93\xec\xb1}Y\x19c\xc5Dk\\ڝ!\v\xe9mO\xb8Í\r\r\x9eG\x9a\x83QA+\xda\xdb\xf3HQᗊJT\xd3J\x81\rO!\xaa\xa9\xba\xd4;\x1f\\\xeaig\xecV j(\v\xfb\x86Zr?\x87n\xdfv3u\xa1\xac訞\x00+e\xa0x\xa8!\"D\x1fe\bQ\x00>]\xa4`\x101\x00V\f\xb4\xd6k&KP\xc0\xdeM\x80\x98\xb7\x97\x8c\\\xa0qv\xa1\xa5\x13\xe6Wyb\xf7\x83\x04\xc4\xd9~c.x9afq\xd4[o\xb8\xc9\xeb\xe1\xfd\x84\x1e\xf8\xec\xf6\x945}\x1c\xcb\x1a\xf7Hm洪\x85ˑ\x04\xdd]\x84\x84p\xdd\xd2iU\x9b*\x9dL\xf7\xe1t\xb1\x7f\xf32\xb2\x13\f\x9e\x1b\xf9\x12\x88\x89\xb2&\fW6\x8cGa%\xb4\xa5\x1b\x17\xaa+b\x04\x9dz\xec^\xa8l\xdd\xfd\x17*\x03\x95\xee\xc9@\x1f\xdf \xa4\xb930\x9ca\xb9s|\x9a\x95\x05\xb3(\xbb\x9e\r\xbc'[\xae$\xf7\x06\x9e\x96\x96;\xd1ǁ\xfb\xbb\xf0\xc7\x1d\x1dx4X\xde\xc3ގ\x95\xa1\xfd,\t%%\xc1\xa8\xf1Z\x98\xfc\x1c(P\xe7ƴ\xdeف\xc2S\x87\a\xccP_\x82D\x1e\x11l\xf1\x83\x960o)\f,\x9f\xaf\x95R\xc2\xca\u0603C\x18P\x88^\xbf\x14yU\xb1\xb0\xac\v&\x1d\xca\xf2\xc2\x14\x10YȘ\x02\xb9 \x89\xf9\x15{\xabt(\xc5b/ȸ!\xdd\a\x83\x8c\n!=\x91\r\xaa\xbc\xe2\x97\xefh\xce#փC\xc7T\xcfA0\x8f,\xad!b\x06G\xf3\xa6=\xf0Dҗ$T0v\xe3\xae\xd7f\xb0=\xa5\x137{`5\x17\x19q?\xe3[ɨ\x90o5z\xf7V\tU\xce'\xe9\xbe\x1546.J\xd6\x13mP\xf1<\xb4\x86ѡ4\xe7Fg\xa9\xd8;\xb9\x87\xc1\xf0#CӤO\x10\xb2\x90\x9e\x83\x0f7ʃH\xcdFz\xaek:\xae_6t\x92\xd1\xdc\xd64\x88\xf48p\xabT\x9f\xa8֎aA\xe6\xc9m\xa5+\x99\xf6\a=\x99\xf9ӕ<\x9bO\xcd\x17Ay\xf4\xa6)\xa8]\xebF\x97Sűw\x81\xc2\xf2HI]\x95'2\xd6dl7\xe4\xd1\xfd$=\xe9\x03:=.J\xf0\xed\xe6u(\xf7\xd5\xe3\xaazD\x86ٵ\xad\xc9<!\xf7\xb6<\xad\xda\"&\x13tT\xecv\x94\xfe\xf4\x01\xcf\x1a\x88\xb4\xefn\xc1\xfbъ{BB`\xa6\x8d\x93!R\xa5\x81J\xb8\x05-إ\xb7\x0eY\x1e&\x14b\x0f\x89p~\xd1\x11\xe2F\x97c&\xc7\xe3߉1\xef=V{\x18:)\xa8t\x17\x91\xc2\xcad\xd5r\xa1\xd7\n<\xab\x96\xef\xcei\xb9\x83\x87\xa3\xffQ\xba\xa0A\a\xc2\xc7\t*XТ\x02>>\xe1Jݾe)\xa2Dp\xcbl\xbb\x99\xfb\f\x92~\x84A'7\b\x97\xf8H'\xadɷ\x93\x00\xefy\x80\x03=\x14\xfb=\xa4,\xc5\xdf\xe5R|\x905\xf2\xe8ê\xdc\xfa\x0fs1\xfd\xc8\xd29#\xa2\xf4aֲ\x14\x87\x82I\x1f\x1d\x9eN,\xc6\xf4\xcb\xe3\xc8y\xa1\xa7_\x1f\xef辈ԯ\x8ew|0PuO\x8f/\x1b\xbfzzS\xf58wh\xfas\xba{\x1d\n\xabEF{\xeca\xfc\xfd<%\xc9|\x1b\xffс)\xa4=\x9dg*^\xf6\xcb\xfaώ\xe0g?\xbc\x1f\x9aEƻ<\f+'\xe1G^W2-x\xe2\xab\xfe\x8f\x8f\xa0\x1ey\xf4\xff\xf9=\x1dy\x99\x01\xf7!y\xe9\x03\xbf\xb8\v\xca\xc91\xf8\xc9\x11\xa0\xc4\x14\x84C\xca\x1c\xcfP\xf8\xe1!\xd8x\xf0\xf5\xd0Rܝ\xdf\xf0\xb8\xb6\xebK\xc6\xc3{yC\xcaσx/Ϛg\xa5Bd\xea}r\xa6D\xe6>\xe5&R\xe4z\xb1\xd1D\x8bLyM\xce\xc3\xc8T\xaf\x8c4\x8d\xccS 1\x8b\xe3\xfb\xf9\xa8\x87\x9f=.k\xad2i\x1f\x99^\xd2^2\xc8\xf3\x01q\x19\xb0`\xa4R^vk\x88\x88\x96~\x90\xa7\xa5\x1a5\xfdR\x92\xa9Q\x1a\xbf\xc0\xa3|\x9cTS1\x84/I\x99\xfe\x8aA&\xa3\xc0\xec\x8at2\x84\xa5\xee\xd4,\x83\xbe\xfd\xaf\xc4w\xa1\xee\xe4\xf0d:+\x16\xf2rꉊl4\xbal\x97w\xff\xb6\xf0\xc6Z\xfe5\xa8\x1c\xcfw\xf2\xc6\x13q\xf02\xd1\xf6\x16*\xd3F$\xa7@e\xee\xa9ʄr\xdc\xf2ޫ\xb9Ӳ%\xa7]e\x9a\xaac\xc9X\x99\x17\xba\xcc|\xac̣$)]+\xd3\\\xe5ds\x1d\x1a\xee^\xb2W\xa6\xe6\x1f\xcd\x05\xfb\xe9=\xdd\u0604\xb1\xfbPLV١5<\x98t\x16\xf0\x9e%\xde~.КI\x0e\xfc\xbbi\x03?\x92\xf4\x03\x9f\xe2\xc3\xd0\x02\x81\x88\x8c\xaa\xc8\xcc\xfe\xd9\xc1N\xd1ۿd\xd8t\t\x1a\x8d\xe3\xca\x15\x80\xff\x05\xb7\ax\x7f>w\x04=\xfd\x12\x93vpX༛F\xce\"G\xaf\x19i~\xe8\x02F\x19i\x89\x1ad\xa3\xcb\xc7ε\x052\xe9ڒf\x1e\x16\xd0\xc4;K\xee\xf4\x13.,i\xf6`\x81<|[q\f\x92RS}UI\xbbA\xab\x01\f\xe8iɟT\xc7\xd1\b꼓.\xed\xd9Ja\xbf\x88\xff\xa7\xa0\xd8\xec\x85\xeaG\x86\xd6\x10\xbby\xa7{h\xbc\xeap}ѡ\xdf\xceR\xf7\f\xd0\xf5\xfa\xda-\x87/\v\x90\x91\xb6\xd5!\xc7\xd6\x10\xe9\xaf߾dd\x98R\x93\xf8\xe7\x1e(d\xa9|\x11\x83j\xe1\xd2\r\xea\xf7\xf2\x06\x9f\x16\x12J\xb3\xd2\v\xe8\xff\xc1J/\xe0\xbbV:ͤ.`/hR\x17\xd0\x175\xa9\x0e\xecK\x99\xd4\x05\xf2\xb0I\xe5\x8b\xe2X\xb4\xfd$8g\x00\xfb?\x1b\xe7'\x1f\x84\xb3(ԯ\x8eE\xb2(\xfc\x8fғ\x94`\xb2\xaa\x8fSTd\xea0\x13\xf8I\xa7\x1a8\xf4\xbcz\xf8t\x13\xdaᅙ\x10\x00\xe8\x8c\xcf&\xb0\xdd\xe8r,\xfd\x05 (RK\x84*\xbbi\x1d0\xef\br\v$\xf4\xe6\xabb\xf8\x9dƄ\x9e\x82\x89p\xd8D\xa9\xba\x9ap\xf5\xd9j\x1b\xe4g\xa6\x99Ԙ\vFo\x1b?\xf0%\x13\xd8U\xfb\xc6?\x87xS\x90C,\aT\x19\xf3kH\xb8\x900\x11\x12\xe0\xe8<ò\xc6\xeaW#\xcfnŲ\xab\xfb\x82\xebc\xc2oϼ\xa3L(\xe5\xf9\xa4BӴ\xf5C\x9d\xe6'\xf5v~Q\xd0\xfer\xdd\xde\xcf\xeeE~\x03ʹ.?\xf8\xb5\xfbSi\xee\xafFD~\x19\xcc\xcbw\x8d\xfd\xc2DB6\xa2\xfb\x85\x9fa\x15M^L2&\xfe7`\x1bS\xec\xcf\xff\x00\x00\x00\xff\xff\x01\x00\x00\xff\xff\x80\x16\xe4\xfd\x8fU\x00\x00"))
 }

--- a/api/core/schema.yml
+++ b/api/core/schema.yml
@@ -27,6 +27,24 @@ kinds:
       type: ref
       doc: The version of the project that should be used
 
+    active_deployment:
+      type: ref
+      doc: The deployment attempt that made active_version current
+
+    deployment_lock:
+      type: component
+      doc: The expiring lock held by the deployment currently mutating this app
+      attrs:
+        deployment_id:
+          type: string
+          doc: The deployment attempt that owns the lock
+        acquired_at:
+          type: time
+          doc: When the lock was taken
+        expires_at:
+          type: time
+          doc: When another deployment may take over the lock
+
     initial_config:
       type: ref
       doc: Reference to the initial ConfigVersion entity created before the first deploy
@@ -71,6 +89,20 @@ kinds:
     version:
       type: string
       doc: The version of this app
+
+    source:
+      type: component
+      doc: Sanitized source provenance captured when this version was built
+      attrs:
+        git_sha:
+          type: string
+          doc: Git commit SHA used to build the version
+        git_branch:
+          type: string
+          doc: Git branch used to build the version
+        repository:
+          type: string
+          doc: Repository URL without credentials, query parameters, or fragments
 
     image_url:
       type: string
@@ -289,65 +321,95 @@ kinds:
       indexed: true
 
   deployment:
-    app_name:
-      type: string
-      doc: The name of the app being deployed
+    # Canonical immutable-attempt fields.
+    app:
+      type: ref
+      doc: The app this attempt targeted
       indexed: true
-    
-    app_version:
-      type: string
-      doc: The app version ID or temporary value (pending-build, failed-{id})
-    
-    cluster_id:
-      type: string
-      doc: The cluster where the deployment is happening
+
+    version:
+      type: ref
+      doc: The app version produced or selected by this attempt
       indexed: true
-    
-    status:
+
+    parent_deployment:
+      type: ref
+      doc: Optional deployment this attempt was based on
+
+    operation:
       type: string
-      doc: Deployment status (in_progress, active, failed, rolled_back)
+      doc: The intent of this attempt
+
+    outcome:
+      type: string
+      doc: Terminal result of this attempt; absent while the attempt is in progress
       indexed: true
-    
+
     phase:
       type: string
-      doc: Current phase of deployment (preparing, building, pushing, activating)
-    
+      doc: Last progress phase observed while the attempt was in progress
+
+    started_at:
+      type: time
+      doc: When the attempt acquired the deployment lock
+
+    completed_at:
+      type: string
+      doc: RFC3339 time when the attempt reached a terminal outcome
+
+    app_name:
+      type: string
+      doc: "[DEPRECATED] Denormalized app name retained for downgrade compatibility; canonical identity is app"
+      indexed: true
+
+    app_version:
+      type: string
+      doc: "[DEPRECATED] Version value retained for downgrade compatibility; use version"
+
+    cluster_id:
+      type: string
+      doc: "[DEPRECATED] Client-supplied cluster display value; coordinator storage is cluster-scoped"
+      indexed: true
+
+    status:
+      type: string
+      doc: "[DEPRECATED] Mutable lifecycle status retained for downgrade compatibility; use outcome and app.active_deployment"
+      indexed: true
+
     deployed_by:
       type: component
       doc: Information about who initiated the deployment
       attrs:
         user_id:
           type: string
-          doc: The ID of the user who deployed
+          doc: "[DEPRECATED] Caller-supplied user ID retained for compatibility"
         user_name:
           type: string
-          doc: The username of the user who deployed
+          doc: "[DEPRECATED] Caller-supplied username retained for compatibility"
         user_email:
           type: string
-          doc: The email of the user who deployed
+          doc: "[DEPRECATED] Caller-supplied email retained for compatibility"
         timestamp:
           type: string
-          doc: When the deployment was initiated (RFC3339 format)
-    
-    completed_at:
-      type: string
-      doc: When the deployment was completed (RFC3339 format)
-    
+          doc: "[DEPRECATED] RFC3339 start time retained for compatibility; use started_at"
+        subject:
+          type: string
+          doc: Stable subject from the server-authenticated RPC identity
+        auth_method:
+          type: string
+          doc: Authentication method used by the initiating subject
+
     error_message:
       type: string
-      doc: Error message if deployment failed
-    
-    build_logs:
-      type: string
-      doc: Build logs concatenated with newlines (especially useful for failed deployments)
+      doc: "[DEPRECATED] Bounded failure summary retained until lifecycle errors are queryable from the log stream"
 
     source_deployment_id:
       type: string
-      doc: ID of the deployment this was based on (for rollback/redeploy provenance)
+      doc: "[DEPRECATED] Lineage ID retained for downgrade compatibility; use parent_deployment"
 
     git_info:
       type: component
-      doc: Git information at time of deployment
+      doc: "[DEPRECATED] Build provenance retained for compatibility; stable source identity lives on AppVersion.source"
       attrs:
         sha:
           type: string
@@ -376,30 +438,6 @@ kinds:
         repository:
           type: string
           doc: Git repository remote URL
-
-  deployment_lock:
-    app_name:
-      type: string
-      doc: >
-        The app this lock covers. The lock is app-scoped, not app+cluster: a
-        coordinator's store only holds its own cluster's deployments, and the
-        client-supplied cluster_id is unreliable (see MIR-1465).
-      indexed: true
-
-    deployment_id:
-      type: string
-      doc: The deployment currently holding the lock
-
-    acquired_at:
-      type: time
-      doc: When the lock was taken
-
-    expires_at:
-      type: time
-      doc: >
-        When the lock may be stolen by another deployment. A holder whose
-        deployment reached a terminal status is stealable before this too.
-      indexed: true
 
   config_version:
     app:

--- a/api/deployment/rpc.yml
+++ b/api/deployment/rpc.yml
@@ -14,9 +14,9 @@ interfaces:
       - name: CreateDeployment
         index: 0
         doc: >
-          [DEPRECATED] The build server now owns the deployment record lifecycle
-          (see the build service DeployRequest). Retained so an older CLI still
-          works against a newer server. Do not add new callers.
+          [DEPRECATED] The build server owns the deployment record lifecycle
+          (see the build service DeployRequest). Retained on the wire so older
+          clients receive an explicit upgrade error. Do not add new callers.
         parameters:
           - name: app_name
             type: string

--- a/api/deployment/rpc.yml
+++ b/api/deployment/rpc.yml
@@ -14,7 +14,7 @@ interfaces:
       - name: CreateDeployment
         index: 0
         doc: >
-          DEPRECATED: The build server now owns the deployment record lifecycle
+          [DEPRECATED] The build server now owns the deployment record lifecycle
           (see the build service DeployRequest). Retained so an older CLI still
           works against a newer server. Do not add new callers.
         parameters:
@@ -44,7 +44,7 @@ interfaces:
       - name: UpdateDeploymentStatus
         index: 1
         doc: >
-          DEPRECATED: superseded by server-owned deployment lifecycle. Retained
+          [DEPRECATED] superseded by server-owned deployment lifecycle. Retained
           for older CLIs. Do not add new callers.
         parameters:
           - name: deployment_id
@@ -64,7 +64,7 @@ interfaces:
       - name: UpdateDeploymentPhase
         index: 2
         doc: >
-          DEPRECATED: superseded by server-owned deployment lifecycle. Retained
+          [DEPRECATED] superseded by server-owned deployment lifecycle. Retained
           for older CLIs. Do not add new callers.
         parameters:
           - name: deployment_id
@@ -81,7 +81,7 @@ interfaces:
       - name: UpdateFailedDeployment
         index: 3
         doc: >
-          DEPRECATED: superseded by server-owned deployment lifecycle. Retained
+          [DEPRECATED] superseded by server-owned deployment lifecycle. Retained
           for older CLIs. Do not add new callers.
         parameters:
           - name: deployment_id
@@ -92,7 +92,7 @@ interfaces:
             doc: Error message describing the failure
           - name: build_logs
             type: string
-            doc: Build logs from the failed deployment
+            doc: "[DEPRECATED] accepted and ignored; build output lives in the log stream"
         results:
           - name: deployment
             type: DeploymentInfo
@@ -101,7 +101,7 @@ interfaces:
       - name: UpdateDeploymentAppVersion
         index: 4
         doc: >
-          DEPRECATED: superseded by server-owned deployment lifecycle. Retained
+          [DEPRECATED] superseded by server-owned deployment lifecycle. Retained
           for older CLIs. Do not add new callers.
         parameters:
           - name: deployment_id
@@ -364,11 +364,11 @@ types:
       - name: error_message
         type: string
         index: 10
-        doc: Error message if deployment failed (optional)
+        doc: "[DEPRECATED] Bounded failure summary retained until lifecycle errors are queryable from the log stream"
       - name: build_logs
         type: string
         index: 11
-        doc: Build logs from the deployment (especially for failures)
+        doc: "[DEPRECATED] reserved for wire compatibility; servers no longer populate it"
       - name: git_info
         type: GitInfo
         index: 12
@@ -376,7 +376,7 @@ types:
       - name: source_deployment_id
         type: string
         index: 22
-        doc: ID of the source deployment (set for rollback/redeploy, empty for fresh builds)
+        doc: ID of the deployment this attempt was based on
       - name: short_id
         type: string
         index: 23

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -48,6 +48,7 @@ import (
 	artifactctrl "miren.dev/runtime/controllers/artifact"
 	certctrl "miren.dev/runtime/controllers/certificate"
 	deploymentctrl "miren.dev/runtime/controllers/deployment"
+	deploymentattemptsctrl "miren.dev/runtime/controllers/deploymentattempts"
 	ephemeralctrl "miren.dev/runtime/controllers/ephemeral"
 	indexgcctrl "miren.dev/runtime/controllers/indexgc"
 	keyrotationctrl "miren.dev/runtime/controllers/keyrotation"
@@ -386,6 +387,7 @@ type Coordinator struct {
 
 	state *rpc.State
 	eac   *esv1.EntityAccessClient // Entity access client for querying entities
+	store entity.Store
 
 	aa            activator.AppActivator
 	spm           *sandboxpool.Manager
@@ -448,6 +450,15 @@ func (c *Coordinator) SandboxPoolManager() *sandboxpool.Manager {
 
 func (c *Coordinator) HttpIngress() *httpingress.Server {
 	return c.hs
+}
+
+// NewDeploymentAttemptController returns the migration controller after the
+// coordinator has opened its entity store. The caller owns its lifecycle.
+func (c *Coordinator) NewDeploymentAttemptController() (*deploymentattemptsctrl.Controller, error) {
+	if c.store == nil || c.eac == nil {
+		return nil, errors.New("coordinator entity store is not ready")
+	}
+	return deploymentattemptsctrl.New(c.Log, c.store, c.eac), nil
 }
 
 // RecoverBuildSagas resumes in-flight build sagas left by a previous
@@ -1034,6 +1045,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		c.Log.Error("failed to create etcd store", "error", err)
 		return err
 	}
+	c.store = etcdStore
 
 	err = schema.Apply(ctx, etcdStore)
 	if err != nil {

--- a/components/server/boot_deployment_attempt_migration.go
+++ b/components/server/boot_deployment_attempt_migration.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package server
+
+import (
+	"context"
+
+	deploymentattemptsctrl "miren.dev/runtime/controllers/deploymentattempts"
+	"miren.dev/runtime/pkg/boot"
+)
+
+// deploymentAttemptMigrationBoot owns the controller's background lifecycle.
+type deploymentAttemptMigrationBoot struct {
+	component  *boot.Component
+	controller *deploymentattemptsctrl.Controller
+}
+
+func newDeploymentAttemptMigrationBoot(coordinator boot.Output[coordinatorBootOutput]) *deploymentAttemptMigrationBoot {
+	b := &deploymentAttemptMigrationBoot{}
+	b.component = boot.Run1("deployment-attempt-migration", coordinator, b.start,
+		boot.WithStop(b.stop, componentStopTimeout),
+	)
+	return b
+}
+
+func (b *deploymentAttemptMigrationBoot) start(ctx context.Context, coordinator coordinatorBootOutput) error {
+	controller, err := coordinator.coordinator.NewDeploymentAttemptController()
+	if err != nil {
+		return err
+	}
+	b.controller = controller
+	b.controller.Start(ctx)
+	return nil
+}
+
+func (b *deploymentAttemptMigrationBoot) stop(context.Context) error {
+	if b.controller != nil {
+		b.controller.Stop()
+	}
+	return nil
+}

--- a/components/server/runtime.go
+++ b/components/server/runtime.go
@@ -78,6 +78,7 @@ func (s *startup) addComponents() error {
 		s.victoriaMetrics.component,
 		s.buildkit.component,
 		s.coordinator.component,
+		s.deploymentAttempts.component,
 		s.entityAccess.component,
 		s.appMetrics.component,
 		s.network.component,

--- a/components/server/startup.go
+++ b/components/server/startup.go
@@ -37,6 +37,7 @@ type startup struct {
 	victoriaMetrics     *victoriaMetricsBoot
 	buildkit            *buildkitBoot
 	coordinator         *coordinatorBoot
+	deploymentAttempts  *deploymentAttemptMigrationBoot
 	entityAccess        *entityAccessBoot
 	appMetrics          *appMetricsBoot
 	network             *networkBoot
@@ -84,6 +85,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 		buildkit.output,
 		observability.output,
 	)
+	deploymentAttempts := newDeploymentAttemptMigrationBoot(coordinator.output)
 	entityAccess := newEntityAccessBoot(entityAccessInputs(options), coordinator.output, observability.output)
 	appMetrics := newAppMetricsBoot(
 		appMetricsInputs(options),
@@ -128,6 +130,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 		victoriaMetrics:     victoriaMetrics,
 		buildkit:            buildkit,
 		coordinator:         coordinator,
+		deploymentAttempts:  deploymentAttempts,
 		entityAccess:        entityAccess,
 		appMetrics:          appMetrics,
 		network:             network,

--- a/controllers/deploymentattempts/controller.go
+++ b/controllers/deploymentattempts/controller.go
@@ -1,0 +1,337 @@
+// Package deploymentattempts backfills canonical deployment attempts and
+// continuously repairs the activation crash window.
+package deploymentattempts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/deploylifecycle"
+	"miren.dev/runtime/pkg/entity"
+)
+
+const (
+	phaseDeployments = "deployments"
+	phaseVersions    = "app_versions"
+	phaseApps        = "apps"
+	phaseReconcile   = "reconcile"
+
+	// Older CLIs embedded the complete BuildKit output in the deployment
+	// entity. Keep the literal after removing the attribute from the generated
+	// schema so the migration can physically evict existing payloads.
+	legacyDeploymentBuildLogs = entity.Id("dev.miren.core/deployment.build_logs")
+)
+
+type Config struct {
+	Interval  time.Duration
+	BatchSize int64
+}
+
+func DefaultConfig() Config {
+	return Config{Interval: 10 * time.Second, BatchSize: 200}
+}
+
+type Controller struct {
+	Log     *slog.Logger
+	Store   entity.Store
+	Tracker *deploylifecycle.Tracker
+	Config  Config
+	cancel  context.CancelFunc
+
+	// Canonical fields on the records are the durable migration ledger. These
+	// fields only bound this process's scan; a restart begins at the front and
+	// cheaply skips work that the previous process completed.
+	phase               string
+	cursor              string
+	passFailed          bool
+	firstCleanSweepOnce sync.Once
+}
+
+func New(log *slog.Logger, store entity.Store, eac *entityserver_v1alpha.EntityAccessClient) *Controller {
+	return &Controller{
+		Log: log.With("module", "deployment-attempts"), Store: store,
+		Tracker: deploylifecycle.NewTracker(log, eac), Config: DefaultConfig(),
+	}
+}
+
+func (c *Controller) Start(ctx context.Context) {
+	if c.Config.Interval <= 0 {
+		c.Config.Interval = DefaultConfig().Interval
+	}
+	if c.Config.BatchSize <= 0 {
+		c.Config.BatchSize = DefaultConfig().BatchSize
+	}
+	ctx, c.cancel = context.WithCancel(ctx)
+	go c.run(ctx)
+}
+
+func (c *Controller) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func (c *Controller) run(ctx context.Context) {
+	for {
+		if err := c.Step(ctx); err != nil && ctx.Err() == nil {
+			c.Log.Warn("deployment-attempt migration pass failed", "error", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(c.Config.Interval):
+		}
+	}
+}
+
+// Step processes one bounded page. It is public so tests and operators can
+// drive convergence without waiting for the loop.
+func (c *Controller) Step(ctx context.Context) error {
+	if c.phase == "" {
+		c.phase = phaseDeployments
+	}
+
+	kind, migrate := c.phaseWork(c.phase)
+	page, err := c.Store.ListIndexPage(ctx, entity.Ref(entity.EntityKind, kind), c.cursor, c.Config.BatchSize)
+	if err != nil {
+		return err
+	}
+	entities, err := c.Store.GetEntities(ctx, page.Ids)
+	if err != nil {
+		return err
+	}
+	var migrateErrs []error
+	for _, ent := range entities {
+		if err := migrate(ctx, ent); err != nil {
+			wrapped := fmt.Errorf("migrating %s in phase %s: %w", ent.Id(), c.phase, err)
+			migrateErrs = append(migrateErrs, wrapped)
+			c.passFailed = true
+			c.Log.Warn("deployment-attempt migration skipped a record",
+				"id", ent.Id(), "phase", c.phase, "error", err)
+		}
+	}
+
+	if page.Cursor != "" {
+		c.cursor = page.Cursor
+		return errors.Join(migrateErrs...)
+	}
+
+	c.cursor = ""
+	switch c.phase {
+	case "", phaseDeployments:
+		c.phase = phaseVersions
+	case phaseVersions:
+		c.phase = phaseApps
+	case phaseApps:
+		c.phase = phaseReconcile
+	case phaseReconcile:
+		if c.passFailed {
+			c.Log.Warn("deployment-attempt sweep completed with migration failures")
+			c.passFailed = false
+		} else {
+			c.firstCleanSweepOnce.Do(func() {
+				c.Log.Info("deployment-attempt migration and reconciliation initial pass complete")
+			})
+		}
+		// Keep scanning forever. This catches records written by a downgraded
+		// runtime and continuously closes future activation crash windows.
+		c.phase = phaseDeployments
+	}
+	return errors.Join(migrateErrs...)
+}
+
+func (c *Controller) phaseWork(phase string) (entity.Id, func(context.Context, *entity.Entity) error) {
+	switch phase {
+	case phaseVersions:
+		return core_v1alpha.KindAppVersion, c.migrateVersion
+	case phaseApps:
+		return core_v1alpha.KindApp, c.migrateApp
+	case phaseReconcile:
+		return core_v1alpha.KindDeployment, c.reconcileDeployment
+	default:
+		return core_v1alpha.KindDeployment, c.migrateDeployment
+	}
+}
+
+func (c *Controller) migrateDeployment(ctx context.Context, ent *entity.Entity) error {
+	if _, ok := ent.Get(legacyDeploymentBuildLogs); ok {
+		clean := ent.Clone()
+		clean.Remove(legacyDeploymentBuildLogs)
+		var err error
+		ent, err = c.Store.ReplaceEntity(ctx, clean, entity.WithFromRevision(ent.GetRevision()))
+		if err != nil {
+			return fmt.Errorf("removing embedded build logs: %w", err)
+		}
+	}
+
+	var dep core_v1alpha.Deployment
+	dep.Decode(ent)
+	rec := &deploylifecycle.Record{Deployment: &dep}
+	if rec.Canonical() {
+		return nil
+	}
+
+	var outcome string
+	switch deploylifecycle.Status(dep.Status) {
+	case deploylifecycle.StatusInProgress:
+		// A running attempt has no outcome. Its canonical started_at/app refs
+		// below distinguish it from an unmigrated legacy record.
+	case deploylifecycle.StatusActive, deploylifecycle.StatusSucceeded, deploylifecycle.StatusRolledBack:
+		outcome = string(deploylifecycle.StatusSucceeded)
+	case deploylifecycle.StatusFailed:
+		outcome = string(deploylifecycle.StatusFailed)
+	case deploylifecycle.StatusCancelled:
+		outcome = string(deploylifecycle.StatusCancelled)
+	case deploylifecycle.StatusInterrupted:
+		outcome = string(deploylifecycle.StatusInterrupted)
+	default:
+		return nil
+	}
+
+	attrs := []entity.Attr{entity.Ref(entity.DBId, dep.ID)}
+	if outcome != "" {
+		attrs = append(attrs,
+			entity.String(core_v1alpha.DeploymentOutcomeId, outcome))
+	}
+	if dep.AppName != "" {
+		if app, err := c.Store.GetEntity(ctx, entity.Id("app/"+dep.AppName)); err == nil {
+			attrs = append(attrs, entity.Ref(core_v1alpha.DeploymentAppId, app.Id()))
+		}
+	}
+	if version := legacyVersion(dep.AppVersion, string(dep.ID)); version != "" {
+		if v := c.legacyAppVersion(ctx, version); v != nil {
+			attrs = append(attrs, entity.Ref(core_v1alpha.DeploymentVersionId, v.Id()))
+		}
+	}
+	if dep.SourceDeploymentId != "" {
+		if parent, err := c.Store.GetEntity(ctx, entity.Id(dep.SourceDeploymentId)); err == nil {
+			attrs = append(attrs, entity.Ref(core_v1alpha.DeploymentParentDeploymentId, parent.Id()))
+		}
+	}
+	if started, err := time.Parse(time.RFC3339, dep.DeployedBy.Timestamp); err == nil {
+		attrs = append(attrs, entity.Time(core_v1alpha.DeploymentStartedAtId, started))
+	}
+	_, err := c.Store.PatchEntity(ctx, entity.New(attrs), entity.WithFromRevision(ent.GetRevision()))
+	return err
+}
+
+func (c *Controller) legacyAppVersion(ctx context.Context, ref string) *entity.Entity {
+	candidates := []entity.Id{entity.Id(ref)}
+	if len(ref) < len("app_version/") || ref[:len("app_version/")] != "app_version/" {
+		candidates = append(candidates, entity.Id("app_version/"+ref))
+	}
+	for _, id := range candidates {
+		if version, err := c.Store.GetEntity(ctx, id); err == nil && entity.Is(version, core_v1alpha.KindAppVersion) {
+			return version
+		}
+	}
+	return nil
+}
+
+func (c *Controller) migrateVersion(ctx context.Context, ent *entity.Entity) error {
+	var version core_v1alpha.AppVersion
+	version.Decode(ent)
+	if !version.Source.Empty() {
+		return nil
+	}
+
+	ids, err := c.Store.ListIndex(ctx, entity.Ref(core_v1alpha.DeploymentVersionId, version.ID))
+	if err != nil {
+		return err
+	}
+	deployments, err := c.Store.GetEntities(ctx, ids)
+	if err != nil {
+		return err
+	}
+	var consensus core_v1alpha.Source
+	haveConsensus := false
+	for _, raw := range deployments {
+		var dep core_v1alpha.Deployment
+		dep.Decode(raw)
+		source := deploylifecycle.SourceFromGitInfo(dep.GitInfo)
+		if source.Empty() {
+			continue
+		}
+		if !haveConsensus {
+			consensus = source
+			haveConsensus = true
+		} else if consensus != source {
+			return nil
+		}
+	}
+	if !haveConsensus || consensus.Empty() {
+		return nil
+	}
+	patch := entity.New(
+		entity.Ref(entity.DBId, version.ID),
+		entity.Component(core_v1alpha.AppVersionSourceId, consensus.Encode()),
+	)
+	_, err = c.Store.PatchEntity(ctx, patch, entity.WithFromRevision(ent.GetRevision()))
+	return err
+}
+
+func (c *Controller) migrateApp(ctx context.Context, ent *entity.Entity) error {
+	var app core_v1alpha.App
+	app.Decode(ent)
+	if app.ActiveVersion == "" {
+		return nil
+	}
+	if app.ActiveDeployment != "" {
+		if raw, err := c.Store.GetEntity(ctx, app.ActiveDeployment); err == nil {
+			var current core_v1alpha.Deployment
+			current.Decode(raw)
+			if current.Version == app.ActiveVersion {
+				return nil
+			}
+		}
+	}
+	ids, err := c.Store.ListIndex(ctx, entity.Ref(core_v1alpha.DeploymentVersionId, app.ActiveVersion))
+	if err != nil {
+		return err
+	}
+	var candidate entity.Id
+	for _, id := range ids {
+		raw, err := c.Store.GetEntity(ctx, id)
+		if err != nil {
+			continue
+		}
+		var dep core_v1alpha.Deployment
+		dep.Decode(raw)
+		if dep.App == app.ID && dep.Status == string(deploylifecycle.StatusActive) {
+			if candidate != "" {
+				return nil
+			}
+			candidate = dep.ID
+		}
+	}
+	if candidate == "" {
+		return nil
+	}
+	_, err = c.Store.PatchEntity(ctx, entity.New(
+		entity.Ref(entity.DBId, app.ID),
+		entity.Ref(core_v1alpha.AppActiveDeploymentId, candidate),
+	), entity.WithFromRevision(ent.GetRevision()))
+	return err
+}
+
+func (c *Controller) reconcileDeployment(ctx context.Context, ent *entity.Entity) error {
+	if err := c.Tracker.Reconcile(ctx, string(ent.Id())); err != nil &&
+		!errors.Is(err, cond.ErrConflict{}) && !errors.Is(err, cond.ErrNotFound{}) {
+		return err
+	}
+	return nil
+}
+
+func legacyVersion(version, deploymentID string) string {
+	if version == "pending-build" || version == "failed-"+deploymentID {
+		return ""
+	}
+	return version
+}

--- a/controllers/deploymentattempts/controller_test.go
+++ b/controllers/deploymentattempts/controller_test.go
@@ -1,0 +1,349 @@
+package deploymentattempts
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/deploylifecycle"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+)
+
+type migrationFailStore struct {
+	entity.Store
+	fail entity.Id
+}
+
+func (s *migrationFailStore) ReplaceEntity(ctx context.Context, ent *entity.Entity, opts ...entity.EntityOption) (*entity.Entity, error) {
+	if ent.Id() == s.fail {
+		return nil, errors.New("injected migration failure")
+	}
+	return s.Store.ReplaceEntity(ctx, ent, opts...)
+}
+
+func (s *migrationFailStore) PatchEntity(ctx context.Context, ent *entity.Entity, opts ...entity.EntityOption) (*entity.Entity, error) {
+	if ent.Id() == s.fail {
+		return nil, errors.New("injected migration failure")
+	}
+	return s.Store.PatchEntity(ctx, ent, opts...)
+}
+
+func TestInitialPassMigratesCanonicalGraphAndProvenance(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	app := &core_v1alpha.App{ID: "app/web", ActiveVersion: "app_version/v1"}
+	version := &core_v1alpha.AppVersion{ID: "app_version/v1", App: app.ID, Version: "web-v1"}
+	parentID := entity.Id("deployment/parent")
+	started := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	finished := started.Add(time.Minute)
+	dep := &core_v1alpha.Deployment{
+		ID: "deployment/legacy", AppName: "web", AppVersion: string(version.ID),
+		Status: "active", Phase: "activating", SourceDeploymentId: string(parentID),
+		DeployedBy:  core_v1alpha.DeployedBy{Timestamp: started.Format(time.RFC3339)},
+		CompletedAt: finished.Format(time.RFC3339),
+		GitInfo: core_v1alpha.GitInfo{
+			Sha: "abc123", Branch: "main",
+			Repository: "https://user:secret@example.com/acme/web.git?token=nope#frag",
+		},
+	}
+	_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, parentID)))
+	require.NoError(t, err)
+	for _, model := range []interface{ Encode() []entity.Attr }{app, version, dep} {
+		attrs := model.Encode()
+		var id entity.Id
+		switch v := model.(type) {
+		case *core_v1alpha.App:
+			id = v.ID
+		case *core_v1alpha.AppVersion:
+			id = v.ID
+		case *core_v1alpha.Deployment:
+			id = v.ID
+		}
+		_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, id), attrs))
+		require.NoError(t, err)
+	}
+
+	controller := New(log, inmem.Store, inmem.EAC)
+	controller.Config.BatchSize = 100
+	for range 4 {
+		require.NoError(t, controller.Step(ctx))
+	}
+
+	rawDep, err := inmem.Store.GetEntity(ctx, dep.ID)
+	require.NoError(t, err)
+	var migratedDep core_v1alpha.Deployment
+	migratedDep.Decode(rawDep)
+	assert.Equal(t, app.ID, migratedDep.App)
+	assert.Equal(t, version.ID, migratedDep.Version)
+	assert.Equal(t, string(deploylifecycle.StatusSucceeded), migratedDep.Outcome)
+	assert.Equal(t, "activating", migratedDep.Phase)
+	assert.Equal(t, started, migratedDep.StartedAt)
+	assert.Equal(t, finished.Format(time.RFC3339), migratedDep.CompletedAt)
+	assert.Equal(t, parentID, migratedDep.ParentDeployment)
+	assert.Empty(t, migratedDep.Operation, "migration must not invent intent")
+	assert.Equal(t, "active", migratedDep.Status, "legacy representation is retained")
+
+	rawVersion, err := inmem.Store.GetEntity(ctx, version.ID)
+	require.NoError(t, err)
+	var migratedVersion core_v1alpha.AppVersion
+	migratedVersion.Decode(rawVersion)
+	assert.Equal(t, "abc123", migratedVersion.Source.GitSha)
+	assert.Equal(t, "main", migratedVersion.Source.GitBranch)
+	assert.Equal(t, "https://example.com/acme/web.git", migratedVersion.Source.Repository)
+
+	rawApp, err := inmem.Store.GetEntity(ctx, app.ID)
+	require.NoError(t, err)
+	var migratedApp core_v1alpha.App
+	migratedApp.Decode(rawApp)
+	assert.Equal(t, dep.ID, migratedApp.ActiveDeployment)
+
+}
+
+func TestDeploymentMigrationRediscoversProgressAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	for _, id := range []entity.Id{"deployment/one", "deployment/two"} {
+		dep := &core_v1alpha.Deployment{ID: id, AppName: "web", Status: "failed"}
+		_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, id), dep.Encode()))
+		require.NoError(t, err)
+	}
+
+	first := New(log, inmem.Store, inmem.EAC)
+	first.Config.BatchSize = 1
+	require.NoError(t, first.Step(ctx))
+	assert.NotEmpty(t, first.cursor)
+
+	// Process-local scan position is deliberately lost. The new controller
+	// starts at the front, observes that the first record is already canonical,
+	// then advances to the remaining legacy record on its next bounded step.
+	second := New(log, inmem.Store, inmem.EAC)
+	second.Config.BatchSize = 1
+	require.NoError(t, second.Step(ctx))
+	require.NoError(t, second.Step(ctx))
+
+	canonical := 0
+	for _, id := range []entity.Id{"deployment/one", "deployment/two"} {
+		raw, err := inmem.Store.GetEntity(ctx, id)
+		require.NoError(t, err)
+		var dep core_v1alpha.Deployment
+		dep.Decode(raw)
+		if dep.Outcome == "failed" {
+			canonical++
+		}
+	}
+	assert.Equal(t, 2, canonical)
+}
+
+func TestVersionMigrationIgnoresDeploymentsWithoutProvenance(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	version := &core_v1alpha.AppVersion{ID: "app_version/v1", App: "app/web", Version: "web-v1"}
+	deployments := []*core_v1alpha.Deployment{
+		{ID: "deployment/a-no-source", Version: version.ID},
+		{
+			ID: "deployment/z-with-source", Version: version.ID,
+			GitInfo: core_v1alpha.GitInfo{
+				Sha: "abc123", Branch: "main", Repository: "https://example.com/acme/web.git",
+			},
+		},
+	}
+	_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, version.ID), version.Encode()))
+	require.NoError(t, err)
+	for _, deployment := range deployments {
+		_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, deployment.ID), deployment.Encode()))
+		require.NoError(t, err)
+	}
+
+	raw, err := inmem.Store.GetEntity(ctx, version.ID)
+	require.NoError(t, err)
+	controller := New(log, inmem.Store, inmem.EAC)
+	require.NoError(t, controller.migrateVersion(ctx, raw))
+
+	raw, err = inmem.Store.GetEntity(ctx, version.ID)
+	require.NoError(t, err)
+	var migrated core_v1alpha.AppVersion
+	migrated.Decode(raw)
+	assert.Equal(t, "abc123", migrated.Source.GitSha)
+	assert.Equal(t, "main", migrated.Source.GitBranch)
+	assert.Equal(t, "https://example.com/acme/web.git", migrated.Source.Repository)
+}
+
+func TestMigrationFailureDoesNotBlockLaterPhases(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dep := &core_v1alpha.Deployment{ID: "deployment/broken", AppName: "web", Status: "failed"}
+	_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, dep.ID), dep.Encode()))
+	require.NoError(t, err)
+
+	failing := &migrationFailStore{Store: inmem.Store, fail: dep.ID}
+	controller := New(log, failing, inmem.EAC)
+	controller.Config.BatchSize = 100
+	require.Error(t, controller.Step(ctx))
+	for range 3 {
+		require.NoError(t, controller.Step(ctx))
+	}
+	assert.Equal(t, phaseDeployments, controller.phase,
+		"a bad record must not prevent later phases from running")
+
+	failing.fail = ""
+	for range 4 {
+		require.NoError(t, controller.Step(ctx))
+	}
+}
+
+func TestMigrationLeavesRunningAttemptWithoutOutcome(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	started := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	app := &core_v1alpha.App{ID: "app/web"}
+	dep := &core_v1alpha.Deployment{
+		ID: "deployment/running", AppName: "web", Status: "in_progress", Phase: "building",
+		DeployedBy: core_v1alpha.DeployedBy{Timestamp: started.Format(time.RFC3339)},
+	}
+	for id, attrs := range map[entity.Id][]entity.Attr{app.ID: app.Encode(), dep.ID: dep.Encode()} {
+		_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, id), attrs))
+		require.NoError(t, err)
+	}
+
+	controller := New(log, inmem.Store, inmem.EAC)
+	require.NoError(t, controller.Step(ctx))
+
+	raw, err := inmem.Store.GetEntity(ctx, dep.ID)
+	require.NoError(t, err)
+	var migrated core_v1alpha.Deployment
+	migrated.Decode(raw)
+	rec := &deploylifecycle.Record{Deployment: &migrated}
+	assert.True(t, rec.Canonical())
+	assert.Equal(t, deploylifecycle.StatusInProgress, rec.Status())
+	assert.Empty(t, migrated.Outcome)
+	assert.Equal(t, "building", migrated.Phase)
+	assert.Equal(t, started, migrated.StartedAt)
+	assert.Equal(t, app.ID, migrated.App)
+}
+
+func TestDeploymentMigrationEvictsEmbeddedBuildLogsFromCanonicalRecord(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Simulate a store upgraded from a schema that allowed the legacy attr.
+	_, err := inmem.Store.CreateEntity(ctx, entity.New(
+		entity.Ident, types.Keyword(legacyDeploymentBuildLogs),
+		entity.Doc, "legacy embedded build output",
+		entity.Cardinality, entity.CardinalityOne,
+		entity.Type, entity.TypeStr,
+	), entity.WithOverwrite)
+	require.NoError(t, err)
+
+	dep := &core_v1alpha.Deployment{
+		ID: "deployment/canonical-with-logs", AppName: "web",
+		Status: "failed", Outcome: "failed", StartedAt: time.Now().UTC(),
+	}
+	attrs := append(dep.Encode(), entity.String(legacyDeploymentBuildLogs, strings.Repeat("build output\n", 10_000)))
+	_, err = inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, dep.ID), attrs))
+	require.NoError(t, err)
+
+	controller := New(log, inmem.Store, inmem.EAC)
+	require.NoError(t, controller.Step(ctx))
+
+	raw, err := inmem.Store.GetEntity(ctx, dep.ID)
+	require.NoError(t, err)
+	_, found := raw.Get(legacyDeploymentBuildLogs)
+	assert.False(t, found, "canonical records must not retain legacy embedded logs")
+
+	var migrated core_v1alpha.Deployment
+	migrated.Decode(raw)
+	assert.Equal(t, "failed", migrated.Outcome)
+}
+
+func TestReconcilePhaseDiscoversRunningAttemptDirectly(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	controller := New(log, inmem.Store, inmem.EAC)
+
+	app := &core_v1alpha.App{ID: "app/web"}
+	version := &core_v1alpha.AppVersion{ID: "app_version/v1", App: app.ID}
+	for id, attrs := range map[entity.Id][]entity.Attr{app.ID: app.Encode(), version.ID: version.Encode()} {
+		_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, id), attrs))
+		require.NoError(t, err)
+	}
+
+	rec, err := controller.Tracker.Begin(ctx, deploylifecycle.BeginParams{AppName: "web"})
+	require.NoError(t, err)
+	require.NoError(t, controller.Tracker.SetAppVersion(ctx, string(rec.Deployment.ID), string(version.ID)))
+
+	current, revision, err := controller.Tracker.Store().AppByName(ctx, "web")
+	require.NoError(t, err)
+	require.NoError(t, controller.Tracker.Store().SetActivePointers(
+		ctx, current.ID, revision, version.ID, rec.Deployment.ID))
+
+	controller.phase = phaseReconcile
+	controller.Config.BatchSize = 100
+	require.NoError(t, controller.Step(ctx))
+
+	settled, err := controller.Tracker.Store().Get(ctx, string(rec.Deployment.ID))
+	require.NoError(t, err)
+	assert.Equal(t, deploylifecycle.StatusSucceeded, settled.Status())
+	assert.Equal(t, "succeeded", settled.Deployment.Outcome)
+}
+
+func TestReupgradeRepairsPointerChangedByDowngradedRuntime(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	app := &core_v1alpha.App{ID: "app/web", ActiveVersion: "app_version/v2", ActiveDeployment: "deployment/old"}
+	v1 := &core_v1alpha.AppVersion{ID: "app_version/v1", App: app.ID}
+	v2 := &core_v1alpha.AppVersion{ID: "app_version/v2", App: app.ID}
+	old := &core_v1alpha.Deployment{
+		ID: "deployment/old", App: app.ID, Version: v1.ID,
+		Outcome: "succeeded", AppName: "web", AppVersion: string(v1.ID), Status: "succeeded",
+	}
+	current := &core_v1alpha.Deployment{
+		ID: "deployment/current", AppName: "web", AppVersion: string(v2.ID), Status: "active",
+	}
+	for id, attrs := range map[entity.Id][]entity.Attr{
+		app.ID: app.Encode(), v1.ID: v1.Encode(), v2.ID: v2.Encode(),
+		old.ID: old.Encode(), current.ID: current.Encode(),
+	} {
+		_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, id), attrs))
+		require.NoError(t, err)
+	}
+
+	controller := New(log, inmem.Store, inmem.EAC)
+	controller.Config.BatchSize = 100
+	for range 3 {
+		require.NoError(t, controller.Step(ctx))
+	}
+	raw, err := inmem.Store.GetEntity(ctx, app.ID)
+	require.NoError(t, err)
+	var got core_v1alpha.App
+	got.Decode(raw)
+	assert.Equal(t, current.ID, got.ActiveDeployment)
+}

--- a/pkg/deploylifecycle/compat.go
+++ b/pkg/deploylifecycle/compat.go
@@ -1,0 +1,192 @@
+package deploylifecycle
+
+import (
+	"time"
+
+	"miren.dev/runtime/pkg/entity"
+)
+
+// Canonical reports whether any attempt-shaped field is present. Outcome cannot
+// be the discriminator because it is deliberately absent while an attempt is
+// in progress.
+func (r *Record) Canonical() bool {
+	if r == nil || r.Deployment == nil {
+		return false
+	}
+	d := r.Deployment
+	return d.Outcome != "" || d.App != "" || d.Version != "" ||
+		d.ParentDeployment != "" || d.Operation != "" || !d.StartedAt.IsZero()
+}
+
+// Status returns the attempt's lifecycle state. A canonical attempt with no
+// outcome is still in progress; outcomes exist only after it settles. Legacy
+// serving-state statuses collapse to succeeded because serving state belongs to
+// app.active_deployment.
+func (r *Record) Status() Status {
+	if r == nil || r.Deployment == nil {
+		return ""
+	}
+	if r.Canonical() {
+		if r.Deployment.Outcome == "" {
+			return StatusInProgress
+		}
+		return statusFromSchema(r.Deployment.Outcome)
+	}
+	return Status(r.Deployment.Status).Canonical()
+}
+
+func (r *Record) Operation() Operation {
+	if !r.Canonical() {
+		return ""
+	}
+	switch r.Deployment.Operation {
+	case string(OperationBuild):
+		return OperationBuild
+	case string(OperationRedeploy):
+		return OperationRedeploy
+	case string(OperationRollback):
+		return OperationRollback
+	case string(OperationConfigChange):
+		return OperationConfigChange
+	default:
+		return ""
+	}
+}
+
+func (r *Record) Phase() Phase {
+	if r == nil || r.Deployment == nil {
+		return ""
+	}
+	return Phase(r.Deployment.Phase)
+}
+
+func (r *Record) AppID() entity.Id {
+	if r.Canonical() {
+		return r.Deployment.App
+	}
+	return ""
+}
+
+// AppVersion returns the canonical version reference, or the normalized legacy
+// value for an unmigrated record.
+func (r *Record) AppVersion() string {
+	if r == nil || r.Deployment == nil {
+		return ""
+	}
+	if r.Canonical() {
+		return string(r.Deployment.Version)
+	}
+	version := r.Deployment.AppVersion
+	if version == pendingBuildSentinel || isFailedSentinel(version, string(r.Deployment.ID)) {
+		return ""
+	}
+	return version
+}
+
+func (r *Record) ParentDeploymentID() string {
+	if r == nil || r.Deployment == nil {
+		return ""
+	}
+	if r.Canonical() {
+		return string(r.Deployment.ParentDeployment)
+	}
+	return r.Deployment.SourceDeploymentId
+}
+
+func (r *Record) StartedAt() time.Time {
+	if r == nil || r.Deployment == nil {
+		return time.Time{}
+	}
+	if r.Canonical() {
+		return r.Deployment.StartedAt
+	}
+	t, _ := time.Parse(time.RFC3339, r.Deployment.DeployedBy.Timestamp)
+	return t
+}
+
+func (r *Record) CompletedAt() time.Time {
+	if r == nil || r.Deployment == nil {
+		return time.Time{}
+	}
+	t, _ := time.Parse(time.RFC3339, r.Deployment.CompletedAt)
+	return t
+}
+
+func statusFromSchema(outcome string) Status {
+	switch outcome {
+	case string(StatusSucceeded):
+		return StatusSucceeded
+	case string(StatusFailed):
+		return StatusFailed
+	case string(StatusCancelled):
+		return StatusCancelled
+	case string(StatusInterrupted):
+		return StatusInterrupted
+	default:
+		// Outcomes are terminal by contract. Treat a value written by a newer
+		// runtime as interrupted so this older reader never turns a settled record
+		// into an inert, non-terminal lock holder.
+		return StatusInterrupted
+	}
+}
+
+func schemaOutcome(status Status) string {
+	switch status {
+	case StatusActive, StatusSucceeded, StatusRolledBack:
+		return string(StatusSucceeded)
+	case StatusFailed, StatusCancelled, StatusInterrupted:
+		return string(status)
+	case StatusInProgress:
+		return ""
+	default:
+		return ""
+	}
+}
+
+func schemaOperation(operation Operation) string {
+	return string(operation)
+}
+
+// setOutcome dual-writes the canonical result and the closest legacy status.
+// A successful current attempt stays legacy-active until a later activation
+// supersedes it. interrupted has no legacy equivalent and degrades to failed.
+func (r *Record) setOutcome(status Status) {
+	outcome := schemaOutcome(status)
+	if outcome == "" {
+		panic("deploylifecycle: setOutcome requires a terminal attempt result")
+	}
+	r.Deployment.Outcome = outcome
+	switch status.Canonical() {
+	case StatusSucceeded:
+		r.Deployment.Status = string(StatusActive)
+	case StatusInterrupted:
+		r.Deployment.Status = string(StatusFailed)
+	case StatusFailed, StatusCancelled:
+		r.Deployment.Status = string(status.Canonical())
+	case StatusInProgress, StatusActive, StatusRolledBack:
+		panic("deploylifecycle: canonical terminal status resolved to " + string(status.Canonical()))
+	default:
+		panic("deploylifecycle: unknown terminal status " + string(status))
+	}
+}
+
+// setInProgress initializes only the downgrade-compatible status. Canonical
+// outcome remains absent until the attempt reaches a terminal result.
+func (r *Record) setInProgress() {
+	r.Deployment.Outcome = ""
+	r.Deployment.Status = string(StatusInProgress)
+}
+
+func (r *Record) setPhase(phase Phase) {
+	r.Deployment.Phase = string(phase)
+}
+
+func (r *Record) setVersion(version entity.Id) {
+	r.Deployment.Version = version
+	r.Deployment.AppVersion = string(version)
+}
+
+func (r *Record) setParentDeployment(parent entity.Id) {
+	r.Deployment.ParentDeployment = parent
+	r.Deployment.SourceDeploymentId = string(parent)
+}

--- a/pkg/deploylifecycle/compat_test.go
+++ b/pkg/deploylifecycle/compat_test.go
@@ -1,0 +1,65 @@
+package deploylifecycle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+func TestRecordCanonicalPresenceWinsOverLegacyFields(t *testing.T) {
+	started := time.Date(2026, 8, 1, 1, 2, 3, 0, time.UTC)
+	rec := &Record{Deployment: &core_v1alpha.Deployment{
+		ID: "deployment/mixed", App: "app/web", Version: "app_version/v2",
+		Outcome: "failed", StartedAt: started,
+		AppName: "web", AppVersion: "app_version/v1", Status: "active", Phase: "building",
+	}}
+
+	assert.True(t, rec.Canonical())
+	assert.Equal(t, StatusFailed, rec.Status())
+	assert.Equal(t, "app_version/v2", rec.AppVersion())
+	assert.Equal(t, PhaseBuilding, rec.Phase())
+	assert.Equal(t, started, rec.StartedAt())
+}
+
+func TestCanonicalAttemptWithoutOutcomeIsInProgress(t *testing.T) {
+	rec := &Record{Deployment: &core_v1alpha.Deployment{
+		ID: "deployment/running", App: "app/web",
+		StartedAt: time.Date(2026, 8, 1, 1, 2, 3, 0, time.UTC),
+		Status:    "active", Phase: "building",
+	}}
+
+	assert.True(t, rec.Canonical())
+	assert.Empty(t, rec.Deployment.Outcome)
+	assert.Equal(t, StatusInProgress, rec.Status(), "absence of a terminal outcome wins over legacy serving status")
+	assert.Equal(t, PhaseBuilding, rec.Phase())
+}
+
+func TestRecordDecodesLegacyServingStatusesAsSuccessfulAttempts(t *testing.T) {
+	for _, legacy := range []string{"active", "succeeded", "rolled_back"} {
+		rec := &Record{Deployment: &core_v1alpha.Deployment{
+			ID: entity.Id("deployment/" + legacy), Status: legacy,
+		}}
+		assert.False(t, rec.Canonical())
+		assert.Equal(t, StatusSucceeded, rec.Status())
+	}
+}
+
+func TestUnknownCanonicalOutcomeRemainsTerminal(t *testing.T) {
+	rec := &Record{Deployment: &core_v1alpha.Deployment{
+		ID: "deployment/future", App: "app/web", Outcome: "superseded",
+	}}
+
+	assert.Equal(t, StatusInterrupted, rec.Status())
+	assert.True(t, rec.Status().Terminal())
+}
+
+func TestNilRecordAccessorsReturnZeroValues(t *testing.T) {
+	for _, rec := range []*Record{nil, {}} {
+		assert.Empty(t, rec.ParentDeploymentID())
+		assert.True(t, rec.StartedAt().IsZero())
+		assert.True(t, rec.CompletedAt().IsZero())
+	}
+}

--- a/pkg/deploylifecycle/legacy_lock.go
+++ b/pkg/deploylifecycle/legacy_lock.go
@@ -1,0 +1,181 @@
+package deploylifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/schema"
+)
+
+// The standalone lock is retained as a downgrade compatibility shadow for one
+// supported window. New code treats app.deployment_lock as canonical, but an
+// older binary only checks deploy-lock/<app>. Writing both prevents an upgrade
+// or downgrade boundary from splitting mutual exclusion across two locations.
+const (
+	legacyLockKind         = entity.Id("dev.miren.core/deployment_lock")
+	legacyLockAppName      = entity.Id("dev.miren.core/deployment_lock.app_name")
+	legacyLockDeploymentID = entity.Id("dev.miren.core/deployment_lock.deployment_id")
+	legacyLockAcquiredAt   = entity.Id("dev.miren.core/deployment_lock.acquired_at")
+	legacyLockExpiresAt    = entity.Id("dev.miren.core/deployment_lock.expires_at")
+)
+
+func init() {
+	// Fresh clusters still need the old attribute definitions so the current
+	// binary can write a shadow that a downgraded binary understands. Register
+	// them outside the generated core model to keep the standalone entity out of
+	// the canonical API.
+	schema.Register("dev.miren.core.deployment-lock-compat", "v1alpha", func(sb *schema.SchemaBuilder) {
+		sb.Singleton(string(legacyLockKind))
+		sb.String("app_name", string(legacyLockAppName), schema.Indexed)
+		sb.String("deployment_id", string(legacyLockDeploymentID))
+		sb.Time("acquired_at", string(legacyLockAcquiredAt))
+		sb.Time("expires_at", string(legacyLockExpiresAt), schema.Indexed)
+	})
+}
+
+func legacyLockID(appName string) entity.Id {
+	return entity.Id("deploy-lock/" + appName)
+}
+
+func (l *Locks) acquireLegacy(ctx context.Context, appName, deploymentID string) (*Holder, bool, error) {
+	id := legacyLockID(appName)
+	for attempt := range lockAcquireLimit {
+		mine := l.holderFor(appName, deploymentID)
+		res, err := l.eac.Ensure(ctx, encodeLegacyLock(id, mine))
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to acquire compatibility deploy lock: %w", err)
+		}
+		if res.Created() {
+			mine.Revision = res.Revision()
+			return mine, true, nil
+		}
+
+		current, err := l.getLegacy(ctx, appName)
+		if err != nil {
+			if errors.Is(err, cond.ErrNotFound{}) {
+				l.backoff(attempt + 1)
+				continue
+			}
+			return nil, false, err
+		}
+		if current.DeploymentID == deploymentID {
+			mine.AcquiredAt = current.AcquiredAt
+			refreshed, err := l.replaceLegacy(ctx, id, current.Revision, mine)
+			if err == nil {
+				return refreshed, false, nil
+			}
+			if errors.Is(err, cond.ErrConflict{}) {
+				l.backoff(attempt + 1)
+				continue
+			}
+			return nil, false, err
+		}
+
+		stealable, reason := l.stealable(ctx, current)
+		if !stealable {
+			return current, false, &LockHeldError{Holder: current}
+		}
+		if current.DeploymentID != "" {
+			l.log.Warn("stealing compatibility deploy lock",
+				"app", appName,
+				"from_deployment_id", current.DeploymentID,
+				"to_deployment_id", deploymentID,
+				"reason", reason)
+		}
+
+		taken, err := l.replaceLegacy(ctx, id, current.Revision, mine)
+		if err != nil {
+			if errors.Is(err, cond.ErrConflict{}) {
+				l.backoff(attempt + 1)
+				continue
+			}
+			return nil, false, err
+		}
+		return taken, true, nil
+	}
+
+	return nil, false, fmt.Errorf("gave up acquiring compatibility deploy lock for %s after %d attempts",
+		appName, lockAcquireLimit)
+}
+
+func (l *Locks) releaseLegacy(ctx context.Context, appName, deploymentID string) error {
+	id := legacyLockID(appName)
+	for attempt := range lockAcquireLimit {
+		current, err := l.getLegacy(ctx, appName)
+		if err != nil {
+			if errors.Is(err, cond.ErrNotFound{}) {
+				return nil
+			}
+			return err
+		}
+		if current.DeploymentID == "" || current.DeploymentID != deploymentID {
+			return nil
+		}
+
+		released := &Holder{
+			AppName:    appName,
+			AcquiredAt: current.AcquiredAt,
+			ExpiresAt:  l.now.Now(),
+		}
+		if _, err := l.replaceLegacy(ctx, id, current.Revision, released); err != nil {
+			if errors.Is(err, cond.ErrConflict{}) {
+				l.backoff(attempt + 1)
+				continue
+			}
+			return fmt.Errorf("failed to release compatibility deploy lock: %w", err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("gave up releasing compatibility deploy lock for %s after %d attempts",
+		appName, lockAcquireLimit)
+}
+
+func (l *Locks) getLegacy(ctx context.Context, appName string) (*Holder, error) {
+	res, err := l.eac.Get(ctx, string(legacyLockID(appName)))
+	if err != nil {
+		return nil, err
+	}
+	attrs := &entityAttrs{entity: res.Entity()}
+	holder := &Holder{AppName: appName, Revision: res.Entity().Revision()}
+	if attr, ok := attrs.Get(legacyLockAppName); ok && attr.Value.Kind() == entity.KindString {
+		holder.AppName = attr.Value.String()
+	}
+	if attr, ok := attrs.Get(legacyLockDeploymentID); ok && attr.Value.Kind() == entity.KindString {
+		holder.DeploymentID = attr.Value.String()
+	}
+	if attr, ok := attrs.Get(legacyLockAcquiredAt); ok && attr.Value.Kind() == entity.KindTime {
+		holder.AcquiredAt = attr.Value.Time()
+	}
+	if attr, ok := attrs.Get(legacyLockExpiresAt); ok && attr.Value.Kind() == entity.KindTime {
+		holder.ExpiresAt = attr.Value.Time()
+	}
+	return holder, nil
+}
+
+func (l *Locks) replaceLegacy(ctx context.Context, id entity.Id, revision int64, holder *Holder) (*Holder, error) {
+	res, err := l.eac.Replace(ctx, encodeLegacyLock(id, holder), revision)
+	if err != nil {
+		return nil, err
+	}
+	replaced := *holder
+	replaced.Revision = res.Revision()
+	return &replaced, nil
+}
+
+func encodeLegacyLock(id entity.Id, holder *Holder) []entity.Attr {
+	attrs := []entity.Attr{
+		entity.Ref(entity.DBId, id),
+		entity.Ref(entity.EntityKind, legacyLockKind),
+		entity.String(legacyLockAppName, holder.AppName),
+		entity.Time(legacyLockAcquiredAt, holder.AcquiredAt),
+		entity.Time(legacyLockExpiresAt, holder.ExpiresAt),
+	}
+	if holder.DeploymentID != "" {
+		attrs = append(attrs, entity.String(legacyLockDeploymentID, holder.DeploymentID))
+	}
+	return attrs
+}

--- a/pkg/deploylifecycle/lifecycle.go
+++ b/pkg/deploylifecycle/lifecycle.go
@@ -17,12 +17,24 @@ import (
 type Status string
 
 const (
-	StatusInProgress Status = "in_progress"
-	StatusActive     Status = "active"
-	StatusSucceeded  Status = "succeeded"
-	StatusFailed     Status = "failed"
-	StatusRolledBack Status = "rolled_back"
-	StatusCancelled  Status = "cancelled"
+	StatusInProgress  Status = "in_progress"
+	StatusActive      Status = "active"
+	StatusSucceeded   Status = "succeeded"
+	StatusFailed      Status = "failed"
+	StatusRolledBack  Status = "rolled_back"
+	StatusCancelled   Status = "cancelled"
+	StatusInterrupted Status = "interrupted"
+)
+
+// Operation records why an attempt was started. Unlike a status, it never
+// changes as work progresses.
+type Operation string
+
+const (
+	OperationBuild        Operation = "build"
+	OperationRedeploy     Operation = "redeploy"
+	OperationRollback     Operation = "rollback"
+	OperationConfigChange Operation = "config_change"
 )
 
 // Phase is the fine-grained progress of a deployment that is still in_progress.
@@ -40,7 +52,7 @@ const (
 var (
 	allStatuses = []Status{
 		StatusInProgress, StatusActive, StatusSucceeded,
-		StatusFailed, StatusRolledBack, StatusCancelled,
+		StatusFailed, StatusRolledBack, StatusCancelled, StatusInterrupted,
 	}
 	allPhases = []Phase{PhasePreparing, PhaseBuilding, PhasePushing, PhaseActivating}
 )
@@ -50,10 +62,11 @@ var (
 // missing validTransitions entry — is what makes the init check below able to
 // catch a status that was added without deciding whether it is terminal.
 var terminalStatuses = map[Status]struct{}{
-	StatusSucceeded:  {},
-	StatusFailed:     {},
-	StatusRolledBack: {},
-	StatusCancelled:  {},
+	StatusSucceeded:   {},
+	StatusFailed:      {},
+	StatusRolledBack:  {},
+	StatusCancelled:   {},
+	StatusInterrupted: {},
 }
 
 // validTransitions maps a status to the statuses reachable from it.
@@ -61,7 +74,7 @@ var terminalStatuses = map[Status]struct{}{
 // in_progress is reachable from itself so that a no-op update (the client
 // re-asserting the state it is already in) is not an error.
 var validTransitions = map[Status][]Status{
-	StatusInProgress: {StatusInProgress, StatusActive, StatusFailed, StatusCancelled},
+	StatusInProgress: {StatusInProgress, StatusActive, StatusSucceeded, StatusFailed, StatusCancelled, StatusInterrupted},
 	StatusActive:     {StatusSucceeded, StatusRolledBack},
 }
 
@@ -96,8 +109,35 @@ func (s Status) Valid() bool {
 // Terminal reports whether s admits no further transitions. A deployment in a
 // terminal status holds no lock and will not change again.
 func (s Status) Terminal() bool {
+	// Legacy active records have completed their attempt even though an older
+	// runtime may later rewrite their serving-state status. Treat them as
+	// terminal for lock ownership; canonical records use succeeded instead.
+	if s == StatusActive {
+		return true
+	}
 	_, ok := terminalStatuses[s]
 	return ok
+}
+
+// Canonical removes serving-state history from a legacy status.
+func (s Status) Canonical() Status {
+	switch s {
+	case StatusActive, StatusRolledBack:
+		return StatusSucceeded
+	case StatusInProgress, StatusSucceeded, StatusFailed, StatusCancelled, StatusInterrupted:
+		return s
+	default:
+		return s
+	}
+}
+
+func (o Operation) Valid() bool {
+	switch o {
+	case OperationBuild, OperationRedeploy, OperationRollback, OperationConfigChange:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s Status) String() string { return string(s) }

--- a/pkg/deploylifecycle/lifecycle_test.go
+++ b/pkg/deploylifecycle/lifecycle_test.go
@@ -27,19 +27,22 @@ func isConflict(err error) bool {
 // restatement of validTransitions.
 var allowedTransitions = map[Status]map[Status]bool{
 	StatusInProgress: {
-		StatusInProgress: true,
-		StatusActive:     true,
-		StatusFailed:     true,
-		StatusCancelled:  true,
+		StatusInProgress:  true,
+		StatusActive:      true,
+		StatusSucceeded:   true,
+		StatusFailed:      true,
+		StatusCancelled:   true,
+		StatusInterrupted: true,
 	},
 	StatusActive: {
 		StatusSucceeded:  true,
 		StatusRolledBack: true,
 	},
-	StatusSucceeded:  {},
-	StatusFailed:     {},
-	StatusRolledBack: {},
-	StatusCancelled:  {},
+	StatusSucceeded:   {},
+	StatusFailed:      {},
+	StatusRolledBack:  {},
+	StatusCancelled:   {},
+	StatusInterrupted: {},
 }
 
 // TestTransitionMatrix exercises every (from, to) pair, so a new status or a
@@ -85,10 +88,12 @@ func TestTransitionFromUnknownStatusIsRejected(t *testing.T) {
 
 func TestTerminal(t *testing.T) {
 	terminal := map[Status]bool{
-		StatusSucceeded:  true,
-		StatusFailed:     true,
-		StatusRolledBack: true,
-		StatusCancelled:  true,
+		StatusSucceeded:   true,
+		StatusFailed:      true,
+		StatusRolledBack:  true,
+		StatusCancelled:   true,
+		StatusInterrupted: true,
+		StatusActive:      true,
 	}
 
 	for _, s := range allStatuses {

--- a/pkg/deploylifecycle/lock.go
+++ b/pkg/deploylifecycle/lock.go
@@ -14,7 +14,7 @@ import (
 )
 
 // DefaultLockTTL is how long a lock survives without its holder finishing. It
-// backstops a deploy whose driver died without releasing; a holder that reaches
+// backstops a deploy whose driver died without releasing. A holder that reaches
 // a terminal status is stealable sooner than this.
 const DefaultLockTTL = 30 * time.Minute
 
@@ -66,17 +66,16 @@ func (h *Holder) Expired(now time.Time) bool {
 	return !h.ExpiresAt.After(now)
 }
 
-// StatusLookup reports the stored status of a deployment record. Acquire uses it
-// so a lock whose holder has already finished — the record says failed, the lock
-// says running — can be taken immediately instead of waiting out the TTL.
+// StatusLookup reports the stored status of a deployment record. Acquire uses
+// it so a lock whose holder has already finished can be taken immediately
+// instead of waiting out the TTL.
 type StatusLookup func(ctx context.Context, deploymentID string) (Status, error)
 
-// Locks manages the deploy lock entity for an app.
+// Locks manages the expiring deployment lock stored on an app.
 //
-// Acquisition is a compare-and-create against the entity store, so two callers
-// racing to start a deploy cannot both win. That is the whole point of the type:
-// the previous scheme listed in-progress deployments and then created a record,
-// which admitted an interleaving where both callers saw an empty list.
+// The app is the single compare-and-swap point for acquisition. A
+// revision-guarded patch ensures that two callers racing to deploy the same app
+// cannot both become its lock holder.
 //
 // The lock is scoped to the app, not app+cluster: a coordinator's entity store
 // is a loopback into its own etcd, so it only ever holds this cluster's
@@ -155,18 +154,6 @@ func NewLocks(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, st
 	}
 }
 
-// LockID is the deterministic entity id for an app's deploy lock. Determinism is
-// what makes create-if-absent a mutual exclusion primitive: every contender
-// computes the same key.
-//
-// The app name is the sole variable component, so it is used raw. It must not be
-// rewritten (e.g. slashes to underscores): that would let two distinct names
-// collide on one lock. As the last path segment the name is unambiguous even
-// when it contains a slash.
-func LockID(appName string) entity.Id {
-	return entity.Id("deploy-lock/" + appName)
-}
-
 // Acquire takes the deploy lock for deploymentID, returning the holder it
 // established.
 //
@@ -179,55 +166,73 @@ func (l *Locks) Acquire(ctx context.Context, appName, deploymentID string) (*Hol
 			"app_name and deployment_id are both required to acquire a deploy lock")
 	}
 
-	id := LockID(appName)
+	// Take the downgrade-compatible shadow first. An older binary only knows
+	// about that entity, so holding it closes the cross-version acquisition race
+	// before we touch the canonical App lock.
+	legacy, shadowCreated, err := l.acquireLegacy(ctx, appName, deploymentID)
+	if err != nil {
+		return legacy, err
+	}
+
+	holder, err := l.acquireApp(ctx, appName, deploymentID)
+	if err != nil && shadowCreated {
+		// We introduced this shadow during the failed attempt, so unwind it. A
+		// shadow that already belonged to deploymentID may protect an existing
+		// worker retrying this call and must stay in place.
+		if releaseErr := l.releaseLegacy(ctx, appName, deploymentID); releaseErr != nil {
+			l.log.Error("failed to release compatibility lock after app lock acquisition failed",
+				"app", appName, "deployment_id", deploymentID, "error", releaseErr)
+		}
+	}
+	return holder, err
+}
+
+func (l *Locks) acquireApp(ctx context.Context, appName, deploymentID string) (*Holder, error) {
 
 	for attempt := range lockAcquireLimit {
 		mine := l.holderFor(appName, deploymentID)
-
-		res, err := l.eac.Ensure(ctx, l.encode(id, mine))
+		current, app, err := l.readApp(ctx, appName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to acquire deploy lock: %w", err)
 		}
 
-		if res.Created() {
-			mine.Revision = res.Revision()
-			l.log.Debug("acquired deploy lock",
-				"app", appName, "deployment_id", deploymentID)
-			return mine, nil
-		}
-
-		// Someone holds it. Whether we may take it over depends on who they are
-		// and whether they are still alive.
-		current, err := l.Get(ctx, appName)
-		if err != nil {
-			if errors.Is(err, cond.ErrNotFound{}) {
-				// Released between our Ensure and our read — try again.
+		if current.DeploymentID == deploymentID {
+			// Refresh extends the authority boundary without rewriting when the
+			// lock originally began.
+			mine.AcquiredAt = current.AcquiredAt
+			refreshed, err := l.replace(ctx, app.ID, current.Revision, mine)
+			if err == nil {
+				return refreshed, nil
+			}
+			if errors.Is(err, cond.ErrConflict{}) {
 				l.backoff(attempt + 1)
 				continue
 			}
 			return nil, err
 		}
 
-		if current.DeploymentID == deploymentID {
-			return l.refresh(ctx, id, current, mine)
+		reason := "unclaimed"
+		if current.DeploymentID != "" {
+			stealable, why := l.stealable(ctx, current)
+			if !stealable {
+				return current, &LockHeldError{Holder: current}
+			}
+			reason = why
 		}
 
-		stealable, reason := l.stealable(ctx, current)
-		if !stealable {
-			return current, &LockHeldError{Holder: current}
+		if current.DeploymentID != "" {
+			l.log.Warn("stealing deploy lock",
+				"app", appName,
+				"from_deployment_id", current.DeploymentID,
+				"to_deployment_id", deploymentID,
+				"reason", reason)
 		}
-
-		l.log.Warn("stealing deploy lock",
-			"app", appName,
-			"from_deployment_id", current.DeploymentID,
-			"to_deployment_id", deploymentID,
-			"reason", reason)
 
 		if l.stealRace != nil {
 			l.stealRace()
 		}
 
-		taken, err := l.replace(ctx, id, current.Revision, mine)
+		taken, err := l.replace(ctx, app.ID, current.Revision, mine)
 		if err != nil {
 			if errors.Is(err, cond.ErrConflict{}) {
 				// Another contender moved the lock first. Re-read and decide
@@ -237,25 +242,13 @@ func (l *Locks) Acquire(ctx context.Context, appName, deploymentID string) (*Hol
 			}
 			return nil, err
 		}
+		l.log.Debug("acquired deploy lock",
+			"app", appName, "deployment_id", deploymentID)
 		return taken, nil
 	}
 
 	return nil, fmt.Errorf("gave up acquiring deploy lock for %s after %d attempts",
 		appName, lockAcquireLimit)
-}
-
-// refresh extends an expiry for the deployment that already holds the lock.
-func (l *Locks) refresh(ctx context.Context, id entity.Id, current, mine *Holder) (*Holder, error) {
-	refreshed, err := l.replace(ctx, id, current.Revision, mine)
-	if err != nil {
-		if errors.Is(err, cond.ErrConflict{}) {
-			// Someone rewrote the lock under us. current is still ours by
-			// deployment id, so report it rather than failing the deploy.
-			return current, nil
-		}
-		return nil, err
-	}
-	return refreshed, nil
 }
 
 // stealable reports whether a held lock may be taken over, and why.
@@ -265,7 +258,7 @@ func (l *Locks) stealable(ctx context.Context, h *Holder) (bool, string) {
 	}
 
 	if h.DeploymentID == "" {
-		// A lock with no owner cannot be reconciled against a record; treat it
+		// A lock with no owner cannot be reconciled against a record. Treat it
 		// as debris rather than an indefinite block.
 		return true, "no owner recorded"
 	}
@@ -277,8 +270,10 @@ func (l *Locks) stealable(ctx context.Context, h *Holder) (bool, string) {
 	status, err := l.status(ctx, h.DeploymentID)
 	if err != nil {
 		if errors.Is(err, cond.ErrNotFound{}) {
-			// The record is gone, so nothing will ever release this lock.
-			return true, "holding deployment no longer exists"
+			// Absence is not positive evidence that the holder is dead. Direct lock
+			// callers may still be publishing their record, so the lease remains the
+			// recovery bound when there is nothing to reconcile.
+			return false, ""
 		}
 		l.log.Warn("could not read holding deployment; treating lock as held",
 			"deployment_id", h.DeploymentID, "error", err)
@@ -292,58 +287,74 @@ func (l *Locks) stealable(ctx context.Context, h *Holder) (bool, string) {
 	return false, ""
 }
 
-// Release drops the lock, but only if deploymentID still holds it.
-//
-// The release is a revision-guarded write rather than a delete: between reading
-// the holder and acting on it, another deployment may legitimately steal the
-// lock — a deployment that has just finished is exactly what makes a lock
-// stealable — and an unguarded delete would then remove the successor's lock,
-// letting a third deployment start alongside it. The entity server's delete
-// takes no caller revision, so the write has to be a Replace to be safe.
-//
-// The released lock is left behind as a tombstone: owned by nobody, already
-// expired. Acquire treats that as free.
-func (l *Locks) Release(ctx context.Context, appName, deploymentID string) error {
-	current, err := l.Get(ctx, appName)
+// Owns reports whether deploymentID is the current, unexpired holder.
+func (l *Locks) Owns(ctx context.Context, appName, deploymentID string) (bool, error) {
+	holder, err := l.Get(ctx, appName)
 	if err != nil {
 		if errors.Is(err, cond.ErrNotFound{}) {
-			return nil
+			return false, nil
 		}
+		return false, err
+	}
+	return holder.DeploymentID == deploymentID && !holder.Expired(l.now.Now()), nil
+}
+
+// Release clears the canonical App lock, then its downgrade-compatible shadow,
+// but only if deploymentID still holds them. Releasing in this order keeps old
+// binaries excluded until the canonical lock is safely clear.
+func (l *Locks) Release(ctx context.Context, appName, deploymentID string) error {
+	if err := l.releaseApp(ctx, appName, deploymentID); err != nil {
 		return err
 	}
+	return l.releaseLegacy(ctx, appName, deploymentID)
+}
 
-	if current.DeploymentID != deploymentID {
-		l.log.Debug("not releasing deploy lock held by another deployment",
-			"app", appName,
-			"holder", current.DeploymentID, "caller", deploymentID)
+// releaseApp clears the app lock, but only if deploymentID still holds it.
+//
+// The revision guard matters because another deployment may legitimately take
+// over between our read and write. App revisions can also move for unrelated
+// changes, so a conflict is re-read rather than assumed to mean the lock moved.
+func (l *Locks) releaseApp(ctx context.Context, appName, deploymentID string) error {
+	for attempt := range lockAcquireLimit {
+		current, app, err := l.readApp(ctx, appName)
+		if err != nil {
+			if errors.Is(err, cond.ErrNotFound{}) {
+				return nil
+			}
+			return err
+		}
+
+		if current.DeploymentID == "" {
+			return nil
+		}
+		if current.DeploymentID != deploymentID {
+			l.log.Debug("not releasing deploy lock held by another deployment",
+				"app", appName,
+				"holder", current.DeploymentID, "caller", deploymentID)
+			return nil
+		}
+
+		if l.releaseRace != nil {
+			l.releaseRace()
+		}
+
+		if _, err := l.replace(ctx, app.ID, current.Revision, &Holder{AppName: appName}); err != nil {
+			if errors.Is(err, cond.ErrConflict{}) {
+				// App revisions also move for unrelated app changes. Re-read so we
+				// can distinguish that from a successor taking over the lock.
+				l.backoff(attempt + 1)
+				continue
+			}
+			return fmt.Errorf("failed to release deploy lock: %w", err)
+		}
+
+		l.log.Debug("released deploy lock",
+			"app", appName, "deployment_id", deploymentID)
 		return nil
 	}
 
-	if l.releaseRace != nil {
-		l.releaseRace()
-	}
-
-	// No DeploymentID: the lock is owned by nobody once released.
-	released := &Holder{
-		AppName:    appName,
-		AcquiredAt: current.AcquiredAt,
-		ExpiresAt:  l.now.Now(),
-	}
-
-	if _, err := l.replace(ctx, LockID(appName), current.Revision, released); err != nil {
-		if errors.Is(err, cond.ErrConflict{}) {
-			// The lock moved between our read and our write, so it is no longer
-			// ours to release. Whoever holds it now keeps it.
-			l.log.Debug("deploy lock moved before release; leaving it alone",
-				"app", appName, "caller", deploymentID)
-			return nil
-		}
-		return fmt.Errorf("failed to release deploy lock: %w", err)
-	}
-
-	l.log.Debug("released deploy lock",
-		"app", appName, "deployment_id", deploymentID)
-	return nil
+	return fmt.Errorf("gave up releasing deploy lock for %s after %d attempts",
+		appName, lockAcquireLimit)
 }
 
 // Blocking returns the holder that would block a new deployment for this app, or
@@ -351,10 +362,18 @@ func (l *Locks) Release(ctx context.Context, appName, deploymentID string) error
 //
 // This is the question callers actually have — a pre-flight check before
 // uploading a build context, or the lock info rendered in a "deployment
-// blocked" message — and it is not the same as "a lock entity exists". A
-// released tombstone, an expired lock, and a lock whose deployment already
-// finished all read as free.
+// blocked" message. An empty lock, an expired lock, and a lock whose
+// deployment already finished all read as free.
 func (l *Locks) Blocking(ctx context.Context, appName string) (*Holder, error) {
+	legacy, err := l.getLegacy(ctx, appName)
+	if err == nil {
+		if stealable, _ := l.stealable(ctx, legacy); !stealable {
+			return legacy, nil
+		}
+	} else if !errors.Is(err, cond.ErrNotFound{}) {
+		return nil, err
+	}
+
 	current, err := l.Get(ctx, appName)
 	if err != nil {
 		if errors.Is(err, cond.ErrNotFound{}) {
@@ -370,25 +389,34 @@ func (l *Locks) Blocking(ctx context.Context, appName string) (*Holder, error) {
 	return current, nil
 }
 
-// Get returns the current holder, or cond.ErrNotFound if the lock is free.
+// Get returns the current holder, or cond.ErrNotFound if the app is unlocked.
 func (l *Locks) Get(ctx context.Context, appName string) (*Holder, error) {
-	id := LockID(appName)
-
-	res, err := l.eac.Get(ctx, string(id))
+	holder, _, err := l.readApp(ctx, appName)
 	if err != nil {
 		return nil, err
 	}
+	if holder.DeploymentID == "" {
+		return nil, cond.NotFound("deployment lock", appName)
+	}
+	return holder, nil
+}
 
-	var stored core_v1alpha.DeploymentLock
-	stored.Decode(&entityAttrs{entity: res.Entity()})
+func (l *Locks) readApp(ctx context.Context, appName string) (*Holder, *core_v1alpha.App, error) {
+	res, err := l.eac.Get(ctx, "app/"+appName)
+	if err != nil {
+		return nil, nil, err
+	}
 
+	var app core_v1alpha.App
+	app.Decode(&entityAttrs{entity: res.Entity()})
+	lock := app.DeploymentLock
 	return &Holder{
-		AppName:      stored.AppName,
-		DeploymentID: stored.DeploymentId,
-		AcquiredAt:   stored.AcquiredAt,
-		ExpiresAt:    stored.ExpiresAt,
+		AppName:      appName,
+		DeploymentID: lock.DeploymentId,
+		AcquiredAt:   lock.AcquiredAt,
+		ExpiresAt:    lock.ExpiresAt,
 		Revision:     res.Entity().Revision(),
-	}, nil
+	}, &app, nil
 }
 
 func (l *Locks) holderFor(appName, deploymentID string) *Holder {
@@ -401,21 +429,20 @@ func (l *Locks) holderFor(appName, deploymentID string) *Holder {
 	}
 }
 
-func (l *Locks) encode(id entity.Id, h *Holder) []entity.Attr {
-	stored := &core_v1alpha.DeploymentLock{
-		AppName:      h.AppName,
+// replace updates the app's lock under a revision guard, so two callers that
+// both judged it available cannot both succeed. An empty holder writes an empty
+// component, which decodes as no lock while preserving patch semantics for
+// unrelated app attributes.
+func (l *Locks) replace(ctx context.Context, appID entity.Id, revision int64, h *Holder) (*Holder, error) {
+	lock := core_v1alpha.DeploymentLock{
 		DeploymentId: h.DeploymentID,
 		AcquiredAt:   h.AcquiredAt,
 		ExpiresAt:    h.ExpiresAt,
 	}
-
-	return append(stored.Encode(), entity.Ref(entity.DBId, id))
-}
-
-// replace takes over the lock entity under a revision guard, so two callers that
-// both judged the lock stealable cannot both succeed.
-func (l *Locks) replace(ctx context.Context, id entity.Id, revision int64, h *Holder) (*Holder, error) {
-	res, err := l.eac.Replace(ctx, l.encode(id, h), revision)
+	res, err := l.eac.Patch(ctx, []entity.Attr{
+		entity.Ref(entity.DBId, appID),
+		entity.Component(core_v1alpha.AppDeploymentLockId, lock.Encode()),
+	}, revision)
 	if err != nil {
 		return nil, err
 	}
@@ -423,6 +450,63 @@ func (l *Locks) replace(ctx context.Context, id entity.Id, revision int64, h *Ho
 	taken := *h
 	taken.Revision = res.Revision()
 	return &taken, nil
+}
+
+// CommitActivation swings the serving pointers while the same app revision
+// still proves that deploymentID owns the lock. The lock deliberately stays
+// in place until the attempt's terminal outcome is durable. That preserves a
+// recovery witness if the process dies between these two entity writes.
+func (l *Locks) CommitActivation(ctx context.Context, appName string, appID, versionID entity.Id, deploymentID string) error {
+	return l.commitActivation(ctx, appName, appID, versionID, deploymentID, 0)
+}
+
+// CommitActivationAtRevision preserves optimistic concurrency for a version
+// derived from a particular app snapshot. Unlike a regular deployment, a
+// configuration mutation must be rebuilt if that snapshot has moved.
+func (l *Locks) CommitActivationAtRevision(ctx context.Context, appName string, appID, versionID entity.Id,
+	deploymentID string, expectedRevision int64) error {
+	return l.commitActivation(ctx, appName, appID, versionID, deploymentID, expectedRevision)
+}
+
+func (l *Locks) commitActivation(ctx context.Context, appName string, appID, versionID entity.Id,
+	deploymentID string, expectedRevision int64) error {
+	for attempt := range updateRetryLimit {
+		current, app, err := l.readApp(ctx, appName)
+		if err != nil {
+			return err
+		}
+		if app.ID != appID {
+			return cond.Conflict("deployment-app", "deployment app reference no longer matches app name")
+		}
+		if app.ActiveVersion == versionID && app.ActiveDeployment == entity.Id(deploymentID) {
+			return nil
+		}
+		if expectedRevision != 0 && current.Revision != expectedRevision {
+			return cond.Conflict("app-revision", "app changed after deployment version was derived")
+		}
+		if current.DeploymentID != deploymentID || current.Expired(l.now.Now()) {
+			return cond.Conflict("deployment-lock", "deployment no longer owns its app lock")
+		}
+
+		_, err = l.eac.Patch(ctx, []entity.Attr{
+			entity.Ref(entity.DBId, app.ID),
+			entity.Ref(core_v1alpha.AppActiveVersionId, versionID),
+			entity.Ref(core_v1alpha.AppActiveDeploymentId, entity.Id(deploymentID)),
+		}, current.Revision)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, cond.ErrConflict{}) {
+			return fmt.Errorf("failed to update active deployment pointers: %w", err)
+		}
+		if expectedRevision != 0 {
+			return err
+		}
+		l.backoff(attempt + 1)
+	}
+
+	return fmt.Errorf("gave up activating deployment %s after %d attempts",
+		deploymentID, updateRetryLimit)
 }
 
 // entityAttrs adapts an RPC entity to the AttrGetter the generated decoders want.

--- a/pkg/deploylifecycle/lock_test.go
+++ b/pkg/deploylifecycle/lock_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 )
 
@@ -44,6 +46,13 @@ func newTestLocks(t *testing.T, status StatusLookup) (*Locks, *fakeClock) {
 	locks := NewLocks(log, inmem.EAC, status)
 	locks.now = clock.Now
 	locks.sleep = func(time.Duration) {} // don't add real latency to contention tests
+	for _, appName := range []string{"web", "api"} {
+		_, err := inmem.EAC.Ensure(context.Background(), []entity.Attr{
+			entity.Ref(entity.DBId, entity.Id("app/"+appName)),
+			entity.Ref(entity.EntityKind, core_v1alpha.KindApp),
+		})
+		require.NoError(t, err)
+	}
 
 	return locks, clock
 }
@@ -91,6 +100,8 @@ func TestAcquireIsIdempotentForSameDeployment(t *testing.T) {
 	second, err := locks.Acquire(ctx, "web", "dep-1")
 	require.NoError(t, err)
 	assert.Equal(t, "dep-1", second.DeploymentID)
+	assert.Equal(t, first.AcquiredAt, second.AcquiredAt,
+		"refreshing authority must preserve when the lock began")
 	assert.True(t, second.ExpiresAt.After(first.ExpiresAt),
 		"re-acquiring should extend the expiry")
 }
@@ -110,6 +121,35 @@ func TestAcquireStealsExpiredLock(t *testing.T) {
 	holder, err := locks.Acquire(ctx, "web", "dep-2")
 	require.NoError(t, err)
 	assert.Equal(t, "dep-2", holder.DeploymentID)
+}
+
+func TestCommitActivationAtRevisionRejectsChangedBase(t *testing.T) {
+	ctx := context.Background()
+	locks, _ := newTestLocks(t, nil)
+
+	_, err := locks.Acquire(ctx, "web", "dep-1")
+	require.NoError(t, err)
+
+	base, err := locks.eac.Get(ctx, "app/web")
+	require.NoError(t, err)
+	baseRevision := base.Entity().Revision()
+
+	_, err = locks.eac.Patch(ctx, []entity.Attr{
+		entity.Ref(entity.DBId, "app/web"),
+		entity.Ref(core_v1alpha.AppActiveVersionId, "app_version/concurrent"),
+	}, 0)
+	require.NoError(t, err)
+
+	err = locks.CommitActivationAtRevision(ctx, "web", "app/web", "app_version/ours", "dep-1", baseRevision)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, cond.ErrConflict{}), "got %T: %v", err, err)
+
+	current, err := locks.eac.Get(ctx, "app/web")
+	require.NoError(t, err)
+	var app core_v1alpha.App
+	app.Decode(&entityAttrs{entity: current.Entity()})
+	assert.Equal(t, entity.Id("app_version/concurrent"), app.ActiveVersion)
+	assert.Empty(t, app.ActiveDeployment)
 }
 
 // Lock and record can drift apart: the build failed but the lock outlived it.
@@ -135,17 +175,21 @@ func TestAcquireStealsLockWhoseDeploymentIsTerminal(t *testing.T) {
 	assert.Equal(t, "dep-2", holder.DeploymentID)
 }
 
-func TestAcquireStealsLockWhoseDeploymentIsGone(t *testing.T) {
+func TestAcquireWaitsForMissingDeploymentCreateWindow(t *testing.T) {
 	ctx := context.Background()
-	locks, _ := newTestLocks(t, func(context.Context, string) (Status, error) {
+	locks, clock := newTestLocks(t, func(context.Context, string) (Status, error) {
 		return "", cond.NotFound("deployment", "dep-1")
 	})
 
 	_, err := locks.Acquire(ctx, "web", "dep-1")
 	require.NoError(t, err)
 
+	_, err = locks.Acquire(ctx, "web", "dep-2")
+	require.ErrorIs(t, err, ErrLockHeld, "Begin acquires the lock just before creating its record")
+
+	clock.Advance(DefaultLockTTL + time.Second)
 	holder, err := locks.Acquire(ctx, "web", "dep-2")
-	require.NoError(t, err, "nothing will ever release a lock whose record vanished")
+	require.NoError(t, err)
 	assert.Equal(t, "dep-2", holder.DeploymentID)
 }
 
@@ -266,7 +310,35 @@ func TestReleaseDoesNotFreeALockStolenInTheReadWindow(t *testing.T) {
 		"a third deploy must not be able to start alongside dep-2")
 }
 
-// A released lock leaves a tombstone rather than disappearing, so the free/held
+func TestReleaseRetriesAfterUnrelatedAppWrite(t *testing.T) {
+	ctx := context.Background()
+	locks, _ := newTestLocks(t, nil)
+
+	_, err := locks.Acquire(ctx, "web", "dep-1")
+	require.NoError(t, err)
+
+	locks.releaseRace = func() {
+		locks.releaseRace = nil
+		_, err := locks.eac.Patch(ctx, []entity.Attr{
+			entity.Ref(entity.DBId, "app/web"),
+			entity.String(core_v1alpha.AppWorkloadRoleId, "app-writer"),
+		}, 0)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, locks.Release(ctx, "web", "dep-1"))
+	blocking, err := locks.Blocking(ctx, "web")
+	require.NoError(t, err)
+	assert.Nil(t, blocking)
+
+	res, err := locks.eac.Get(ctx, "app/web")
+	require.NoError(t, err)
+	var app core_v1alpha.App
+	app.Decode(&entityAttrs{entity: res.Entity()})
+	assert.Equal(t, "app-writer", app.WorkloadRole)
+}
+
+// A released lock is represented by an empty component, so the free/held
 // distinction has to survive that.
 func TestBlockingReportsOnlyRealBlockers(t *testing.T) {
 	ctx := context.Background()
@@ -298,7 +370,7 @@ func TestBlockingReportsOnlyRealBlockers(t *testing.T) {
 
 	blocking, err = locks.Blocking(ctx, "web")
 	require.NoError(t, err)
-	assert.Nil(t, blocking, "a released tombstone blocks nobody")
+	assert.Nil(t, blocking, "a released lock blocks nobody")
 
 	_, err = locks.Acquire(ctx, "web", "dep-2")
 	require.NoError(t, err)
@@ -340,8 +412,7 @@ func TestGetFreeLockReportsNotFound(t *testing.T) {
 	assert.True(t, errors.Is(err, cond.ErrNotFound{}), "got %T: %v", err, err)
 }
 
-// The race the old list-then-create scheme lost: many callers starting a deploy
-// for the same app+cluster at once.
+// Concurrent contenders for one app must produce exactly one admitted owner.
 func TestConcurrentAcquireYieldsExactlyOneWinner(t *testing.T) {
 	ctx := context.Background()
 	locks, _ := newTestLocks(t, func(context.Context, string) (Status, error) {
@@ -427,9 +498,39 @@ func TestAcquireRequiresIdentifiers(t *testing.T) {
 	}
 }
 
-func TestLockIDIsStable(t *testing.T) {
-	assert.Equal(t, LockID("web"), LockID("web"))
-	assert.NotEqual(t, LockID("web"), LockID("api"))
+func TestLockIsCanonicalOnAppAndShadowedForDowngrade(t *testing.T) {
+	ctx := context.Background()
+	locks, _ := newTestLocks(t, nil)
+
+	_, err := locks.Acquire(ctx, "web", "dep-1")
+	require.NoError(t, err)
+
+	res, err := locks.eac.Get(ctx, "app/web")
+	require.NoError(t, err)
+	var app core_v1alpha.App
+	app.Decode(&entityAttrs{entity: res.Entity()})
+	assert.Equal(t, "dep-1", app.DeploymentLock.DeploymentId)
+
+	legacy, err := locks.getLegacy(ctx, "web")
+	require.NoError(t, err)
+	assert.Equal(t, "dep-1", legacy.DeploymentID)
+}
+
+func TestLegacyOnlyLockBlocksCurrentAcquire(t *testing.T) {
+	ctx := context.Background()
+	locks, _ := newTestLocks(t, nil)
+
+	legacy := locks.holderFor("web", "old-deployment")
+	_, err := locks.eac.Ensure(ctx, encodeLegacyLock(legacyLockID("web"), legacy))
+	require.NoError(t, err)
+
+	holder, err := locks.Acquire(ctx, "web", "new-deployment")
+	require.ErrorIs(t, err, ErrLockHeld)
+	require.NotNil(t, holder)
+	assert.Equal(t, "old-deployment", holder.DeploymentID)
+
+	_, err = locks.Get(ctx, "web")
+	assert.ErrorIs(t, err, cond.ErrNotFound{}, "blocked acquire must not publish the canonical app lock")
 }
 
 // The lock is app-scoped: the same app is one lock regardless of cluster, but

--- a/pkg/deploylifecycle/source.go
+++ b/pkg/deploylifecycle/source.go
@@ -1,0 +1,58 @@
+package deploylifecycle
+
+import (
+	"net/url"
+	"strings"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+)
+
+// SourceFromGitInfo converts the verbose, legacy build metadata into the small
+// provenance record owned by AppVersion. Repository credentials and request
+// decorations are deliberately discarded before the value becomes durable.
+func SourceFromGitInfo(info core_v1alpha.GitInfo) core_v1alpha.Source {
+	return core_v1alpha.Source{
+		GitSha:     info.Sha,
+		GitBranch:  info.Branch,
+		Repository: sanitizeRepository(info.Repository),
+	}
+}
+
+func sanitizeRepository(repository string) string {
+	repository = strings.TrimSpace(repository)
+	if repository == "" {
+		return ""
+	}
+
+	// Git's scp-like syntax is not a URL, but it can still carry a user name.
+	// Preserve the familiar host:path form while dropping that user component.
+	if !strings.Contains(repository, "://") {
+		host := repository
+		if cut := strings.IndexAny(repository, ":/"); cut >= 0 {
+			host = repository[:cut]
+		}
+		if at := strings.LastIndex(host, "@"); at >= 0 {
+			repository = repository[at+1:]
+		}
+		if cut := strings.IndexAny(repository, "?#"); cut >= 0 {
+			repository = repository[:cut]
+		}
+		return repository
+	}
+
+	u, err := url.Parse(repository)
+	if err != nil || u.Scheme == "" {
+		return ""
+	}
+	// A local checkout path is not useful cluster provenance and can disclose
+	// host-specific filesystem details. Reject file URLs explicitly rather than
+	// relying on their normally empty host to do so incidentally.
+	if strings.EqualFold(u.Scheme, "file") || u.Host == "" {
+		return ""
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+	return u.String()
+}

--- a/pkg/deploylifecycle/source_test.go
+++ b/pkg/deploylifecycle/source_test.go
@@ -1,0 +1,26 @@
+package deploylifecycle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"miren.dev/runtime/api/core/core_v1alpha"
+)
+
+func TestSourceFromGitInfoSanitizesRepository(t *testing.T) {
+	tests := map[string]string{
+		"https://user:secret@example.com/acme/web.git?token=nope#fragment": "https://example.com/acme/web.git",
+		"git@example.com:acme/web.git":                                     "example.com:acme/web.git",
+		"git@example.com:acme/web.git@v1":                                  "example.com:acme/web.git@v1",
+		"example.com:acme/pkg@2":                                           "example.com:acme/pkg@2",
+		"file:///home/user/private/repo":                                   "",
+	}
+	for repository, want := range tests {
+		source := SourceFromGitInfo(core_v1alpha.GitInfo{
+			Sha: "abc", Branch: "main", Repository: repository,
+		})
+		assert.Equal(t, "abc", source.GitSha)
+		assert.Equal(t, "main", source.GitBranch)
+		assert.Equal(t, want, source.Repository)
+	}
+}

--- a/pkg/deploylifecycle/store.go
+++ b/pkg/deploylifecycle/store.go
@@ -12,6 +12,7 @@ import (
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
 )
 
 // pendingBuildSentinel and the failed-<id> pattern are values older clients wrote
@@ -19,27 +20,19 @@ import (
 // they are normalized away on read rather than migrated.
 const pendingBuildSentinel = "pending-build"
 
+// lockReservationStatus is written on the otherwise anonymous entity that
+// reserves a deployment ID for the lock owner. It is deliberately not a
+// public lifecycle status: an older runtime only needs to see a non-terminal
+// record while the compatibility lock points at the ID. Omitting entity/kind
+// and app_name keeps the reservation out of deployment history and migration.
+const lockReservationStatus = "_locking"
+
 // Record is a deployment entity together with what a caller needs to write it
 // back: the revision it was read at, and the raw entity for short-id rendering.
 type Record struct {
 	Deployment *core_v1alpha.Deployment
 	Entity     *entityserver_v1alpha.Entity
 	Revision   int64
-}
-
-// Status returns the record's status as a typed value.
-func (r *Record) Status() Status {
-	return Status(r.Deployment.Status)
-}
-
-// AppVersion returns the recorded app version, with legacy placeholder values
-// reported as empty — they never named a real version.
-func (r *Record) AppVersion() string {
-	version := r.Deployment.AppVersion
-	if version == pendingBuildSentinel || isFailedSentinel(version, string(r.Deployment.ID)) {
-		return ""
-	}
-	return version
 }
 
 func isFailedSentinel(version, deploymentID string) bool {
@@ -54,6 +47,9 @@ func isFailedSentinel(version, deploymentID string) bool {
 type Query struct {
 	AppName string
 	Status  Status
+	// LegacyStatus selects the downgrade representation. It is used only for
+	// compatibility bookkeeping such as settling the previously active row.
+	LegacyStatus Status
 
 	// Limit caps the result after sorting newest-first. Zero means no cap.
 	Limit int
@@ -77,6 +73,57 @@ func NewStore(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *S
 		eac: eac,
 		log: log.With("module", "deploylifecycle.store"),
 	}
+}
+
+func (s *Store) AppByName(ctx context.Context, name string) (*core_v1alpha.App, int64, error) {
+	res, err := s.eac.Get(ctx, "app/"+name)
+	if err != nil {
+		return nil, 0, err
+	}
+	var app core_v1alpha.App
+	app.Decode(&entityAttrs{entity: res.Entity()})
+	return &app, res.Entity().Revision(), nil
+}
+
+func (s *Store) EnsureApp(ctx context.Context, name string) (*core_v1alpha.App, int64, error) {
+	app, revision, err := s.AppByName(ctx, name)
+	if err == nil {
+		return app, revision, nil
+	}
+	if !errors.Is(err, cond.ErrNotFound{}) {
+		return nil, 0, err
+	}
+	app = &core_v1alpha.App{ID: entity.Id("app/" + name), Project: "project/default"}
+	attrs := append(app.Encode(), entity.Ref(entity.DBId, app.ID))
+	if _, ensureErr := s.eac.Ensure(ctx, attrs); ensureErr != nil {
+		return nil, 0, ensureErr
+	}
+	return s.AppByName(ctx, name)
+}
+
+func (s *Store) AppVersionByID(ctx context.Context, id string) (*core_v1alpha.AppVersion, error) {
+	res, err := s.eac.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	var version core_v1alpha.AppVersion
+	version.Decode(&entityAttrs{entity: res.Entity()})
+	return &version, nil
+}
+
+// SetActivePointers changes the two app pointers as one entity update. The
+// revision guard prevents an unrelated stale app write from silently undoing
+// an activation; callers retry after re-reading.
+func (s *Store) SetActivePointers(ctx context.Context, appID entity.Id, revision int64, versionID, deploymentID entity.Id) error {
+	attrs := []entity.Attr{
+		entity.Ref(entity.DBId, appID),
+		entity.Ref(core_v1alpha.AppActiveVersionId, versionID),
+		entity.Ref(core_v1alpha.AppActiveDeploymentId, deploymentID),
+	}
+	if _, err := s.eac.Patch(ctx, attrs, revision); err != nil {
+		return fmt.Errorf("failed to update active deployment pointers: %w", err)
+	}
+	return nil
 }
 
 // Get reads one deployment record.
@@ -109,15 +156,14 @@ func (s *Store) List(ctx context.Context, q Query) ([]*Record, error) {
 	records := make([]*Record, 0, len(res.Values()))
 	for _, e := range res.Values() {
 		rec := recordFrom(e)
-		if !q.matches(rec.Deployment) {
+		if !q.matches(rec) {
 			continue
 		}
 		records = append(records, rec)
 	}
 
-	// Timestamps are RFC3339, so lexical order is chronological order.
 	sort.Slice(records, func(i, j int) bool {
-		return records[i].Deployment.DeployedBy.Timestamp > records[j].Deployment.DeployedBy.Timestamp
+		return records[i].StartedAt().After(records[j].StartedAt())
 	})
 
 	if q.Limit > 0 && len(records) > q.Limit {
@@ -131,11 +177,6 @@ func (s *Store) List(ctx context.Context, q Query) ([]*Record, error) {
 // rather than by how many deploys have ever run: the deploy lock allows one
 // in-flight deployment per app, and activation settles the previous active one.
 // Every other status accumulates forever.
-var liveStatuses = map[Status]struct{}{
-	StatusInProgress: {},
-	StatusActive:     {},
-}
-
 // index picks the narrowest index the query's filters allow. Filters it does not
 // cover are still applied in memory, but over a far smaller set than a kind scan.
 //
@@ -146,27 +187,37 @@ var liveStatuses = map[Status]struct{}{
 // around. For a settled status the comparison flips, since those do grow without
 // bound, so the app index stays the better choice there.
 func (s *Store) index(q Query) entity.Attr {
-	statusIndex := entity.String(core_v1alpha.DeploymentStatusId, string(q.Status))
-
-	if _, live := liveStatuses[q.Status]; live {
-		return statusIndex
-	}
-
 	switch {
 	case q.AppName != "":
 		return entity.String(core_v1alpha.DeploymentAppNameId, q.AppName)
+	case q.LegacyStatus != "":
+		return entity.String(core_v1alpha.DeploymentStatusId, string(q.LegacyStatus))
+	case q.Status == StatusInProgress:
+		// Canonical outcome is absent while an attempt is running. During the
+		// downgrade window, the legacy status remains the narrow index for this
+		// compatibility query. Operational reconciliation walks deployment
+		// attempts directly, since the app lock is intentionally not a queue.
+		return entity.String(core_v1alpha.DeploymentStatusId, string(StatusInProgress))
 	case q.Status != "":
-		return statusIndex
+		// A settled canonical outcome has no compatibility-safe union with the
+		// legacy status index. Scan the kind during the downgrade window so an
+		// unmigrated matching record reaches Query.matches instead of disappearing
+		// before the canonical-first decoder sees it.
+		return entity.Ref(entity.EntityKind, core_v1alpha.KindDeployment)
 	default:
 		return entity.Ref(entity.EntityKind, core_v1alpha.KindDeployment)
 	}
 }
 
-func (q Query) matches(dep *core_v1alpha.Deployment) bool {
+func (q Query) matches(rec *Record) bool {
+	dep := rec.Deployment
 	if q.AppName != "" && dep.AppName != q.AppName {
 		return false
 	}
-	if q.Status != "" && dep.Status != string(q.Status) {
+	if q.Status != "" && rec.Status() != q.Status.Canonical() {
+		return false
+	}
+	if q.LegacyStatus != "" && dep.Status != string(q.LegacyStatus) {
 		return false
 	}
 	return true
@@ -187,20 +238,53 @@ func (s *Store) Put(ctx context.Context, rec *Record) error {
 	return nil
 }
 
-// Create writes a new deployment record and returns it with its assigned id.
+// Create writes a new deployment record. Ensure makes a fantastically unlikely
+// ID collision explicit instead of updating an existing attempt.
 func (s *Store) Create(ctx context.Context, dep *core_v1alpha.Deployment) (*Record, error) {
-	ent := &entityserver_v1alpha.Entity{}
-	ent.SetAttrs(dep.Encode())
-
-	res, err := s.eac.Put(ctx, ent)
+	if dep.ID == "" {
+		dep.ID = entity.Id(idgen.GenNS("deployment"))
+	}
+	attrs := append(dep.Encode(), entity.Ref(entity.DBId, dep.ID))
+	res, err := s.eac.Ensure(ctx, attrs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create deployment: %w", err)
 	}
-
-	dep.ID = entity.Id(res.Id())
+	if !res.Created() {
+		return nil, cond.Conflict("deployment-id", string(dep.ID))
+	}
 
 	// Read back so the caller holds a revision it can write against.
-	return s.Get(ctx, res.Id())
+	return s.Get(ctx, string(dep.ID))
+}
+
+// ReserveLockOwner creates an anonymous placeholder for a deployment ID before
+// lock acquisition. During a rolling upgrade, an older runtime treats a legacy
+// lock whose deployment record is missing as abandoned and steals it. The
+// placeholder closes that publication window without making an unsuccessful
+// lock attempt appear in deployment history.
+func (s *Store) ReserveLockOwner(ctx context.Context, deploymentID entity.Id) (int64, error) {
+	attrs := []entity.Attr{
+		entity.Ref(entity.DBId, deploymentID),
+		entity.String(core_v1alpha.DeploymentStatusId, string(lockReservationStatus)),
+	}
+	res, err := s.eac.Ensure(ctx, attrs)
+	if err != nil {
+		return 0, fmt.Errorf("failed to reserve deployment lock owner: %w", err)
+	}
+	if !res.Created() {
+		return 0, cond.Conflict("deployment-id", string(deploymentID))
+	}
+	return res.Revision(), nil
+}
+
+// PublishLockOwner atomically replaces a lock-owner reservation with the full
+// deployment record after both the compatibility and canonical locks are held.
+func (s *Store) PublishLockOwner(ctx context.Context, dep *core_v1alpha.Deployment, revision int64) (*Record, error) {
+	attrs := append(dep.Encode(), entity.Ref(entity.DBId, dep.ID))
+	if _, err := s.eac.Replace(ctx, attrs, revision); err != nil {
+		return nil, fmt.Errorf("failed to publish deployment lock owner: %w", err)
+	}
+	return s.Get(ctx, string(dep.ID))
 }
 
 // Delete removes a deployment record.
@@ -218,8 +302,8 @@ func (s *Store) Delete(ctx context.Context, deploymentID string) error {
 // a settled status, leaving the incoming deployment alone.
 func (s *Store) MarkPreviousActiveAs(ctx context.Context, appName, exceptID string, target Status) error {
 	previous, err := s.List(ctx, Query{
-		AppName: appName,
-		Status:  StatusActive,
+		AppName:      appName,
+		LegacyStatus: StatusActive,
 	})
 	if err != nil {
 		return err
@@ -230,12 +314,8 @@ func (s *Store) MarkPreviousActiveAs(ctx context.Context, appName, exceptID stri
 			continue
 		}
 
-		if err := Transition(rec.Status(), target); err != nil {
-			s.log.Warn("skipping previous deployment that cannot settle",
-				"deployment_id", rec.Deployment.ID, "from", rec.Status(), "to", target, "error", err)
-			continue
-		}
-
+		// This is compatibility-only bookkeeping. Never touch canonical outcome:
+		// the prior attempt succeeded regardless of what is serving now.
 		rec.Deployment.Status = string(target)
 		if rec.Deployment.CompletedAt == "" {
 			rec.Deployment.CompletedAt = s.now.Now().Format(time.RFC3339)

--- a/pkg/deploylifecycle/store_test.go
+++ b/pkg/deploylifecycle/store_test.go
@@ -44,9 +44,9 @@ func seed(t *testing.T, s *Store, app, cluster string, status Status, at time.Ti
 	return string(rec.Deployment.ID)
 }
 
-// TestIndexSelection pins the index each query shape uses. Getting this wrong
-// does not break correctness — the in-memory filters still apply — it silently
-// reintroduces the full scan this type exists to remove.
+// TestIndexSelection pins the index each query shape uses. The selected index
+// determines which records reach the in-memory compatibility filter, so this is
+// a correctness choice as well as a scan-size choice during migration.
 func TestIndexSelection(t *testing.T) {
 	s := newTestStore(t)
 
@@ -61,17 +61,14 @@ func TestIndexSelection(t *testing.T) {
 			want:  entity.String(core_v1alpha.DeploymentAppNameId, "web"),
 		},
 		{
-			// A live status is bounded by app count, so it beats the app index,
-			// which grows with that app's whole deploy history. This is the
-			// activation path's query.
-			name:  "live status wins over app name",
+			name:  "app name wins over canonical status",
 			query: Query{AppName: "web", Status: StatusActive},
-			want:  entity.String(core_v1alpha.DeploymentStatusId, "active"),
+			want:  entity.String(core_v1alpha.DeploymentAppNameId, "web"),
 		},
 		{
-			name:  "in_progress is live too",
+			name:  "app name wins for in progress too",
 			query: Query{AppName: "web", Status: StatusInProgress},
-			want:  entity.String(core_v1alpha.DeploymentStatusId, "in_progress"),
+			want:  entity.String(core_v1alpha.DeploymentAppNameId, "web"),
 		},
 		{
 			// Settled statuses accumulate forever, so the app index is narrower.
@@ -83,6 +80,11 @@ func TestIndexSelection(t *testing.T) {
 			name:  "status only",
 			query: Query{Status: StatusInProgress},
 			want:  entity.String(core_v1alpha.DeploymentStatusId, "in_progress"),
+		},
+		{
+			name:  "settled status includes legacy records",
+			query: Query{Status: StatusFailed},
+			want:  entity.Ref(entity.EntityKind, core_v1alpha.KindDeployment),
 		},
 		{
 			name:  "unfiltered falls back to a kind scan",
@@ -113,6 +115,17 @@ func TestListFiltersByAppAndStatus(t *testing.T) {
 	got, err := s.List(ctx, Query{AppName: "web", Status: StatusInProgress})
 	require.NoError(t, err)
 
+	require.Len(t, got, 1)
+	assert.Equal(t, want, string(got[0].Deployment.ID))
+}
+
+func TestSettledStatusOnlyQueryIncludesLegacyRecord(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	want := seed(t, s, "web", "prod", StatusFailed, time.Now())
+
+	got, err := s.List(ctx, Query{Status: StatusFailed})
+	require.NoError(t, err)
 	require.Len(t, got, 1)
 	assert.Equal(t, want, string(got[0].Deployment.ID))
 }
@@ -187,7 +200,43 @@ func TestStatusLookup(t *testing.T) {
 	_, err = s.Status(ctx, "deployment/missing")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, cond.ErrNotFound{}),
-		"a missing record must report NotFound so the lock can steal from it; got %T", err)
+		"a missing record must remain distinguishable from an empty status; got %T", err)
+}
+
+func TestLockReservationIsPrivateUntilPublished(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	id := entity.Id("deployment/reserved")
+
+	revision, err := s.ReserveLockOwner(ctx, id)
+	require.NoError(t, err)
+	assert.Positive(t, revision)
+
+	status, err := s.Status(ctx, string(id))
+	require.NoError(t, err)
+	assert.Equal(t, Status(lockReservationStatus), status)
+	assert.False(t, status.Terminal(),
+		"an older runtime must not steal the compatibility lock during acquisition")
+
+	listed, err := s.List(ctx, Query{})
+	require.NoError(t, err)
+	assert.Empty(t, listed, "a lock reservation is not deployment history")
+
+	dep := &core_v1alpha.Deployment{
+		ID:        id,
+		AppName:   "web",
+		Operation: string(OperationBuild),
+		StartedAt: time.Now(),
+		Status:    string(StatusInProgress),
+	}
+	rec, err := s.PublishLockOwner(ctx, dep, revision)
+	require.NoError(t, err)
+	assert.Equal(t, StatusInProgress, rec.Status())
+
+	listed, err = s.List(ctx, Query{})
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, id, listed[0].Deployment.ID)
 }
 
 // The Store satisfies the lock manager's StatusLookup without an adapter, which
@@ -241,10 +290,10 @@ func TestMarkPreviousActiveAs(t *testing.T) {
 
 	require.NoError(t, s.MarkPreviousActiveAs(ctx, "web", incoming, StatusSucceeded))
 
-	assertStatus(t, s, previous, StatusSucceeded)
-	assertStatus(t, s, incoming, StatusActive)
-	assertStatus(t, s, otherApp, StatusActive)
-	assertStatus(t, s, otherClusterString, StatusSucceeded)
+	assertLegacyStatus(t, s, previous, StatusSucceeded)
+	assertLegacyStatus(t, s, incoming, StatusActive)
+	assertLegacyStatus(t, s, otherApp, StatusActive)
+	assertLegacyStatus(t, s, otherClusterString, StatusSucceeded)
 
 	rec, err := s.Get(ctx, previous)
 	require.NoError(t, err)
@@ -261,7 +310,7 @@ func TestMarkPreviousActiveAsRolledBack(t *testing.T) {
 
 	require.NoError(t, s.MarkPreviousActiveAs(ctx, "web", incoming, StatusRolledBack))
 
-	assertStatus(t, s, previous, StatusRolledBack)
+	assertLegacyStatus(t, s, previous, StatusRolledBack)
 }
 
 // Only active deployments are settled. An in-progress one is someone else's
@@ -276,7 +325,7 @@ func TestMarkPreviousActiveAsLeavesInProgressAlone(t *testing.T) {
 
 	require.NoError(t, s.MarkPreviousActiveAs(ctx, "web", incoming, StatusSucceeded))
 
-	assertStatus(t, s, running, StatusInProgress)
+	assertLegacyStatus(t, s, running, StatusInProgress)
 }
 
 func TestPutRejectsStaleRevision(t *testing.T) {
@@ -308,10 +357,9 @@ func ids(records []*Record) []string {
 	return out
 }
 
-func assertStatus(t *testing.T, s *Store, id string, want Status) {
+func assertLegacyStatus(t *testing.T, s *Store, id string, want Status) {
 	t.Helper()
-
 	rec, err := s.Get(context.Background(), id)
 	require.NoError(t, err)
-	assert.Equal(t, want, rec.Status(), "status of %s", id)
+	assert.Equal(t, string(want), rec.Deployment.Status, "legacy status of %s", id)
 }

--- a/pkg/deploylifecycle/tracker.go
+++ b/pkg/deploylifecycle/tracker.go
@@ -6,16 +6,26 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+	"unicode/utf8"
 
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/rpc"
 )
 
 // updateRetryLimit bounds the read-modify-write loop. A conflict means another
 // writer touched the record between our read and our write, so retrying is the
 // correct response; the cap only exists to stop a pathological loop.
 const updateRetryLimit = 100
+
+// Failure summaries are stored on the attempt so history can explain a failed
+// deployment without fetching logs. Keep them small: detailed and potentially
+// unbounded build output belongs in the log stream, not the entity record.
+const maxFailureSummaryBytes = 4 * 1024
+const failureSummaryEllipsis = "…"
 
 // Tracker is the deployment lifecycle as a set of operations, and the surface
 // the build paths call. It exists so the record is a byproduct of the work
@@ -33,8 +43,8 @@ type Tracker struct {
 }
 
 // NewTracker wires a tracker over the entity store. The lock manager is given
-// the store's status lookup, so an abandoned lock can be reconciled against the
-// record it claims to be holding for.
+// the store's status lookup, so an abandoned app lock can be reconciled
+// against the record it names.
 func NewTracker(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *Tracker {
 	store := NewStore(log, eac)
 
@@ -56,7 +66,9 @@ func (t *Tracker) Locks() *Locks { return t.locks }
 // BeginParams describes a deployment about to start.
 type BeginParams struct {
 	AppName   string
+	AppID     entity.Id
 	ClusterID string
+	Operation Operation
 
 	// AppVersion is normally empty: a forward deploy does not know its version
 	// until the build produces one. Rollback knows it up front.
@@ -64,49 +76,152 @@ type BeginParams struct {
 
 	GitInfo    core_v1alpha.GitInfo
 	DeployedBy core_v1alpha.DeployedBy
+	Subject    string
+	AuthMethod string
 
-	// SourceDeploymentID records what this deployment was derived from, for
-	// rollback and redeploy provenance.
-	SourceDeploymentID string
+	// ParentDeploymentID records the deployment this attempt was based on.
+	ParentDeploymentID string
 }
 
-// Begin creates the deployment record and takes the deploy lock for it.
+// Begin acquires the deploy lock and publishes a deployment record.
 //
 // If another live deployment holds the lock, Begin returns a *LockHeldError
 // (matching errors.Is(err, ErrLockHeld)) describing the blocker, and leaves no
-// record behind.
+// deployment in history. A private lock-owner reservation ensures that an
+// older runtime cannot mistake the compatibility lock's not-yet-published owner
+// for an abandoned deployment during a rolling upgrade.
 func (t *Tracker) Begin(ctx context.Context, params BeginParams) (*Record, error) {
-	if params.AppName == "" || params.ClusterID == "" {
+	if params.AppName == "" {
 		return nil, cond.ValidationFailure("missing-field",
-			"app_name and cluster_id are required to begin a deployment")
+			"app_name is required to begin a deployment")
+	}
+	if params.Operation == "" {
+		params.Operation = OperationBuild
+	}
+	autoParent := false
+	if !params.Operation.Valid() {
+		return nil, cond.ValidationFailure("invalid-operation", "unknown deployment operation")
+	}
+
+	var app *core_v1alpha.App
+	if params.AppID == "" {
+		var resolved *core_v1alpha.App
+		var err error
+		if params.Operation == OperationBuild {
+			resolved, _, err = t.store.EnsureApp(ctx, params.AppName)
+		} else {
+			resolved, _, err = t.store.AppByName(ctx, params.AppName)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve deployment app: %w", err)
+		}
+		app = resolved
+		params.AppID = app.ID
+	} else if params.Operation == OperationConfigChange && params.ParentDeploymentID == "" {
+		resolved, _, err := t.store.AppByName(ctx, params.AppName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve deployment app: %w", err)
+		}
+		if resolved.ID != params.AppID {
+			return nil, cond.ValidationFailure("deployment-app-mismatch", "deployment app reference does not match app name")
+		}
+		app = resolved
+	}
+	if params.ParentDeploymentID == "" && app != nil && app.ActiveDeployment != "" {
+		params.ParentDeploymentID = string(app.ActiveDeployment)
+		autoParent = true
 	}
 
 	deployedBy := params.DeployedBy
+	if params.Subject == "" || params.AuthMethod == "" {
+		if identity := rpc.IdentityFromContext(ctx); identity != nil && identity.Method != rpc.AuthMethodAnonymous {
+			if params.Subject == "" {
+				params.Subject = identity.Subject
+			}
+			if params.AuthMethod == "" {
+				params.AuthMethod = string(identity.Method)
+			}
+		}
+	}
+	if params.Subject != "" {
+		deployedBy.Subject = params.Subject
+	}
+	if params.AuthMethod != "" {
+		deployedBy.AuthMethod = params.AuthMethod
+	}
 	if deployedBy.Timestamp == "" {
 		deployedBy.Timestamp = t.now.Now().Format(time.RFC3339)
 	}
+	startedAt := t.now.Now().UTC()
+	if parsed, err := time.Parse(time.RFC3339, deployedBy.Timestamp); err == nil {
+		startedAt = parsed.UTC()
+	}
+	params.GitInfo.Repository = SourceFromGitInfo(params.GitInfo).Repository
 
-	rec, err := t.store.Create(ctx, &core_v1alpha.Deployment{
-		AppName:            params.AppName,
-		ClusterId:          params.ClusterID,
-		AppVersion:         params.AppVersion,
-		Status:             string(StatusInProgress),
-		Phase:              string(PhasePreparing),
-		DeployedBy:         deployedBy,
-		GitInfo:            params.GitInfo,
-		SourceDeploymentId: params.SourceDeploymentID,
-	})
+	dep := &core_v1alpha.Deployment{
+		ID:         entity.Id(idgen.GenNS("deployment")),
+		App:        params.AppID,
+		AppName:    params.AppName,
+		ClusterId:  params.ClusterID,
+		Operation:  schemaOperation(params.Operation),
+		StartedAt:  startedAt,
+		DeployedBy: deployedBy,
+		GitInfo:    params.GitInfo,
+	}
+	pending := &Record{Deployment: dep}
+	pending.setInProgress()
+	pending.setPhase(PhasePreparing)
+
+	if params.AppVersion != "" {
+		version, err := t.store.AppVersionByID(ctx, params.AppVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve deployment version: %w", err)
+		}
+		if version.App != "" && version.App != params.AppID {
+			return nil, cond.ValidationFailure("app-version-mismatch", "app version does not belong to deployment app")
+		}
+		pending.setVersion(version.ID)
+	}
+	if params.ParentDeploymentID != "" {
+		parent, err := t.store.Get(ctx, params.ParentDeploymentID)
+		if err != nil {
+			if autoParent && errors.Is(err, cond.ErrNotFound{}) {
+				params.ParentDeploymentID = ""
+			} else {
+				return nil, fmt.Errorf("failed to resolve parent deployment: %w", err)
+			}
+		} else {
+			if (parent.Canonical() && parent.AppID() != params.AppID) ||
+				(!parent.Canonical() && parent.Deployment.AppName != params.AppName) {
+				return nil, cond.ValidationFailure("parent-deployment-mismatch", "parent deployment does not belong to deployment app")
+			}
+			pending.setParentDeployment(parent.Deployment.ID)
+		}
+	}
+
+	deploymentID := string(dep.ID)
+	lockReservationRevision, err := t.store.ReserveLockOwner(ctx, dep.ID)
 	if err != nil {
 		return nil, err
 	}
-
-	deploymentID := string(rec.Deployment.ID)
+	discardLockReservation := func(reason string) {
+		if deleteErr := t.store.Delete(ctx, deploymentID); deleteErr != nil {
+			t.log.Error("failed to discard deployment lock reservation",
+				"deployment_id", deploymentID, "reason", reason, "error", deleteErr)
+		}
+	}
 
 	if _, err := t.locks.Acquire(ctx, params.AppName, deploymentID); err != nil {
-		// We hold no lock, so this record describes a deploy that will never
-		// run. Leaving it would show up in history as a deployment stuck
-		// in_progress forever.
-		t.discard(ctx, rec)
+		discardLockReservation("lock acquisition failed")
+		return nil, err
+	}
+
+	rec, err := t.store.PublishLockOwner(ctx, dep, lockReservationRevision)
+	if err != nil {
+		if releaseErr := t.locks.Release(ctx, params.AppName, deploymentID); releaseErr != nil {
+			t.log.Error("failed to release lock after deployment publication failed", "error", releaseErr)
+		}
+		discardLockReservation("deployment publication failed")
 		return nil, err
 	}
 
@@ -118,14 +233,6 @@ func (t *Tracker) Begin(ctx context.Context, params BeginParams) (*Record, error
 	return rec, nil
 }
 
-// discard removes a record that never became a real deployment.
-func (t *Tracker) discard(ctx context.Context, rec *Record) {
-	if err := t.store.Delete(ctx, string(rec.Deployment.ID)); err != nil {
-		t.log.Error("failed to discard deployment record that never acquired its lock",
-			"deployment_id", rec.Deployment.ID, "error", err)
-	}
-}
-
 // SetPhase records fine-grained progress. Phases only mean something while a
 // deployment is in flight, so setting one on a settled record is a conflict.
 func (t *Tracker) SetPhase(ctx context.Context, deploymentID string, phase Phase) error {
@@ -134,7 +241,7 @@ func (t *Tracker) SetPhase(ctx context.Context, deploymentID string, phase Phase
 			return err
 		}
 
-		rec.Deployment.Phase = string(phase)
+		rec.setPhase(phase)
 		return nil
 	})
 }
@@ -152,7 +259,14 @@ func (t *Tracker) SetAppVersion(ctx context.Context, deploymentID, appVersionID 
 				fmt.Sprintf("cannot set app version on deployment in %s state", rec.Status()))
 		}
 
-		rec.Deployment.AppVersion = appVersionID
+		version, err := t.store.AppVersionByID(ctx, appVersionID)
+		if err != nil {
+			return err
+		}
+		if rec.AppID() != "" && version.App != "" && version.App != rec.AppID() {
+			return cond.ValidationFailure("app-version-mismatch", "app version does not belong to deployment app")
+		}
+		rec.setVersion(version.ID)
 		return nil
 	})
 }
@@ -160,37 +274,83 @@ func (t *Tracker) SetAppVersion(ctx context.Context, deploymentID, appVersionID 
 // Activate marks the deployment live and settles the one it replaced as
 // succeeded. The lock is released: the deploy is over.
 func (t *Tracker) Activate(ctx context.Context, deploymentID string) error {
-	return t.activate(ctx, deploymentID, StatusSucceeded)
+	return t.activate(ctx, deploymentID, "", 0)
+}
+
+// ActivateAtRevision activates only if the app is still at the revision from
+// which a configuration mutation was derived. A conflict lets the caller
+// discard its speculative version and rebuild it from the winning state.
+func (t *Tracker) ActivateAtRevision(ctx context.Context, deploymentID string, appRevision int64) error {
+	return t.activate(ctx, deploymentID, "", appRevision)
 }
 
 // ActivateRollback is Activate for a rollback, which settles the deployment it
 // replaced as rolled_back rather than succeeded.
 func (t *Tracker) ActivateRollback(ctx context.Context, deploymentID string) error {
-	return t.activate(ctx, deploymentID, StatusRolledBack)
+	return t.activate(ctx, deploymentID, StatusRolledBack, 0)
 }
 
-func (t *Tracker) activate(ctx context.Context, deploymentID string, supersede Status) error {
+func (t *Tracker) activate(ctx context.Context, deploymentID string, supersede Status, appRevision int64) error {
+	rec, err := t.store.Get(ctx, deploymentID)
+	if err != nil {
+		return err
+	}
+	if rec.Status() == StatusSucceeded {
+		t.release(ctx, rec)
+		return nil
+	}
+	if err := Transition(rec.Status(), StatusSucceeded); err != nil {
+		return err
+	}
+	if rec.AppID() == "" || rec.AppVersion() == "" {
+		return cond.ValidationFailure("missing-field", "cannot activate a deployment without app and version references")
+	}
+
+	// The app update is the activation. CommitActivation reads the lock and
+	// serving pointers from one app revision, then guards the pointer swing with
+	// that same revision. A worker that lost its lease cannot overwrite its
+	// successor's lock or make itself current.
+	var activationErr error
+	if appRevision == 0 {
+		activationErr = t.locks.CommitActivation(ctx, rec.Deployment.AppName, rec.AppID(),
+			entity.Id(rec.AppVersion()), deploymentID)
+	} else {
+		activationErr = t.locks.CommitActivationAtRevision(ctx, rec.Deployment.AppName, rec.AppID(),
+			entity.Id(rec.AppVersion()), deploymentID, appRevision)
+	}
+	if activationErr != nil {
+		return activationErr
+	}
+
 	var settled *Record
-
-	err := t.update(ctx, deploymentID, func(rec *Record) error {
-		// The version is required here rather than at creation: this is the
-		// point where a deployment claims to be running a specific image.
-		if rec.AppVersion() == "" {
-			return cond.ValidationFailure("missing-field",
-				"cannot activate a deployment with no app version")
+	err = t.update(ctx, deploymentID, func(current *Record) error {
+		if current.Status() == StatusSucceeded {
+			settled = current
+			return nil
 		}
-
-		if err := Transition(rec.Status(), StatusActive); err != nil {
+		if err := Transition(current.Status(), StatusSucceeded); err != nil {
 			return err
 		}
-
-		rec.Deployment.Status = string(StatusActive)
-		rec.Deployment.CompletedAt = t.now.Now().Format(time.RFC3339)
-		settled = rec
+		finished := t.now.Now().UTC()
+		current.setOutcome(StatusSucceeded)
+		current.Deployment.CompletedAt = finished.Format(time.RFC3339)
+		settled = current
 		return nil
 	})
 	if err != nil {
-		return err
+		// The app pointers are already committed. Treat a terminal-record write as
+		// repairable bookkeeping so a caller never reports a live deployment as
+		// failed or tries to compensate it. Leave the app lock owned by this
+		// attempt so reconciliation can settle the outcome before releasing it.
+		t.log.Error("activation committed but terminal deployment write failed",
+			"deployment_id", deploymentID, "error", err)
+		return nil
+	}
+	if supersede == "" {
+		supersede = StatusSucceeded
+		if settled.Operation() == OperationRollback {
+			supersede = StatusRolledBack
+		}
 	}
 
 	// Bookkeeping past this point must not fail an activation that already
@@ -210,16 +370,14 @@ func (t *Tracker) activate(ctx context.Context, deploymentID string, supersede S
 // A deployment that was cancelled stays cancelled: the operator's action is the
 // more meaningful account of what happened, and the build failing afterwards is
 // a consequence of it.
-func (t *Tracker) Fail(ctx context.Context, deploymentID, errorMessage, buildLogs string) error {
+func (t *Tracker) Fail(ctx context.Context, deploymentID, failureSummary string) error {
 	var settled *Record
 
 	err := t.update(ctx, deploymentID, func(rec *Record) error {
 		if rec.Status() == StatusCancelled {
 			// A build failing after an operator cancelled it does not change
 			// what happened: the cancellation is the real account. Keep that
-			// reason and preserve the logs for diagnosis rather than
-			// overwriting the message with a downstream symptom.
-			rec.Deployment.BuildLogs = buildLogs
+			// reason rather than overwriting it with a downstream symptom.
 			settled = rec
 			return nil
 		}
@@ -227,10 +385,10 @@ func (t *Tracker) Fail(ctx context.Context, deploymentID, errorMessage, buildLog
 		if err := Transition(rec.Status(), StatusFailed); err != nil {
 			return err
 		}
-		rec.Deployment.Status = string(StatusFailed)
-		rec.Deployment.ErrorMessage = errorMessage
-		rec.Deployment.BuildLogs = buildLogs
-		rec.Deployment.CompletedAt = t.now.Now().Format(time.RFC3339)
+		finished := t.now.Now().UTC()
+		rec.setOutcome(StatusFailed)
+		rec.Deployment.ErrorMessage = boundedFailureSummary(failureSummary)
+		rec.Deployment.CompletedAt = finished.Format(time.RFC3339)
 		settled = rec
 		return nil
 	})
@@ -251,14 +409,14 @@ func (t *Tracker) Fail(ctx context.Context, deploymentID, errorMessage, buildLog
 // finished" is exactly what a defer wants, and a deployment that is already
 // active, succeeded or cancelled has a better account of itself than a late
 // error does.
-func (t *Tracker) FailIfUnsettled(ctx context.Context, deploymentID, errorMessage, buildLogs string) error {
-	err := t.Fail(ctx, deploymentID, errorMessage, buildLogs)
+func (t *Tracker) FailIfUnsettled(ctx context.Context, deploymentID, failureSummary string) error {
+	err := t.Fail(ctx, deploymentID, failureSummary)
 	if err == nil || !errors.Is(err, cond.ErrConflict{}) {
 		return err
 	}
 
 	t.log.Debug("not recording failure against an already-settled deployment",
-		"deployment_id", deploymentID, "error_message", errorMessage)
+		"deployment_id", deploymentID, "error_message", boundedFailureSummary(failureSummary))
 	return nil
 }
 
@@ -271,10 +429,11 @@ func (t *Tracker) Cancel(ctx context.Context, deploymentID, reason string) error
 			return err
 		}
 
-		rec.Deployment.Status = string(StatusCancelled)
-		rec.Deployment.CompletedAt = t.now.Now().Format(time.RFC3339)
+		finished := t.now.Now().UTC()
+		rec.setOutcome(StatusCancelled)
+		rec.Deployment.CompletedAt = finished.Format(time.RFC3339)
 		if reason != "" {
-			rec.Deployment.ErrorMessage = reason
+			rec.Deployment.ErrorMessage = boundedFailureSummary(reason)
 		}
 		settled = rec
 		return nil
@@ -287,19 +446,103 @@ func (t *Tracker) Cancel(ctx context.Context, deploymentID, reason string) error
 	return nil
 }
 
-// ReleaseLock frees the deploy lock held by a deployment without changing the
-// record, looking the app+cluster up from the record itself.
-//
-// It is a backstop for a caller whose activation already made the version live
-// but whose record settle failed: releasing the lock keeps a record that will
-// never settle from stalling every later deploy of that app+cluster for the
-// full lock TTL. Release is a no-op if a newer deployment already holds the lock.
-func (t *Tracker) ReleaseLock(ctx context.Context, deploymentID string) error {
+func boundedFailureSummary(summary string) string {
+	if len(summary) <= maxFailureSummaryBytes {
+		return summary
+	}
+
+	cut := summary[:maxFailureSummaryBytes-len(failureSummaryEllipsis)]
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + failureSummaryEllipsis
+}
+
+// Reconcile converges the crash window between the app pointer CAS and the
+// attempt's terminal write, and marks abandoned attempts interrupted once their
+// lock lease and grace period are both gone.
+func (t *Tracker) Reconcile(ctx context.Context, deploymentID string) error {
 	rec, err := t.store.Get(ctx, deploymentID)
+	if err != nil || rec.Status() != StatusInProgress {
+		return err
+	}
+	app, _, err := t.store.AppByName(ctx, rec.Deployment.AppName)
 	if err != nil {
 		return err
 	}
-	return t.locks.Release(ctx, rec.Deployment.AppName, deploymentID)
+	versionMatches := rec.AppVersion() != "" && app.ActiveVersion == entity.Id(rec.AppVersion())
+	deploymentMatches := app.ActiveDeployment == rec.Deployment.ID
+	if versionMatches && deploymentMatches {
+		return t.settleReconciledSuccess(ctx, rec)
+	}
+	if versionMatches != deploymentMatches {
+		t.log.Warn("deployment reconciliation found split app pointers",
+			"deployment_id", deploymentID,
+			"active_version", app.ActiveVersion,
+			"active_deployment", app.ActiveDeployment)
+		return nil
+	}
+
+	owned, err := t.locks.Owns(ctx, rec.Deployment.AppName, deploymentID)
+	if err != nil || owned {
+		return err
+	}
+	started := rec.StartedAt()
+	if started.IsZero() && rec.Entity != nil && rec.Entity.HasCreatedAt() {
+		started = time.UnixMilli(rec.Entity.CreatedAt())
+	}
+	if started.IsZero() || t.now.Now().Sub(started) < DefaultLockTTL {
+		return nil
+	}
+	return t.interrupt(ctx, deploymentID)
+}
+
+func (t *Tracker) settleReconciledSuccess(ctx context.Context, rec *Record) error {
+	var settled *Record
+	if err := t.update(ctx, string(rec.Deployment.ID), func(current *Record) error {
+		if current.Status() != StatusInProgress {
+			settled = current
+			return nil
+		}
+		finished := t.now.Now().UTC()
+		current.setOutcome(StatusSucceeded)
+		current.Deployment.CompletedAt = finished.Format(time.RFC3339)
+		settled = current
+		return nil
+	}); err != nil {
+		return err
+	}
+	supersede := StatusSucceeded
+	if settled.Operation() == OperationRollback {
+		supersede = StatusRolledBack
+	}
+	if err := t.store.MarkPreviousActiveAs(ctx,
+		settled.Deployment.AppName, string(settled.Deployment.ID), supersede); err != nil {
+		t.log.Error("failed to settle previously active deployments during reconciliation",
+			"deployment_id", settled.Deployment.ID, "error", err)
+	}
+	t.release(ctx, settled)
+	return nil
+}
+
+func (t *Tracker) interrupt(ctx context.Context, deploymentID string) error {
+	var settled *Record
+	if err := t.update(ctx, deploymentID, func(rec *Record) error {
+		if rec.Status() != StatusInProgress {
+			return nil
+		}
+		finished := t.now.Now().UTC()
+		rec.setOutcome(StatusInterrupted)
+		rec.Deployment.CompletedAt = finished.Format(time.RFC3339)
+		settled = rec
+		return nil
+	}); err != nil {
+		return err
+	}
+	if settled != nil {
+		t.release(ctx, settled)
+	}
+	return nil
 }
 
 // release drops the deploy lock for a settled deployment. A failure here is

--- a/pkg/deploylifecycle/tracker_test.go
+++ b/pkg/deploylifecycle/tracker_test.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/rpc"
 )
 
 func newTestTracker(t *testing.T) (*Tracker, *fakeClock) {
@@ -28,11 +32,31 @@ func newTestTracker(t *testing.T) (*Tracker, *fakeClock) {
 	tracker.store.now = clock.Now
 	tracker.locks.now = clock.Now
 
+	ensureTestApp(t, tracker, "web")
+	for _, id := range []string{"app_version/v1", "app_version/v2"} {
+		_, err := inmem.EAC.Ensure(context.Background(), []entity.Attr{
+			entity.Ref(entity.DBId, entity.Id(id)),
+			entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion),
+			entity.Ref(core_v1alpha.AppVersionAppId, "app/web"),
+		})
+		require.NoError(t, err)
+	}
+
 	return tracker, clock
+}
+
+func ensureTestApp(t *testing.T, tr *Tracker, app string) {
+	t.Helper()
+	_, err := tr.store.eac.Ensure(context.Background(), []entity.Attr{
+		entity.Ref(entity.DBId, entity.Id("app/"+app)),
+		entity.Ref(entity.EntityKind, core_v1alpha.KindApp),
+	})
+	require.NoError(t, err)
 }
 
 func begin(t *testing.T, tr *Tracker, app, cluster string) string {
 	t.Helper()
+	ensureTestApp(t, tr, app)
 
 	rec, err := tr.Begin(context.Background(), BeginParams{AppName: app, ClusterID: cluster})
 	require.NoError(t, err)
@@ -51,6 +75,9 @@ func TestBeginCreatesRecordAndTakesLock(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, StatusInProgress, rec.Status())
+	assert.Empty(t, rec.Deployment.Outcome, "an attempt has no outcome until it finishes")
+	assert.Equal(t, string(StatusInProgress), rec.Deployment.Status)
+	assert.Equal(t, entity.Id("app/web"), rec.AppID())
 	assert.Equal(t, string(PhasePreparing), rec.Deployment.Phase)
 	assert.Equal(t, "abc123", rec.Deployment.GitInfo.Sha)
 	assert.Equal(t, clock.Now().Format(time.RFC3339), rec.Deployment.DeployedBy.Timestamp)
@@ -61,8 +88,29 @@ func TestBeginCreatesRecordAndTakesLock(t *testing.T) {
 	assert.Equal(t, string(rec.Deployment.ID), holder.DeploymentID)
 }
 
-// The whole point of taking the lock inside Begin: the second caller must not
-// end up with a record it will never be able to finish.
+func TestBeginCapturesAuthenticatedIdentity(t *testing.T) {
+	tr, _ := newTestTracker(t)
+	ctx := rpc.ContextWithIdentity(context.Background(), &rpc.Identity{
+		Subject: "user-42", Method: rpc.AuthMethodOIDC,
+	})
+	rec, err := tr.Begin(ctx, BeginParams{AppName: "web", Operation: OperationBuild})
+	require.NoError(t, err)
+	assert.Equal(t, "user-42", rec.Deployment.DeployedBy.Subject)
+	assert.Equal(t, "oidc", rec.Deployment.DeployedBy.AuthMethod)
+}
+
+func TestBeginPreservesCallerIdentityWithoutAuthenticatedOverride(t *testing.T) {
+	tr, _ := newTestTracker(t)
+	rec, err := tr.Begin(context.Background(), BeginParams{
+		AppName: "web", Operation: OperationBuild,
+		DeployedBy: core_v1alpha.DeployedBy{Subject: "wired-subject", AuthMethod: "wired-method"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "wired-subject", rec.Deployment.DeployedBy.Subject)
+	assert.Equal(t, "wired-method", rec.Deployment.DeployedBy.AuthMethod)
+}
+
+// A losing contender must not end up with a record it can never finish.
 func TestBeginLeavesNoRecordWhenLockIsHeld(t *testing.T) {
 	ctx := context.Background()
 	tr, _ := newTestTracker(t)
@@ -79,9 +127,14 @@ func TestBeginLeavesNoRecordWhenLockIsHeld(t *testing.T) {
 	all, err := tr.Store().List(ctx, Query{AppName: "web"})
 	require.NoError(t, err)
 	assert.Len(t, all, 1, "the losing deploy must not leave a record behind")
+
+	reservations, err := tr.store.eac.List(ctx,
+		entity.String(core_v1alpha.DeploymentStatusId, lockReservationStatus))
+	require.NoError(t, err)
+	assert.Empty(t, reservations.Values(), "the losing deploy must discard its private reservation")
 }
 
-func TestBeginRequiresAppAndCluster(t *testing.T) {
+func TestBeginRequiresApp(t *testing.T) {
 	ctx := context.Background()
 	tr, _ := newTestTracker(t)
 
@@ -89,7 +142,20 @@ func TestBeginRequiresAppAndCluster(t *testing.T) {
 	require.Error(t, err)
 
 	_, err = tr.Begin(ctx, BeginParams{AppName: "web"})
+	require.NoError(t, err, "cluster_id is legacy display metadata, not identity")
+}
+
+func TestBeginConfigChangeDoesNotCreateMissingApp(t *testing.T) {
+	ctx := context.Background()
+	tr, _ := newTestTracker(t)
+
+	_, err := tr.Begin(ctx, BeginParams{
+		AppName: "missing", Operation: OperationConfigChange,
+	})
 	require.Error(t, err)
+
+	_, _, getErr := tr.store.AppByName(ctx, "missing")
+	require.Error(t, getErr)
 }
 
 func TestSetPhase(t *testing.T) {
@@ -112,7 +178,7 @@ func TestSetPhaseOnSettledDeploymentIsConflict(t *testing.T) {
 	tr, _ := newTestTracker(t)
 
 	id := begin(t, tr, "web", "prod")
-	require.NoError(t, tr.Fail(ctx, id, "build broke", ""))
+	require.NoError(t, tr.Fail(ctx, id, "build broke"))
 
 	err := tr.SetPhase(ctx, id, PhaseBuilding)
 	require.Error(t, err)
@@ -169,7 +235,10 @@ func TestActivateSettlesPreviousAndReleasesLock(t *testing.T) {
 
 	secondRec, err := tr.Store().Get(ctx, second)
 	require.NoError(t, err)
-	assert.Equal(t, StatusActive, secondRec.Status())
+	assert.Equal(t, StatusSucceeded, secondRec.Status())
+	assert.Equal(t, string(StatusSucceeded), secondRec.Deployment.Outcome)
+	assert.Equal(t, string(StatusActive), secondRec.Deployment.Status,
+		"a downgraded runtime still sees the current successful attempt as active")
 	assert.NotEmpty(t, secondRec.Deployment.CompletedAt)
 }
 
@@ -187,22 +256,22 @@ func TestActivateRollbackSettlesPreviousAsRolledBack(t *testing.T) {
 
 	firstRec, err := tr.Store().Get(ctx, first)
 	require.NoError(t, err)
-	assert.Equal(t, StatusRolledBack, firstRec.Status(),
-		"the version we rolled away from was not a success")
+	assert.Equal(t, StatusSucceeded, firstRec.Status(),
+		"serving history does not rewrite an attempt's successful outcome")
+	assert.Equal(t, string(StatusRolledBack), firstRec.Deployment.Status)
 }
 
-func TestFailRecordsErrorAndReleasesLock(t *testing.T) {
+func TestFailRecordsBoundedSummaryAndReleasesLock(t *testing.T) {
 	ctx := context.Background()
 	tr, _ := newTestTracker(t)
 
 	id := begin(t, tr, "web", "prod")
-	require.NoError(t, tr.Fail(ctx, id, "compile error", "line 1\nline 2"))
+	require.NoError(t, tr.Fail(ctx, id, "compile error"))
 
 	rec, err := tr.Store().Get(ctx, id)
 	require.NoError(t, err)
 	assert.Equal(t, StatusFailed, rec.Status())
 	assert.Equal(t, "compile error", rec.Deployment.ErrorMessage)
-	assert.Equal(t, "line 1\nline 2", rec.Deployment.BuildLogs)
 	assert.NotEmpty(t, rec.Deployment.CompletedAt)
 
 	blocking, err := tr.Locks().Blocking(ctx, "web")
@@ -210,23 +279,35 @@ func TestFailRecordsErrorAndReleasesLock(t *testing.T) {
 	assert.Nil(t, blocking, "a failed deploy must not keep the lock")
 }
 
+func TestFailTruncatesSummaryAtUTF8Boundary(t *testing.T) {
+	ctx := context.Background()
+	tr, _ := newTestTracker(t)
+
+	id := begin(t, tr, "web", "prod")
+	require.NoError(t, tr.Fail(ctx, id, strings.Repeat("界", maxFailureSummaryBytes)))
+
+	rec, err := tr.Store().Get(ctx, id)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(rec.Deployment.ErrorMessage), maxFailureSummaryBytes)
+	assert.True(t, utf8.ValidString(rec.Deployment.ErrorMessage))
+	assert.Contains(t, rec.Deployment.ErrorMessage, failureSummaryEllipsis)
+}
+
 // A cancelled deploy whose build then dies must still read as cancelled: the
 // operator's action is the real account of what happened.
-func TestFailAfterCancelKeepsCancelledButRecordsTheError(t *testing.T) {
+func TestFailAfterCancelKeepsCancelledReason(t *testing.T) {
 	ctx := context.Background()
 	tr, _ := newTestTracker(t)
 
 	id := begin(t, tr, "web", "prod")
 	require.NoError(t, tr.Cancel(ctx, id, "operator cancelled"))
-	require.NoError(t, tr.Fail(ctx, id, "build aborted", "some logs"))
+	require.NoError(t, tr.Fail(ctx, id, "build aborted"))
 
 	rec, err := tr.Store().Get(ctx, id)
 	require.NoError(t, err)
 	assert.Equal(t, StatusCancelled, rec.Status())
 	assert.Equal(t, "operator cancelled", rec.Deployment.ErrorMessage,
 		"the cancellation reason is the real account and must survive a later build failure")
-	assert.Equal(t, "some logs", rec.Deployment.BuildLogs,
-		"the build logs are still worth keeping for diagnosis")
 }
 
 // Refusing active -> failed is correct: the version is live, so the deploy did
@@ -239,13 +320,13 @@ func TestFailAfterActivateIsRefused(t *testing.T) {
 	require.NoError(t, tr.SetAppVersion(ctx, id, "app_version/v1"))
 	require.NoError(t, tr.Activate(ctx, id))
 
-	err := tr.Fail(ctx, id, "late error", "")
+	err := tr.Fail(ctx, id, "late error")
 	require.Error(t, err)
 	assert.True(t, isConflict(err), "got %T: %v", err, err)
 
 	rec, err := tr.Store().Get(ctx, id)
 	require.NoError(t, err)
-	assert.Equal(t, StatusActive, rec.Status(), "the live deployment must stay active")
+	assert.Equal(t, StatusSucceeded, rec.Status(), "the live deployment must stay successful")
 }
 
 // The deferred-handler form of the same situation: fire unconditionally, and a
@@ -257,7 +338,7 @@ func TestFailIfUnsettled(t *testing.T) {
 	t.Run("records a real failure", func(t *testing.T) {
 		id := begin(t, tr, "web", "prod")
 
-		require.NoError(t, tr.FailIfUnsettled(ctx, id, "compile error", "logs"))
+		require.NoError(t, tr.FailIfUnsettled(ctx, id, "compile error"))
 
 		rec, err := tr.Store().Get(ctx, id)
 		require.NoError(t, err)
@@ -270,73 +351,20 @@ func TestFailIfUnsettled(t *testing.T) {
 		require.NoError(t, tr.SetAppVersion(ctx, id, "app_version/v1"))
 		require.NoError(t, tr.Activate(ctx, id))
 
-		require.NoError(t, tr.FailIfUnsettled(ctx, id, "late error", "logs"),
+		require.NoError(t, tr.FailIfUnsettled(ctx, id, "late error"),
 			"a defer firing after a successful deploy is not an error")
 
 		rec, err := tr.Store().Get(ctx, id)
 		require.NoError(t, err)
-		assert.Equal(t, StatusActive, rec.Status())
+		assert.Equal(t, StatusSucceeded, rec.Status())
 		assert.Empty(t, rec.Deployment.ErrorMessage,
 			"a successful deploy must not be annotated with a spurious error")
 	})
 
 	t.Run("still surfaces errors that are not about being settled", func(t *testing.T) {
-		err := tr.FailIfUnsettled(ctx, "deployment/missing", "boom", "")
+		err := tr.FailIfUnsettled(ctx, "deployment/missing", "boom")
 		require.Error(t, err, "a missing deployment is a real problem, not a settled one")
 	})
-}
-
-// ReleaseLock is the backstop for a deploy whose activation settle failed after
-// the version already went live: it frees the lock without settling the record,
-// so the next deploy is not blocked for the full lock TTL.
-func TestReleaseLockFreesAStuckDeployment(t *testing.T) {
-	ctx := context.Background()
-	tr, _ := newTestTracker(t)
-
-	stuck := begin(t, tr, "web", "prod") // in_progress, lock held
-
-	// While that record holds the lock and has not settled, the next deploy is
-	// blocked — this is the stall the backstop exists to prevent.
-	_, err := tr.Begin(ctx, BeginParams{AppName: "web", ClusterID: "prod"})
-	require.ErrorIs(t, err, ErrLockHeld)
-
-	require.NoError(t, tr.ReleaseLock(ctx, stuck))
-
-	// The record is untouched (still in_progress) but the lock is free.
-	rec, err := tr.Store().Get(ctx, stuck)
-	require.NoError(t, err)
-	assert.Equal(t, StatusInProgress, rec.Status(), "ReleaseLock must not change the record")
-
-	next, err := tr.Begin(ctx, BeginParams{AppName: "web", ClusterID: "prod"})
-	require.NoError(t, err, "the next deploy must proceed once the lock is released")
-	assert.NotEqual(t, stuck, string(next.Deployment.ID))
-}
-
-// ReleaseLock must not free a lock a newer deployment already holds.
-func TestReleaseLockIsHolderGuarded(t *testing.T) {
-	ctx := context.Background()
-	tr, clock := newTestTracker(t)
-
-	first := begin(t, tr, "web", "prod")
-
-	// A second deploy steals the lock once the first's expires.
-	clock.Advance(DefaultLockTTL + time.Second)
-	second := begin(t, tr, "web", "prod")
-
-	// The first deployment releasing its (now superseded) lock must be a no-op.
-	require.NoError(t, tr.ReleaseLock(ctx, first))
-
-	holder, err := tr.Locks().Get(ctx, "web")
-	require.NoError(t, err)
-	assert.Equal(t, second, holder.DeploymentID, "the second deploy must still hold the lock")
-}
-
-func TestReleaseLockUnknownDeployment(t *testing.T) {
-	ctx := context.Background()
-	tr, _ := newTestTracker(t)
-
-	err := tr.ReleaseLock(ctx, "deployment/missing")
-	require.Error(t, err, "cannot release a lock for a record that does not exist")
 }
 
 func TestCancelReleasesLock(t *testing.T) {
@@ -378,7 +406,7 @@ func TestOperationsOnUnknownDeployment(t *testing.T) {
 	assert.Error(t, tr.SetPhase(ctx, missing, PhaseBuilding))
 	assert.Error(t, tr.SetAppVersion(ctx, missing, "app_version/v1"))
 	assert.Error(t, tr.Activate(ctx, missing))
-	assert.Error(t, tr.Fail(ctx, missing, "boom", ""))
+	assert.Error(t, tr.Fail(ctx, missing, "boom"))
 	assert.Error(t, tr.Cancel(ctx, missing, ""))
 
 	assert.Error(t, tr.SetPhase(ctx, "", PhaseBuilding), "an empty id is not a lookup")
@@ -397,7 +425,7 @@ func TestAbandonedLockIsReclaimedOnceRecordIsTerminal(t *testing.T) {
 	// lock in place.
 	rec, err := tr.Store().Get(ctx, id)
 	require.NoError(t, err)
-	rec.Deployment.Status = string(StatusFailed)
+	rec.setOutcome(StatusFailed)
 	require.NoError(t, tr.Store().Put(ctx, rec))
 
 	next, err := tr.Begin(ctx, BeginParams{AppName: "web", ClusterID: "prod"})
@@ -438,23 +466,83 @@ func TestConcurrentUpdatesConverge(t *testing.T) {
 	assert.Contains(t, []Status{StatusInProgress, StatusCancelled}, rec.Status())
 }
 
-func TestBeginRecordsProvenanceForRollback(t *testing.T) {
+func TestBeginRecordsParentForRollback(t *testing.T) {
 	ctx := context.Background()
 	tr, _ := newTestTracker(t)
 
-	source := begin(t, tr, "web", "prod")
-	require.NoError(t, tr.SetAppVersion(ctx, source, "app_version/v1"))
-	require.NoError(t, tr.Activate(ctx, source))
+	parent := begin(t, tr, "web", "prod")
+	require.NoError(t, tr.SetAppVersion(ctx, parent, "app_version/v1"))
+	require.NoError(t, tr.Activate(ctx, parent))
 
 	rec, err := tr.Begin(ctx, BeginParams{
 		AppName:            "web",
 		ClusterID:          "prod",
 		AppVersion:         "app_version/v1",
-		SourceDeploymentID: source,
+		ParentDeploymentID: parent,
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, source, rec.Deployment.SourceDeploymentId)
+	assert.Equal(t, parent, rec.ParentDeploymentID())
 	assert.Equal(t, "app_version/v1", rec.AppVersion(),
 		"a rollback knows its version up front, unlike a build")
+}
+
+func TestReconcileSettlesActivationCrashWindow(t *testing.T) {
+	ctx := context.Background()
+	tr, _ := newTestTracker(t)
+	previous := begin(t, tr, "web", "prod")
+	require.NoError(t, tr.SetAppVersion(ctx, previous, "app_version/v1"))
+	require.NoError(t, tr.Activate(ctx, previous))
+
+	id := begin(t, tr, "web", "prod")
+	require.NoError(t, tr.SetAppVersion(ctx, id, "app_version/v2"))
+
+	rec, err := tr.Store().Get(ctx, id)
+	require.NoError(t, err)
+	app, revision, err := tr.Store().AppByName(ctx, "web")
+	require.NoError(t, err)
+	require.NoError(t, tr.Store().SetActivePointers(ctx, app.ID, revision, "app_version/v2", rec.Deployment.ID))
+
+	require.NoError(t, tr.Reconcile(ctx, id))
+	settled, err := tr.Store().Get(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, StatusSucceeded, settled.Status())
+	assert.False(t, settled.CompletedAt().IsZero())
+	old, err := tr.Store().Get(ctx, previous)
+	require.NoError(t, err)
+	assert.Equal(t, string(StatusSucceeded), old.Deployment.Status,
+		"reconciliation must retire the previous legacy-active record")
+}
+
+func TestReconcileInterruptsExpiredAttemptWithoutLock(t *testing.T) {
+	ctx := context.Background()
+	tr, clock := newTestTracker(t)
+	id := begin(t, tr, "web", "prod")
+	require.NoError(t, tr.Locks().Release(ctx, "web", id))
+	clock.Advance(DefaultLockTTL + time.Second)
+
+	require.NoError(t, tr.Reconcile(ctx, id))
+	settled, err := tr.Store().Get(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, StatusInterrupted, settled.Status())
+}
+
+func TestReconcileInterruptsAttemptAfterClaimIsStolen(t *testing.T) {
+	ctx := context.Background()
+	tr, clock := newTestTracker(t)
+	first := begin(t, tr, "web", "prod")
+
+	clock.Advance(DefaultLockTTL + time.Second)
+	second := begin(t, tr, "web", "prod")
+	require.NotEqual(t, first, second)
+
+	require.NoError(t, tr.Reconcile(ctx, first))
+	settled, err := tr.Store().Get(ctx, first)
+	require.NoError(t, err)
+	assert.Equal(t, StatusInterrupted, settled.Status())
+
+	holder, err := tr.Locks().Get(ctx, "web")
+	require.NoError(t, err)
+	assert.Equal(t, second, holder.DeploymentID,
+		"reconciling the old attempt must preserve its successor's lock")
 }

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	appclient "miren.dev/runtime/api/app"
@@ -20,6 +21,7 @@ import (
 	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/pkg/apphealth"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/rpc"
@@ -47,6 +49,9 @@ type AppInfo struct {
 	// Secrets resolves backend-sourced variables so a ConfigVersion minted by an
 	// env change records the exact secret version it saw.
 	Secrets secret.Resolver
+	Deploy  *deploylifecycle.Tracker
+
+	deployOnce sync.Once
 }
 
 func NewAppInfo(log *slog.Logger, ec *entityserver.Client, cpu *metrics.CPUUsage, mem *metrics.MemoryUsage, http *metrics.HTTPMetrics, secrets secret.Resolver) *AppInfo {
@@ -59,6 +64,7 @@ func NewAppInfo(log *slog.Logger, ec *entityserver.Client, cpu *metrics.CPUUsage
 		HTTP: http,
 
 		Secrets: secrets,
+		Deploy:  deploylifecycle.NewTracker(log, ec.EAC()),
 	}
 }
 
@@ -316,12 +322,25 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 	if !rpc.AllowApp(ctx, name) {
 		return rpc.AppAccessError(ctx, name)
 	}
+	attempt, err := r.deployTracker().Begin(ctx, deploylifecycle.BeginParams{
+		AppName: name, Operation: deploylifecycle.OperationConfigChange,
+	})
+	if err != nil {
+		return err
+	}
+	attemptID := string(attempt.Deployment.ID)
+	settled := false
+	defer func() {
+		if !settled {
+			_ = r.deployTracker().FailIfUnsettled(context.WithoutCancel(ctx), attemptID, "configuration change failed")
+		}
+	}()
 
-	// The read-merge-write below is retried under optimistic concurrency
-	// control: the active_version swing is guarded by a CAS on the app revision,
-	// so a concurrent writer (another SetConfiguration, an env mutation, or the
-	// addon controller injecting addon vars) that swings active_version first is
-	// detected and re-merged instead of silently clobbered.
+	// The attempt lock serializes this mutation with lifecycle-aware deploy and
+	// configuration writers. The read-merge-write still keeps its original OCC
+	// guard for downgrade-window writers that only swing active_version: if the
+	// app revision changes after the base config is read, activation conflicts and
+	// the mutation is rebuilt from the winner instead of silently clobbering it.
 	//
 	// maxAttempts is a live-lock backstop, not an expected limit: there are only
 	// ever a handful of concurrent config writers per app, so it is set high
@@ -497,9 +516,10 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 
 		// Swing active_version under OCC. A conflict means another writer got
 		// there first, so re-read and re-merge on the next iteration.
-		err = r.EC.Patch(ctx, appRec.ID, appRev,
-			entity.Ref(core_v1alpha.AppActiveVersionId, avid),
-		)
+		err = r.deployTracker().SetAppVersion(ctx, attemptID, string(avid))
+		if err == nil {
+			err = r.deployTracker().ActivateAtRevision(ctx, attemptID, appRev)
+		}
 		if err != nil {
 			if errors.Is(err, cond.ErrConflict{}) {
 				// This attempt lost the race, so the version pair we just minted
@@ -518,6 +538,7 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 			}
 			return fmt.Errorf("error updating app entity: %w", err)
 		}
+		settled = true
 
 		state.Results().SetVersionId(appVer.Version)
 		if sid := r.versionShortId(ctx, string(avid)); sid != "" {
@@ -714,8 +735,22 @@ func (r *AppInfo) SetWorkloadRole(ctx context.Context, state *app_v1alpha.CrudSe
 }
 
 func (r *AppInfo) setEnvVars(ctx context.Context, name string, vars []appclient.EnvVarInput, service string) (string, error) {
-	result, err := appclient.SetEnvVars(ctx, r.EC, r.Secrets, name, nil, vars, service)
+	attempt, err := r.deployTracker().Begin(ctx, deploylifecycle.BeginParams{
+		AppName: name, Operation: deploylifecycle.OperationConfigChange,
+	})
 	if err != nil {
+		return "", err
+	}
+	attemptID := string(attempt.Deployment.ID)
+	activate := func(ctx context.Context, _ *core_v1alpha.App, revision int64, version entity.Id) error {
+		if err := r.deployTracker().SetAppVersion(ctx, attemptID, string(version)); err != nil {
+			return err
+		}
+		return r.deployTracker().ActivateAtRevision(ctx, attemptID, revision)
+	}
+	result, err := appclient.SetEnvVarsWithActivator(ctx, r.EC, r.Secrets, name, nil, vars, service, activate)
+	if err != nil {
+		_ = r.deployTracker().FailIfUnsettled(context.WithoutCancel(ctx), attemptID, err.Error())
 		return "", err
 	}
 	return result.VersionID, nil
@@ -806,8 +841,22 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 		return rpc.AppAccessError(ctx, args.App())
 	}
 
-	result, err := appclient.DeleteEnvVars(ctx, r.EC, r.Secrets, args.App(), nil, []string{args.Key()}, args.Service())
+	attempt, err := r.deployTracker().Begin(ctx, deploylifecycle.BeginParams{
+		AppName: args.App(), Operation: deploylifecycle.OperationConfigChange,
+	})
 	if err != nil {
+		return err
+	}
+	attemptID := string(attempt.Deployment.ID)
+	activate := func(ctx context.Context, _ *core_v1alpha.App, revision int64, version entity.Id) error {
+		if err := r.deployTracker().SetAppVersion(ctx, attemptID, string(version)); err != nil {
+			return err
+		}
+		return r.deployTracker().ActivateAtRevision(ctx, attemptID, revision)
+	}
+	result, err := appclient.DeleteEnvVarsWithActivator(ctx, r.EC, r.Secrets, args.App(), nil, []string{args.Key()}, args.Service(), activate)
+	if err != nil {
+		_ = r.deployTracker().FailIfUnsettled(context.WithoutCancel(ctx), attemptID, err.Error())
 		return err
 	}
 
@@ -819,6 +868,15 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 		state.Results().SetDeletedSource(result.DeletedSources[0])
 	}
 	return nil
+}
+
+func (r *AppInfo) deployTracker() *deploylifecycle.Tracker {
+	r.deployOnce.Do(func() {
+		if r.Deploy == nil {
+			r.Deploy = deploylifecycle.NewTracker(r.Log, r.EC.EAC())
+		}
+	})
+	return r.Deploy
 }
 
 func (r *AppInfo) Restart(ctx context.Context, state *app_v1alpha.CrudRestart) error {

--- a/servers/app/app_test.go
+++ b/servers/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,11 +13,46 @@ import (
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/secret"
 )
+
+func TestDeployTrackerInitializesOnceConcurrently(t *testing.T) {
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	appInfo := &AppInfo{
+		Log: slog.Default(),
+		EC:  entityserver.NewClient(slog.Default(), inmem.EAC),
+	}
+
+	const callers = 20
+	start := make(chan struct{})
+	results := make(chan *deploylifecycle.Tracker, callers)
+	var workers sync.WaitGroup
+	workers.Add(callers)
+	for range callers {
+		go func() {
+			defer workers.Done()
+			<-start
+			results <- appInfo.deployTracker()
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+
+	var first *deploylifecycle.Tracker
+	for tracker := range results {
+		if first == nil {
+			first = tracker
+		}
+		assert.Same(t, first, tracker)
+	}
+	require.NotNil(t, first)
+}
 
 func TestSetConfiguration_DuplicateEnvVars(t *testing.T) {
 	ctx := context.Background()

--- a/servers/app/delete.go
+++ b/servers/app/delete.go
@@ -28,7 +28,10 @@ func DeleteAppTransitive(ctx context.Context, client *entityserver.Client, log *
 	// 3. Launcher creates new pools
 	// 4. We delete the app
 	// 5. New pools are orphaned and keep trying to launch sandboxes
-	if err := client.Patch(ctx, appId, 0, entity.Ref(core_v1alpha.AppActiveVersionId, entity.Id(""))); err != nil {
+	if err := client.Patch(ctx, appId, 0,
+		entity.Ref(core_v1alpha.AppActiveVersionId, entity.Id("")),
+		entity.Ref(core_v1alpha.AppActiveDeploymentId, entity.Id("")),
+	); err != nil {
 		log.Warn("failed to clear active version (app may already be deleted)", "appId", appId, "error", err)
 		// Continue anyway - the app might already be partially deleted
 	}

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1092,22 +1092,11 @@ func (b *Builder) nextVersion(ctx context.Context, name string) (
 	string,
 	error,
 ) {
-	var appRec core_v1alpha.App
-
-	err := b.ec.Get(ctx, name, &appRec)
+	app, err := b.ensureApp(ctx, name)
 	if err != nil {
-		if !errors.Is(err, cond.ErrNotFound{}) {
-			return nil, nil, core_v1alpha.ConfigSpec{}, "", err
-		}
-
-		appRec.Project = "project/default"
-
-		id, err := b.ec.Create(ctx, name, &appRec)
-		if err != nil {
-			return nil, nil, core_v1alpha.ConfigSpec{}, "", err
-		}
-		appRec.ID = id
+		return nil, nil, core_v1alpha.ConfigSpec{}, "", err
 	}
+	appRec := *app
 
 	var currentCfg core_v1alpha.ConfigSpec
 
@@ -1149,6 +1138,30 @@ func (b *Builder) nextVersion(ctx context.Context, name string) (
 	av.AdminToken = idgen.GenAdminToken()
 
 	return &appRec, &av, currentCfg, art, nil
+}
+
+// ensureApp makes the deployment's canonical app reference available before
+// the build takes its app-scoped lock. It preserves nextVersion's historical
+// create-on-first-deploy behavior.
+func (b *Builder) ensureApp(ctx context.Context, name string) (*core_v1alpha.App, error) {
+	var appRec core_v1alpha.App
+	if err := b.ec.Get(ctx, name, &appRec); err == nil {
+		return &appRec, nil
+	} else if !errors.Is(err, cond.ErrNotFound{}) {
+		return nil, err
+	}
+
+	appRec.Project = "project/default"
+	id, err := b.ec.Create(ctx, name, &appRec)
+	if err != nil {
+		// A concurrent first deploy may have created it between Get and Create.
+		if getErr := b.ec.Get(ctx, name, &appRec); getErr == nil {
+			return &appRec, nil
+		}
+		return nil, err
+	}
+	appRec.ID = id
+	return &appRec, nil
 }
 
 func (b *Builder) loadAppConfig(dfs fsutil.FS) (*appconfig.AppConfig, error) {
@@ -1824,6 +1837,7 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 	}
 	mrv.ConfigVersion = cvid
 	mrv.Config = core_v1alpha.Config{}
+	deploy.setSource(mrv)
 
 	id, err := b.ec.Create(createVerCtx, mrv.Version, mrv)
 	if err != nil {
@@ -1873,15 +1887,6 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 			}
 		}
 
-		b.Log.Info("updating app entity with new version", "app", name, "version", mrv.Version)
-		err = b.appClient.SetActiveVersion(activateCtx, name, string(id))
-		if err != nil {
-			activateSpan.RecordError(err)
-			activateSpan.SetStatus(codes.Error, err.Error())
-			activateSpan.End()
-			return nil, fmt.Errorf("error updating app entity: %w", err)
-		}
-
 		// Apply a workload_role declared in app.toml (app-scoped only).
 		if err := b.applyWorkloadRole(activateCtx, name, ac); err != nil {
 			activateSpan.RecordError(err)
@@ -1889,10 +1894,15 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 			activateSpan.End()
 			return nil, err
 		}
+		// Swing active_version and active_deployment together. This is the
+		// activation itself; the attempt is made terminal immediately afterwards.
+		if err := deploy.activate(activateCtx); err != nil {
+			activateSpan.RecordError(err)
+			activateSpan.SetStatus(codes.Error, err.Error())
+			activateSpan.End()
+			return nil, fmt.Errorf("error activating deployment: %w", err)
+		}
 		activateSpan.End()
-
-		// The new version is running: settle the record and release the lock.
-		deploy.activate(ctx)
 
 		b.Log.Info("app version updated", "app", name, "version", mrv.Version)
 

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -446,6 +446,7 @@ type createVersionIn struct {
 	ArtifactID         string `json:"artifact_id" saga:"artifact_id,optional"`
 	AdminToken         string `json:"admin_token" saga:"admin_token"`
 	ConfigVersionID    string `json:"config_version_id" saga:"config_version_id"`
+	GitInfo            string `json:"deploy_git_info_json,omitempty" saga:"deploy_git_info_json,optional"`
 	EphemeralLabel     string `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
 	EphemeralTTL       string `json:"ephemeral_ttl,omitempty" saga:"ephemeral_ttl,optional"`
 	EphemeralExpiresAt string `json:"ephemeral_expires_at,omitempty" saga:"ephemeral_expires_at,optional"`
@@ -467,6 +468,14 @@ func createVersion(ctx context.Context, in createVersionIn) (createVersionOut, e
 		Artifact:      entity.Id(in.ArtifactID),
 		ConfigVersion: entity.Id(in.ConfigVersionID),
 		Config:        core_v1alpha.Config{},
+	}
+	if in.GitInfo != "" {
+		var gitInfo core_v1alpha.GitInfo
+		if err := json.Unmarshal([]byte(in.GitInfo), &gitInfo); err != nil {
+			b.Log.Warn("ignoring unparseable git info on app version", "version", in.VersionName, "error", err)
+		} else {
+			av.Source = deploylifecycle.SourceFromGitInfo(gitInfo)
+		}
 	}
 	if in.EphemeralLabel != "" {
 		av.EphemeralLabel = in.EphemeralLabel
@@ -535,10 +544,9 @@ func undoProvisionAddons(_ context.Context, _ provisionAddonsIn, _ provisionAddo
 	return nil
 }
 
-// setActiveVersion makes the newly-created AppVersion the app's active
-// one. Skipped for ephemeral deploys (their whole point is to coexist
-// with the active version, not replace it). Records the previous
-// active version so undo can restore it on failure.
+// setActiveVersion keeps the persisted saga action name, but no longer writes
+// either app pointer. It runs the last promotion checks; activateDeployment
+// performs the paired active_version and active_deployment update later.
 
 // runDeployTasksIn gates the version flip on every deploy-triggered task.
 //
@@ -609,18 +617,17 @@ type setActiveVersionIn struct {
 	EphemeralLabel string               `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
 	AppConfig      *appconfig.AppConfig `json:"app_config,omitempty" saga:"app_config,optional"`
 	AddonsReady    saga.Edge            `saga:"addons_provisioned"`
-	// DeployTasksRan puts the version flip strictly after every
+	// DeployTasksRan puts the promotion gate strictly after every
 	// deploy-triggered task has succeeded, so a failed task means a failed
 	// deploy rather than a half-promoted one.
 	DeployTasksRan saga.Edge `saga:"deploy_tasks_ran"`
-	// DeploymentID is empty for an untracked build. Consuming it also anchors
-	// this action after begin-deployment, which is where the record is created.
+	// Consuming DeploymentID anchors this action after begin-deployment. It is
+	// empty only for ephemeral builds and sagas created by an older runtime.
 	DeploymentID string `json:"deployment_id,omitempty" saga:"deployment_id,optional"`
 }
 
 type setActiveVersionOut struct {
-	PreviousVersionID string `json:"previous_version_id,omitempty" saga:"previous_version_id"`
-	Skipped           bool   `json:"skipped" saga:"set_active_skipped"`
+	Skipped bool `json:"skipped" saga:"set_active_skipped"`
 }
 
 func setActiveVersion(ctx context.Context, in setActiveVersionIn) (setActiveVersionOut, error) {
@@ -634,31 +641,17 @@ func setActiveVersion(ctx context.Context, in setActiveVersionIn) (setActiveVers
 	b.trackDeployment(in.DeploymentID, deps.statuses.SenderFor(in.StreamID)).
 		setPhase(ctx, deploylifecycle.PhaseActivating)
 
-	app, err := b.appClient.GetByName(ctx, in.AppName)
-	if err != nil {
-		return setActiveVersionOut{}, fmt.Errorf("looking up app %s: %w", in.AppName, err)
-	}
-	previous := string(app.ActiveVersion)
-
-	if err := b.appClient.SetActiveVersion(ctx, in.AppName, in.AppVersionID); err != nil {
-		return setActiveVersionOut{}, fmt.Errorf("setting active version on %s: %w", in.AppName, err)
-	}
-
 	// Apply a workload_role declared in app.toml (app-scoped only) so it takes
 	// effect on this deploy. A cluster-scoped value fails the deploy.
 	if err := b.applyWorkloadRole(ctx, in.AppName, in.AppConfig); err != nil {
 		return setActiveVersionOut{}, err
 	}
-	return setActiveVersionOut{PreviousVersionID: previous}, nil
+	return setActiveVersionOut{}, nil
 }
 
 func undoSetActiveVersion(ctx context.Context, in setActiveVersionIn, out setActiveVersionOut) error {
 	if out.Skipped {
 		return nil
-	}
-	deps := saga.Get[*buildSagaDeps](ctx)
-	if err := deps.builder.appClient.SetActiveVersion(ctx, in.AppName, out.PreviousVersionID); err != nil {
-		return fmt.Errorf("restoring previous active version on %s: %w", in.AppName, err)
 	}
 	return nil
 }
@@ -725,24 +718,20 @@ func undoFinalize(_ context.Context, _ finalizeIn, _ finalizeOut) error {
 // it deployment_id stays empty and every downstream action skips. Ephemeral
 // builds are never tracked.
 //
-// Only begin-deployment may fail the saga. The record describes the deploy; it
-// must never be able to undo one. Once begin has succeeded the later actions
-// log their failures and return nil, because returning an error here would
-// compensate the saga, and the compensation for set-active-version restores the
-// previous app version — so a failed bookkeeping write would roll back a deploy
-// that is already live. The plain path enforces the same rule in
-// deployTracking.activate; these match it.
-//
-// For the same reason the settles run on a context detached from the saga's:
-// the most likely cause of failure is the client disconnecting, which is
-// exactly when the record most needs to reach a terminal state and drop the
-// deploy lock.
+// Lifecycle actions use detached settle contexts so a client disconnect cannot
+// strand an attempt. Activation is still a real saga gate until the paired app
+// pointers commit. Once they do, a failed terminal-record write is logged and
+// left for continuous reconciliation rather than compensating a live deploy.
 
 type beginDeploymentIn struct {
-	AppName   string `json:"app_name" saga:"app_name"`
-	StreamID  string `json:"stream_id" saga:"stream_id"`
-	ClusterID string `json:"deploy_cluster_id,omitempty" saga:"deploy_cluster_id,optional"`
-	GitInfo   string `json:"deploy_git_info_json,omitempty" saga:"deploy_git_info_json,optional"`
+	AppName        string `json:"app_name" saga:"app_name"`
+	AppID          string `json:"app_id" saga:"app_id"`
+	StreamID       string `json:"stream_id" saga:"stream_id"`
+	ClusterID      string `json:"deploy_cluster_id,omitempty" saga:"deploy_cluster_id,optional"`
+	GitInfo        string `json:"deploy_git_info_json,omitempty" saga:"deploy_git_info_json,optional"`
+	Subject        string `json:"deploy_subject,omitempty" saga:"deploy_subject,optional"`
+	AuthMethod     string `json:"deploy_auth_method,omitempty" saga:"deploy_auth_method,optional"`
+	EphemeralLabel string `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
 }
 
 type beginDeploymentOut struct {
@@ -750,8 +739,7 @@ type beginDeploymentOut struct {
 }
 
 func beginDeployment(ctx context.Context, in beginDeploymentIn) (beginDeploymentOut, error) {
-	// No cluster id means the client did not ask the server to own a record.
-	if in.ClusterID == "" {
+	if in.EphemeralLabel != "" {
 		return beginDeploymentOut{}, nil
 	}
 
@@ -766,9 +754,13 @@ func beginDeployment(ctx context.Context, in beginDeploymentIn) (beginDeployment
 	}
 
 	rec, err := b.deploy.Begin(ctx, deploylifecycle.BeginParams{
-		AppName:   in.AppName,
-		ClusterID: in.ClusterID,
-		GitInfo:   gitInfo,
+		AppName:    in.AppName,
+		AppID:      entity.Id(in.AppID),
+		ClusterID:  in.ClusterID,
+		Operation:  deploylifecycle.OperationBuild,
+		GitInfo:    gitInfo,
+		Subject:    in.Subject,
+		AuthMethod: in.AuthMethod,
 	})
 	if err != nil {
 		return beginDeploymentOut{}, fmt.Errorf("begin deployment for %s: %w", in.AppName, err)
@@ -795,7 +787,7 @@ func undoBeginDeployment(ctx context.Context, in beginDeploymentIn, out beginDep
 	// FailIfUnsettled: if a later action already activated the record, leave it
 	// active — the version is live, and undoSetActiveVersion handles reverting
 	// that separately.
-	if err := deps.builder.deploy.FailIfUnsettled(settleCtx, out.DeploymentID, "build rolled back", ""); err != nil {
+	if err := deps.builder.deploy.FailIfUnsettled(settleCtx, out.DeploymentID, "build rolled back"); err != nil {
 		return fmt.Errorf("failing rolled-back deployment %s: %w", out.DeploymentID, err)
 	}
 	return nil
@@ -816,9 +808,8 @@ func recordAppVersion(ctx context.Context, in recordAppVersionIn) (recordAppVers
 	}
 	deps := saga.Get[*buildSagaDeps](ctx)
 
-	// Delegated so the detached context and the log-rather-than-fail policy live
-	// in one place. A failure here is not fatal: activate-deployment will refuse
-	// to settle a record with no version and release the lock instead.
+	// Delegated so the detached context lives in one place. Activation remains
+	// the gate if recording the version failed.
 	deps.builder.trackDeployment(in.DeploymentID, nil).setAppVersion(ctx, in.AppVersionID)
 	return recordAppVersionOut{}, nil
 }
@@ -838,24 +829,21 @@ type activateDeploymentIn struct {
 type activateDeploymentOut struct{}
 
 func activateDeployment(ctx context.Context, in activateDeploymentIn) (activateDeploymentOut, error) {
-	// Not tracked, or an ephemeral build whose activation was skipped: nothing
-	// to activate.
+	// Ephemeral or pre-upgrade saga: nothing to activate.
 	if in.DeploymentID == "" || in.SetActiveSkipped {
 		return activateDeploymentOut{}, nil
 	}
 	deps := saga.Get[*buildSagaDeps](ctx)
 
-	// Delegated: the version is live by now, so activate detaches its context,
-	// logs rather than returns, and drops the lock as a backstop. See the
-	// failure-policy note at the top of this section.
-	deps.builder.trackDeployment(in.DeploymentID, nil).activate(ctx)
+	if err := deps.builder.trackDeployment(in.DeploymentID, nil).activate(ctx); err != nil {
+		return activateDeploymentOut{}, fmt.Errorf("activating deployment: %w", err)
+	}
 	return activateDeploymentOut{}, nil
 }
 
 func undoActivateDeployment(_ context.Context, _ activateDeploymentIn, _ activateDeploymentOut) error {
-	// The record is already active and the lock released. If a later step fails,
-	// undoSetActiveVersion reverts the running version; the record is left as the
-	// historical account of a deploy that did go live. No compensation here.
+	// The paired app pointers are already committed and the attempt is historical
+	// fact. A later best-effort finalizer must not compensate activation.
 	return nil
 }
 

--- a/servers/build/build_saga_buildkit.go
+++ b/servers/build/build_saga_buildkit.go
@@ -48,9 +48,9 @@ type buildImageIn struct {
 	// Empty when the user didn't pass any, so optional.
 	CLIEnvVars []*build_v1alpha.EnvironmentVariable `json:"cli_env_vars,omitempty" saga:"cli_env_vars,optional"`
 	AppID      string                               `json:"app_id" saga:"app_id"`
-	// DeploymentID is empty for an untracked build. Consuming it also anchors
-	// this action after begin-deployment, so the deploy lock is taken before
-	// any buildkit work starts.
+	// Consuming DeploymentID anchors this action after begin-deployment, so the
+	// deploy lock is taken before any buildkit work starts. It is empty only for
+	// ephemeral builds and sagas created by an older runtime.
 	DeploymentID string `json:"deployment_id,omitempty" saga:"deployment_id,optional"`
 }
 

--- a/servers/build/build_saga_deploy_test.go
+++ b/servers/build/build_saga_deploy_test.go
@@ -88,9 +88,8 @@ func newDeploySagaHarnessWith(t *testing.T, setActive any) *sagaTestHarness {
 	}
 }
 
-// A build that carries deploy_cluster_id must leave exactly one deployment
-// record, active, with its app version recorded — the whole point of the saga
-// owning the lifecycle.
+// A build that carries deploy_cluster_id must leave exactly one successful
+// deployment attempt with its app version recorded. The App owns serving state.
 func TestBuildSaga_Tracked_CreatesAndActivatesDeployment(t *testing.T) {
 	ctx := context.Background()
 
@@ -110,7 +109,7 @@ func TestBuildSaga_Tracked_CreatesAndActivatesDeployment(t *testing.T) {
 	require.Len(t, records, 1, "exactly one deployment record for a tracked build")
 
 	rec := records[0]
-	assert.Equal(t, deploylifecycle.StatusActive, rec.Status())
+	assert.Equal(t, deploylifecycle.StatusSucceeded, rec.Status())
 	assert.NotEmpty(t, rec.AppVersion(), "the built version must be recorded")
 	assert.Equal(t, "prod", rec.Deployment.ClusterId)
 
@@ -146,9 +145,13 @@ func TestBuildSaga_TrackedImage_ActivatesWithoutBuildPhases(t *testing.T) {
 	require.Len(t, records, 1)
 
 	rec := records[0]
-	assert.Equal(t, deploylifecycle.StatusActive, rec.Status())
+	assert.Equal(t, deploylifecycle.StatusSucceeded, rec.Status())
 	assert.Equal(t, string(deploylifecycle.PhaseActivating), rec.Deployment.Phase)
 	assert.NotEmpty(t, rec.AppVersion(), "the direct-image version must be recorded")
+	app, _, err := h.builder.deploy.Store().AppByName(ctx, "demo")
+	require.NoError(t, err)
+	assert.Equal(t, rec.Deployment.ID, app.ActiveDeployment)
+	assert.Equal(t, rec.Deployment.Version, app.ActiveVersion)
 
 	var phases []string
 	for _, deployment := range sender.Deployments {
@@ -192,9 +195,7 @@ func TestBuildSaga_Tracked_EmitsDeploymentProgress(t *testing.T) {
 	assert.Equal(t, string(records[0].Deployment.ID), rec.Deployments[0].DeploymentID)
 }
 
-// A build with no deploy_cluster_id (an older client, or ephemeral) must leave
-// no server-owned record — the additive-safety guarantee.
-func TestBuildSaga_Untracked_CreatesNoDeployment(t *testing.T) {
+func TestBuildSaga_WithoutClusterIDStillCreatesAttempt(t *testing.T) {
 	ctx := context.Background()
 
 	h := newDeploySagaHarness(t)
@@ -209,7 +210,7 @@ func TestBuildSaga_Untracked_CreatesNoDeployment(t *testing.T) {
 
 	records, err := h.builder.deploy.Store().List(ctx, deploylifecycle.Query{AppName: "demo"})
 	require.NoError(t, err)
-	assert.Empty(t, records, "a build with no DeployRequest must not create a record")
+	assert.Len(t, records, 1)
 }
 
 // A second tracked build for the same app+cluster, started while the first
@@ -256,13 +257,7 @@ func setActiveVersionThenCancel(ctx context.Context, in setActiveVersionIn) (set
 	return out, deps.builder.deploy.Cancel(ctx, string(recs[0].Deployment.ID), "cancelled mid-deploy")
 }
 
-// A deployment record that cannot settle must not roll back a deploy that is
-// already live. The record describes the deploy; it does not control it.
-//
-// Before this was fixed, activate-deployment returned the failed settle to the
-// executor, which compensated the saga, and undoSetActiveVersion put the app
-// back on the previous version — a bookkeeping write undoing a real deploy.
-func TestBuildSaga_Tracked_SettleFailureDoesNotRevertLiveDeploy(t *testing.T) {
+func TestBuildSaga_CancellationBeforeActivationFailsDeploy(t *testing.T) {
 	ctx := context.Background()
 
 	h := newDeploySagaHarnessWith(t, setActiveVersionThenCancel)
@@ -274,12 +269,11 @@ func TestBuildSaga_Tracked_SettleFailureDoesNotRevertLiveDeploy(t *testing.T) {
 		Input("deploy_cluster_id", "prod").
 		WithID("test-settle").
 		Execute(ctx)
-	require.NoError(t, err, "a failed deployment settle must not fail the build saga")
+	require.Error(t, err)
 
 	appRec, err := h.builder.appClient.GetByName(ctx, "demo")
 	require.NoError(t, err)
-	assert.NotEmpty(t, appRec.ActiveVersion,
-		"the built version must stay live; compensation would have restored the previous one")
+	assert.Empty(t, appRec.ActiveVersion)
 
 	// The cancellation is the real account of what happened, so it stands.
 	records, err := h.builder.deploy.Store().List(ctx, deploylifecycle.Query{AppName: "demo"})

--- a/servers/build/build_saga_test.go
+++ b/servers/build/build_saga_test.go
@@ -18,6 +18,7 @@ import (
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
@@ -56,6 +57,7 @@ func newSagaTestHarness(t *testing.T) *sagaTestHarness {
 		appClient:  app.NewClient(log, rpcClient),
 		TempDir:    tempDir,
 		cacheLocks: newAppLocks(),
+		deploy:     deploylifecycle.NewTracker(log, inmem.EAC),
 	}
 
 	streams := NewStreamRegistry(tempDir, log)
@@ -82,6 +84,9 @@ func newSagaTestHarness(t *testing.T) *sagaTestHarness {
 		Action(actionProvisionAddons, provisionAddons).Undo(undoProvisionAddons).
 		Action(actionSetActiveVer, setActiveVersion).Undo(undoSetActiveVersion).
 		Action(actionFinalize, finalize).Undo(undoFinalize).
+		Action(actionBeginDeploy, beginDeployment).Undo(undoBeginDeployment).
+		Action(actionRecordVersion, recordAppVersion).Undo(undoRecordAppVersion).
+		Action(actionActivateDeploy, activateDeployment).Undo(undoActivateDeployment).
 		RegisterTo(registry); err != nil {
 		t.Fatalf("registering build saga: %v", err)
 	}
@@ -204,6 +209,29 @@ func TestBuildSaga_HappyPath_RunsFullPipeline(t *testing.T) {
 	if application.ActiveVersion == "" {
 		t.Error("expected app to have an active version after build saga")
 	}
+}
+
+func TestBuildSaga_MalformedGitInfoDoesNotBlockDeployment(t *testing.T) {
+	ctx := context.Background()
+
+	h := newSagaTestHarness(t)
+	h.streams.Register("stream-malformed-git-info", makeTar(t, dockerfileTarball(t)))
+
+	err := h.executor.Start(sagaBuildFromTar).
+		Input("app_name", "demo").
+		Input("stream_id", "stream-malformed-git-info").
+		Input("deploy_git_info_json", "{").
+		WithID("test-malformed-git-info").
+		Execute(ctx)
+	require.NoError(t, err)
+
+	var application core_v1alpha.App
+	require.NoError(t, h.builder.ec.Get(ctx, "demo", &application))
+	require.NotEmpty(t, application.ActiveVersion)
+
+	var version core_v1alpha.AppVersion
+	require.NoError(t, h.builder.ec.GetById(ctx, application.ActiveVersion, &version))
+	assert.Empty(t, version.Source)
 }
 
 func TestBuildSaga_ImageOnly_SkipsBuildKitAndCreatesVersion(t *testing.T) {

--- a/servers/build/deploy_tracking.go
+++ b/servers/build/deploy_tracking.go
@@ -15,25 +15,22 @@ import (
 
 // deployTracking threads the server-owned deployment record through a build.
 //
-// A nil *deployTracking means this build is not tracked — an ephemeral build, or
-// an older client that still drives its own deployment record — and every method
-// is then a no-op. Call sites therefore never branch on whether tracking is
-// active; they call through unconditionally and a nil receiver does the right
-// thing.
+// A nil *deployTracking means this is an ephemeral build (or recovery of an old
+// saga that predates server-owned attempts). Every method is then a no-op.
 type deployTracking struct {
 	tracker      *deploylifecycle.Tracker
 	deploymentID string
+	source       core_v1alpha.Source
 	status       StatusSender
 	log          *slog.Logger
 }
 
 // trackDeployment binds a deployment record to the build that owns it.
 //
-// An empty deploymentID yields nil, which is the "not tracked" case every
-// method treats as a no-op, so callers never branch. Both build paths build
-// their tracking through here: the plain path wraps its RPC stream, the saga
-// path looks its sender up by stream ID. That shared construction is what keeps
-// the two paths from drifting on phases, contexts, or failure policy.
+// An empty deploymentID yields nil, which every method treats as a no-op, so
+// ephemeral and pre-upgrade saga paths need no branches at later call sites.
+// Both build paths construct tracking here, keeping their phases, contexts, and
+// failure policy aligned.
 func (b *Builder) trackDeployment(deploymentID string, status StatusSender) *deployTracking {
 	if deploymentID == "" {
 		return nil
@@ -49,13 +46,15 @@ func (b *Builder) trackDeployment(deploymentID string, status StatusSender) *dep
 	}
 }
 
-// beginDeploy creates and locks a deployment record when the client asked the
-// server to own it, and returns a tracker for the rest of the build.
-//
-// It returns nil (not an error) when the build is not server-tracked: no
-// DeployRequest, or an ephemeral build, which has no deployment record by
-// design. A lock already held by a live deployment is a real error and is
-// returned as such — the build must not proceed alongside another one.
+func (t *deployTracking) setSource(version *core_v1alpha.AppVersion) {
+	if t != nil {
+		version.Source = t.source
+	}
+}
+
+// beginDeploy creates and locks an attempt for every non-ephemeral build. A
+// lock already held by a live deployment is a real error: the build must not
+// proceed alongside another one.
 func (b *Builder) beginDeploy(
 	ctx context.Context,
 	appName string,
@@ -63,29 +62,33 @@ func (b *Builder) beginDeploy(
 	ephemeral *ephemeralOpts,
 	status *stream.SendStreamClient[*build_v1alpha.Status],
 ) (*deployTracking, error) {
-	if req == nil || (ephemeral != nil && ephemeral.label != "") {
+	if ephemeral != nil && ephemeral.label != "" {
 		return nil, nil
 	}
 
-	clusterID := req.ClusterId()
-	// An empty cluster_id means "not tracked", matching the saga path's
-	// begin-deployment action (which skips on the same condition). Without this
-	// the two paths would disagree: the plain path would create a lock-holding
-	// record for an empty cluster_id while the saga path created none.
-	if clusterID == "" {
-		return nil, nil
+	app, err := b.ensureApp(ctx, appName)
+	if err != nil {
+		return nil, err
 	}
+	clusterID := ""
+	if req != nil {
+		clusterID = req.ClusterId()
+	}
+	gitInfo := gitInfoFromRequest(req)
 
 	rec, err := b.deploy.Begin(ctx, deploylifecycle.BeginParams{
 		AppName:   appName,
+		AppID:     app.ID,
 		ClusterID: clusterID,
-		GitInfo:   gitInfoFromRequest(req),
+		Operation: deploylifecycle.OperationBuild,
+		GitInfo:   gitInfo,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	dt := b.trackDeployment(string(rec.Deployment.ID), NewRPCStatusSender(status, b.Log))
+	dt.source = deploylifecycle.SourceFromGitInfo(gitInfo)
 
 	// Announce the record and its opening phase so the client can display and
 	// cancel a deployment it did not create.
@@ -132,26 +135,21 @@ func (t *deployTracking) setAppVersion(ctx context.Context, appVersionID string)
 	}
 }
 
-// activate marks the deployment live once the new version is running.
-//
-// The version is already live by the time this runs, so the settle uses a
-// detached context and, if it still fails, releases the lock directly as a
-// backstop — a live deploy must never leave the app stalled behind a record that
-// will not settle.
-func (t *deployTracking) activate(ctx context.Context) {
+// activate swings the app's version and deployment pointers together, then
+// records the successful outcome. The detached context lets that commit finish
+// after the initiating client disconnects.
+func (t *deployTracking) activate(ctx context.Context) error {
 	if t == nil {
-		return
+		return nil
 	}
 
 	settleCtx, cancel := settleContext(ctx)
 	defer cancel()
 
 	if err := t.tracker.Activate(settleCtx, t.deploymentID); err != nil {
-		t.log.Error("failed to activate deployment; releasing lock as backstop", "error", err)
-		if relErr := t.tracker.ReleaseLock(settleCtx, t.deploymentID); relErr != nil {
-			t.log.Error("failed to release lock after activation error", "error", relErr)
-		}
+		return err
 	}
+	return nil
 }
 
 // failOnError settles the deployment as failed when a build returned an error,
@@ -169,7 +167,7 @@ func (t *deployTracking) failOnError(ctx context.Context, retErr error) {
 	settleCtx, cancel := settleContext(ctx)
 	defer cancel()
 
-	if err := t.tracker.FailIfUnsettled(settleCtx, t.deploymentID, retErr.Error(), ""); err != nil {
+	if err := t.tracker.FailIfUnsettled(settleCtx, t.deploymentID, retErr.Error()); err != nil {
 		t.log.Error("failed to record deployment failure", "error", err)
 	}
 }

--- a/servers/build/deploy_tracking_test.go
+++ b/servers/build/deploy_tracking_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/build/build_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity/testutils"
@@ -37,36 +38,30 @@ func deployRequest(cluster string) *build_v1alpha.DeployRequest {
 	return req
 }
 
-// The ownership signal: a build with no DeployRequest must leave the server
-// managing no deployment record at all, so an older client keeps driving its
-// own and there is never a second record.
-func TestBeginDeployWithoutRequestTracksNothing(t *testing.T) {
+func TestBeginDeployWithoutRequestStillTracksAttempt(t *testing.T) {
 	ctx := context.Background()
 	b := newDeployTestBuilder(t)
 
 	dt, err := b.beginDeploy(ctx, "web", nil, nil, nil)
 	require.NoError(t, err)
-	assert.Nil(t, dt, "no request means no server-owned record")
+	require.NotNil(t, dt)
 
 	all, err := b.deploy.Store().List(ctx, deploylifecycle.Query{AppName: "web"})
 	require.NoError(t, err)
-	assert.Empty(t, all, "the server must not have created a record")
+	assert.Len(t, all, 1)
 }
 
-// A DeployRequest with an empty cluster_id means "not tracked", so the plain
-// path agrees with the saga path (whose begin-deployment action skips on the
-// same condition) instead of creating a lock-holding record.
-func TestBeginDeploySkipsEmptyClusterID(t *testing.T) {
+func TestBeginDeployAllowsEmptyLegacyClusterID(t *testing.T) {
 	ctx := context.Background()
 	b := newDeployTestBuilder(t)
 
 	dt, err := b.beginDeploy(ctx, "web", deployRequest(""), nil, nil)
 	require.NoError(t, err)
-	assert.Nil(t, dt, "an empty cluster_id must not create a server-owned record")
+	require.NotNil(t, dt)
 
 	all, err := b.deploy.Store().List(ctx, deploylifecycle.Query{AppName: "web"})
 	require.NoError(t, err)
-	assert.Empty(t, all)
+	assert.Len(t, all, 1)
 }
 
 // Ephemeral builds have no deployment record by design, even when a request is
@@ -187,7 +182,7 @@ func TestFailOnErrorSettlesEvenWhenContextCancelled(t *testing.T) {
 // release the lock as a backstop so the app is not stalled behind a record that
 // will never settle. Activation is forced to fail deterministically by moving
 // the record to a state Transition-to-active rejects while the lock is held.
-func TestActivateReleasesLockWhenSettleFails(t *testing.T) {
+func TestActivateKeepsLockWhenActivationDidNotCommit(t *testing.T) {
 	ctx := context.Background()
 	b := newDeployTestBuilder(t)
 
@@ -208,12 +203,13 @@ func TestActivateReleasesLockWhenSettleFails(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, blocking, "lock should still be held before the backstop runs")
 
-	rec.activate(ctx)
+	require.Error(t, rec.activate(ctx))
 
-	// The backstop released the lock even though the settle failed.
+	// A failure before the activation commit leaves the lock with this attempt,
+	// so the caller can still settle the record.
 	blocking, err = b.deploy.Locks().Blocking(ctx, "web")
 	require.NoError(t, err)
-	assert.Nil(t, blocking, "a failed activation must still free the lock")
+	assert.NotNil(t, blocking, "a pre-commit failure must not pretend the deploy is over")
 }
 
 // A client disconnect (cancelled context) at activation must not prevent the
@@ -224,16 +220,19 @@ func TestActivateSurvivesCancelledContext(t *testing.T) {
 
 	rec, err := b.beginDeploy(ctx, "web", deployRequest("prod"), nil, nil)
 	require.NoError(t, err)
+	version := &core_v1alpha.AppVersion{App: "app/web", Version: "v1"}
+	_, err = b.ec.Create(ctx, "v1", version)
+	require.NoError(t, err)
 	require.NoError(t, b.deploy.SetAppVersion(ctx, rec.deploymentID, "app_version/v1"))
 
 	cancelled, cancel := context.WithCancel(ctx)
 	cancel()
 
-	rec.activate(cancelled)
+	require.NoError(t, rec.activate(cancelled))
 
 	settled, err := b.deploy.Store().Get(ctx, rec.deploymentID)
 	require.NoError(t, err)
-	assert.Equal(t, deploylifecycle.StatusActive, settled.Status(),
+	assert.Equal(t, deploylifecycle.StatusSucceeded, settled.Status(),
 		"activation must complete on a detached context despite a cancelled parent")
 
 	blocking, err := b.deploy.Locks().Blocking(ctx, "web")

--- a/servers/build/saga_builder.go
+++ b/servers/build/saga_builder.go
@@ -250,13 +250,19 @@ func (s *SagaBuilder) startBuild(
 		}
 	}
 
-	// Seeding deploy_cluster_id is what turns on the server-owned deployment
-	// record: the begin-deployment action skips without it. Absent for older
-	// clients (no DeployRequest) and for ephemeral builds.
-	if deployReq != nil && eph == nil {
-		sb = sb.Input("deploy_cluster_id", deployReq.ClusterId())
-		if gitJSON := marshalDeployGitInfo(deployReq); gitJSON != "" {
-			sb = sb.Input("deploy_git_info_json", gitJSON)
+	// Every non-ephemeral build is an attempt. Seed authenticated identity into
+	// the durable saga inputs because a recovered action no longer has the
+	// initiating RPC context.
+	if eph == nil || eph.label == "" {
+		if deployReq != nil {
+			sb = sb.Input("deploy_cluster_id", deployReq.ClusterId())
+			if gitJSON := marshalDeployGitInfo(deployReq); gitJSON != "" {
+				sb = sb.Input("deploy_git_info_json", gitJSON)
+			}
+		}
+		if identity := rpc.IdentityFromContext(ctx); identity != nil && identity.Method != rpc.AuthMethodAnonymous {
+			sb = sb.Input("deploy_subject", identity.Subject).
+				Input("deploy_auth_method", string(identity.Method))
 		}
 	}
 
@@ -310,7 +316,7 @@ func (s *SagaBuilder) settleAbandonedDeployment(ctx context.Context, executionID
 		return
 	}
 
-	if err := s.inner.deploy.FailIfUnsettled(settleCtx, out.DeploymentID, cause.Error(), ""); err != nil {
+	if err := s.inner.deploy.FailIfUnsettled(settleCtx, out.DeploymentID, cause.Error()); err != nil {
 		s.log.Error("failed to settle deployment after saga failure",
 			"deployment_id", out.DeploymentID, "error", err)
 	}

--- a/servers/deployment/cross_version_test.go
+++ b/servers/deployment/cross_version_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,91 +15,33 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 )
 
-// These tests pin the "exactly one owner per build" guarantee across CLI/server
-// versions. The deployment server (which an older CLI drives through
-// CreateDeployment) and the build server (which a newer CLI drives through the
-// DeployRequest param) hold their locks in the same deploylifecycle namespace
-// over the same entity store. A deploy driven by one must therefore contend
-// with a deploy driven by the other — they cannot both hold the lock, so a
-// client that somehow triggered both would produce one record, not two.
-//
-// The build server's ownership is modeled here by a bare deploylifecycle.Tracker
-// over the same store, which is exactly what servers/build constructs; importing
-// servers/build here would be circular.
-
-func sharedStoreClientAndTracker(t *testing.T) (*deployment_v1alpha.DeploymentClient, *deploylifecycle.Tracker) {
-	t.Helper()
-
+// An older CLI calls CreateDeployment before starting its build. Once the
+// server owns deployment attempts, accepting that call would create a second
+// lifecycle owner that the build cannot safely join. Keep the RPC on the wire,
+// but fail before publishing either a record or a lock.
+func TestCreateDeploymentUpgradeErrorHasNoSideEffects(t *testing.T) {
+	ctx := context.Background()
 	inmem, cleanup := testutils.NewInMemEntityServer(t)
 	t.Cleanup(cleanup)
 
 	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
 	require.NoError(t, err)
-
 	client := &deployment_v1alpha.DeploymentClient{
 		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
 	}
 
+	_, err = client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "run 'miren upgrade'"), err.Error())
+
 	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
-	buildTracker := deploylifecycle.NewTracker(log, inmem.EAC)
-
-	return client, buildTracker
-}
-
-// Old CLI took the lock via CreateDeployment; a server-owned build for the same
-// app+cluster must lose the lock rather than start a second deploy.
-func TestCreateDeploymentBlocksServerOwnedBuild(t *testing.T) {
-	ctx := context.Background()
-	client, buildTracker := sharedStoreClientAndTracker(t)
-
-	created, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err)
-	require.False(t, created.HasError() && created.Error() != "")
-
-	_, err = buildTracker.Begin(ctx, deploylifecycle.BeginParams{AppName: "web", ClusterID: "prod"})
-	require.ErrorIs(t, err, deploylifecycle.ErrLockHeld,
-		"a server-owned build must not run alongside a CLI-driven deployment")
-
-	// And exactly one in-progress record exists.
-	records, err := buildTracker.Store().List(ctx, deploylifecycle.Query{
+	tracker := deploylifecycle.NewTracker(log, inmem.EAC)
+	records, err := tracker.Store().List(ctx, deploylifecycle.Query{
 		AppName: "web", Status: deploylifecycle.StatusInProgress,
 	})
 	require.NoError(t, err)
-	assert.Len(t, records, 1, "the blocked build must not have created a second record")
-}
+	assert.Empty(t, records, "the rejected legacy call must not publish an attempt")
 
-// Symmetric case: a server-owned build holds the lock; an old CLI's
-// CreateDeployment for the same app+cluster is blocked.
-func TestServerOwnedBuildBlocksCreateDeployment(t *testing.T) {
-	ctx := context.Background()
-	client, buildTracker := sharedStoreClientAndTracker(t)
-
-	_, err := buildTracker.Begin(ctx, deploylifecycle.BeginParams{AppName: "web", ClusterID: "prod"})
-	require.NoError(t, err)
-
-	blocked, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err, "the block is a domain outcome, not an RPC error")
-	require.True(t, blocked.HasError() && blocked.Error() != "",
-		"CreateDeployment must be blocked by the server-owned build's lock")
-	assert.Contains(t, blocked.Error(), "blocked")
-	assert.True(t, blocked.HasLockInfo() && blocked.LockInfo() != nil)
-}
-
-// Once the CLI-driven deployment settles, the lock frees and a server-owned
-// build proceeds — the two versions hand off cleanly.
-func TestLockHandsOffBetweenVersions(t *testing.T) {
-	ctx := context.Background()
-	client, buildTracker := sharedStoreClientAndTracker(t)
-
-	created, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err)
-
-	// Old CLI settles its record (build failed).
-	_, err = client.UpdateFailedDeployment(ctx, created.Deployment().Id(), "build broke", "")
-	require.NoError(t, err)
-
-	// New server-owned build now gets through.
-	rec, err := buildTracker.Begin(ctx, deploylifecycle.BeginParams{AppName: "web", ClusterID: "prod"})
-	require.NoError(t, err, "a settled CLI deployment must free the lock for the next build")
-	assert.Equal(t, deploylifecycle.StatusInProgress, rec.Status())
+	_, err = tracker.Begin(ctx, deploylifecycle.BeginParams{AppName: "web", ClusterID: "prod"})
+	require.NoError(t, err, "the rejected legacy call must not hold the deploy lock")
 }

--- a/servers/deployment/guard_test.go
+++ b/servers/deployment/guard_test.go
@@ -113,24 +113,6 @@ func TestDeploy_RejectsCrossAppVersion(t *testing.T) {
 		}
 	})
 
-	t.Run("CreateDeployment rejects another app's real version", func(t *testing.T) {
-		for _, versionRef := range []string{"app-y-v1", string(appYVersionID)} {
-			_, err := client.CreateDeployment(ctx, "app-x", "cluster-1", versionRef, nil)
-			if err == nil || !strings.Contains(err.Error(), "does not belong to app") {
-				t.Fatalf("ref %q: expected ownership error, got %v", versionRef, err)
-			}
-		}
-	})
-
-	t.Run("CreateDeployment allows a pending-build placeholder", func(t *testing.T) {
-		// The normal flow passes a non-existent placeholder version; it must not
-		// be rejected (the real version is attached and checked later).
-		_, err := client.CreateDeployment(ctx, "app-x", "cluster-1", "pending-build", nil)
-		if err != nil && strings.Contains(err.Error(), "does not belong to app") {
-			t.Fatalf("placeholder version must not trip the ownership check: %v", err)
-		}
-	})
-
 	t.Run("UpdateDeploymentAppVersion rejects another app's version", func(t *testing.T) {
 		depID, err := inmem.Client.Create(ctx, "dep-x", &core_v1alpha.Deployment{
 			AppName:    "app-x",

--- a/servers/deployment/lock_integration_test.go
+++ b/servers/deployment/lock_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	deployment_v1alpha "miren.dev/runtime/api/deployment/deployment_v1alpha"
+	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
 )
@@ -31,60 +32,28 @@ func newLockTestClient(t *testing.T) (*deployment_v1alpha.DeploymentClient, *tes
 	}, inmem
 }
 
-// A second CreateDeployment for the same app+cluster must be blocked by the
-// lock the first one took, and must return structured lock info.
-func TestCreateDeploymentTakesAndReportsLock(t *testing.T) {
-	ctx := context.Background()
-	client, _ := newLockTestClient(t)
-
-	first, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
+func beginLockTestDeployment(t *testing.T, inmem *testutils.InMemEntityServer, app, cluster string) *deploylifecycle.Record {
+	t.Helper()
+	tracker := deploylifecycle.NewTracker(slog.Default(), inmem.EAC)
+	rec, err := tracker.Begin(context.Background(), deploylifecycle.BeginParams{
+		AppName: app, ClusterID: cluster, Operation: deploylifecycle.OperationBuild,
+	})
 	require.NoError(t, err)
-	require.False(t, first.HasError() && first.Error() != "", "first deploy should succeed: %s", first.Error())
-
-	second, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err)
-	require.True(t, second.HasError() && second.Error() != "", "second deploy must be blocked")
-	assert.Contains(t, second.Error(), "blocked")
-	require.True(t, second.HasLockInfo() && second.LockInfo() != nil)
-	assert.Equal(t, first.Deployment().Id(), second.LockInfo().BlockingDeploymentId())
-}
-
-// The lock is app-scoped: a different app is a different lock, but the same app
-// with a different client cluster string is still the same lock (a coordinator
-// serves one cluster, and the client cluster string is unreliable — MIR-1465).
-func TestCreateDeploymentLockIsScopedPerApp(t *testing.T) {
-	ctx := context.Background()
-	client, _ := newLockTestClient(t)
-
-	_, err := client.CreateDeployment(ctx, "web", "garden", "pending-build", nil)
-	require.NoError(t, err)
-
-	otherApp, err := client.CreateDeployment(ctx, "api", "garden", "pending-build", nil)
-	require.NoError(t, err)
-	assert.False(t, otherApp.HasError() && otherApp.Error() != "", "a different app is a different lock")
-
-	// Same app, a different cluster_id string (the CI/manual split) must still
-	// be blocked — otherwise the two would deploy the same app concurrently.
-	sameAppOtherClusterString, err := client.CreateDeployment(ctx, "web", "34.122.229.118:8443", "pending-build", nil)
-	require.NoError(t, err)
-	assert.True(t, sameAppOtherClusterString.HasError() && sameAppOtherClusterString.Error() != "",
-		"the same app is a single lock regardless of the cluster string")
-	assert.Contains(t, sameAppOtherClusterString.Error(), "blocked")
+	return rec
 }
 
 // Settling a deployment through the deprecated status update must release the
 // lock, so the next deploy proceeds.
 func TestUpdateStatusReleasesLock(t *testing.T) {
 	ctx := context.Background()
-	client, _ := newLockTestClient(t)
+	client, inmem := newLockTestClient(t)
 
-	first, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err)
-	deploymentID := first.Deployment().Id()
+	first := beginLockTestDeployment(t, inmem, "web", "prod")
+	deploymentID := string(first.Deployment.ID)
 
 	// A version must be recorded before activation is meaningful; the old CLI
 	// did this via UpdateDeploymentAppVersion.
-	_, err = client.UpdateDeploymentAppVersion(ctx, deploymentID, "app_version/v1")
+	_, err := client.UpdateDeploymentAppVersion(ctx, deploymentID, "app_version/v1")
 	require.NoError(t, err)
 
 	_, err = client.UpdateDeploymentStatus(ctx, deploymentID, "active", "")
@@ -94,19 +63,16 @@ func TestUpdateStatusReleasesLock(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, blocked.Held(), "an activated deployment must not keep the lock")
 
-	next, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err)
-	assert.False(t, next.HasError() && next.Error() != "", "the next deploy must not be blocked")
+	beginLockTestDeployment(t, inmem, "web", "prod")
 }
 
 func TestUpdateFailedDeploymentReleasesLock(t *testing.T) {
 	ctx := context.Background()
-	client, _ := newLockTestClient(t)
+	client, inmem := newLockTestClient(t)
 
-	first, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err)
+	first := beginLockTestDeployment(t, inmem, "web", "prod")
 
-	updated, err := client.UpdateFailedDeployment(ctx, first.Deployment().Id(), "build broke", "logs")
+	updated, err := client.UpdateFailedDeployment(ctx, string(first.Deployment.ID), "build broke", "logs")
 	require.NoError(t, err)
 	require.True(t, updated.HasDeployment())
 	assert.Equal(t, "build broke", updated.Deployment().ErrorMessage())
@@ -120,12 +86,11 @@ func TestUpdateFailedDeploymentReleasesLock(t *testing.T) {
 
 func TestCancelDeploymentReleasesLock(t *testing.T) {
 	ctx := context.Background()
-	client, _ := newLockTestClient(t)
+	client, inmem := newLockTestClient(t)
 
-	first, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err)
+	first := beginLockTestDeployment(t, inmem, "web", "prod")
 
-	cancel, err := client.CancelDeployment(ctx, first.Deployment().Id(), "")
+	cancel, err := client.CancelDeployment(ctx, string(first.Deployment.ID), "")
 	require.NoError(t, err)
 	require.True(t, cancel.Success())
 
@@ -136,20 +101,19 @@ func TestCancelDeploymentReleasesLock(t *testing.T) {
 
 func TestGetDeployLockReportsHolder(t *testing.T) {
 	ctx := context.Background()
-	client, _ := newLockTestClient(t)
+	client, inmem := newLockTestClient(t)
 
 	free, err := client.GetDeployLock(ctx, "web", "prod")
 	require.NoError(t, err)
 	assert.False(t, free.Held(), "no deploy has run, so nothing is held")
 
-	first, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
-	require.NoError(t, err)
+	first := beginLockTestDeployment(t, inmem, "web", "prod")
 
 	held, err := client.GetDeployLock(ctx, "web", "prod")
 	require.NoError(t, err)
 	require.True(t, held.Held())
 	require.True(t, held.HasLockInfo() && held.LockInfo() != nil)
-	assert.Equal(t, first.Deployment().Id(), held.LockInfo().BlockingDeploymentId())
+	assert.Equal(t, string(first.Deployment.ID), held.LockInfo().BlockingDeploymentId())
 }
 
 func TestGetDeployLockValidatesArgs(t *testing.T) {
@@ -215,14 +179,13 @@ func TestDeployVersionMissingAppDoesNotCreateLock(t *testing.T) {
 // in history, not as the sentinel.
 func TestPendingBuildSentinelNormalizedInHistory(t *testing.T) {
 	ctx := context.Background()
-	client, _ := newLockTestClient(t)
+	client, inmem := newLockTestClient(t)
 
-	created, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
+	_, err := inmem.Client.Create(ctx, "legacy-dep", &core_v1alpha.Deployment{
+		AppName: "web", ClusterId: "prod", AppVersion: "pending-build", Status: "in_progress",
+	})
 	require.NoError(t, err)
-	assert.Equal(t, "", created.Deployment().AppVersionId(),
-		"the pending-build placeholder must not surface to clients")
 
-	// And through the list path.
 	list, err := client.ListDeployments(ctx, "web", "prod", "", 10)
 	require.NoError(t, err)
 	require.Len(t, list.Deployments(), 1)

--- a/servers/deployment/lock_integration_test.go
+++ b/servers/deployment/lock_integration_test.go
@@ -21,6 +21,10 @@ func newLockTestClient(t *testing.T) (*deployment_v1alpha.DeploymentClient, *tes
 
 	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
 	require.NoError(t, err)
+	_, err = inmem.Client.Create(context.Background(), "v1", &core_v1alpha.AppVersion{
+		App: "app/web", Version: "v1",
+	})
+	require.NoError(t, err)
 
 	return &deployment_v1alpha.DeploymentClient{
 		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
@@ -102,8 +106,12 @@ func TestUpdateFailedDeploymentReleasesLock(t *testing.T) {
 	first, err := client.CreateDeployment(ctx, "web", "prod", "pending-build", nil)
 	require.NoError(t, err)
 
-	_, err = client.UpdateFailedDeployment(ctx, first.Deployment().Id(), "build broke", "logs")
+	updated, err := client.UpdateFailedDeployment(ctx, first.Deployment().Id(), "build broke", "logs")
 	require.NoError(t, err)
+	require.True(t, updated.HasDeployment())
+	assert.Equal(t, "build broke", updated.Deployment().ErrorMessage())
+	assert.False(t, updated.Deployment().HasBuildLogs(),
+		"the deprecated request field must not put embedded logs back into responses")
 
 	blocked, err := client.GetDeployLock(ctx, "web", "prod")
 	require.NoError(t, err)
@@ -183,25 +191,24 @@ func TestDeployVersionReleasesLockWhenDone(t *testing.T) {
 	assert.False(t, res2.HasError() && res2.Error() != "", "the next deploy must not be blocked")
 }
 
-// A DeployVersion whose activation fails must still release the lock, so the
-// failure does not block the app's next deploy. SetActiveVersion is made to fail
-// by pointing at a version whose app entity does not exist.
-func TestDeployVersionFailureReleasesLock(t *testing.T) {
+// A missing app is rejected before Begin, so it must not publish either lock
+// representation as a side effect of validating the request.
+func TestDeployVersionMissingAppDoesNotCreateLock(t *testing.T) {
 	ctx := context.Background()
 	client, inmem := newLockTestClient(t)
 
-	// A version with no corresponding app entity: activation will fail.
+	// A version with no corresponding app entity fails the preflight lookup.
 	_, err := inmem.Client.Create(ctx, "ghost-v1", &core_v1alpha.AppVersion{Version: "ghost-v1"})
 	require.NoError(t, err)
 
 	res, err := client.DeployVersion(ctx, "ghost", "prod", "ghost-v1", false, nil, "", "")
 	require.NoError(t, err)
-	require.True(t, res.HasError() && res.Error() != "", "deploy should have failed to activate")
+	require.True(t, res.HasError() && res.Error() != "", "deploy should reject the missing app")
 
-	// The failure must not have stranded the lock.
+	// Validation must not have created a lock.
 	lock, err := client.GetDeployLock(ctx, "ghost", "prod")
 	require.NoError(t, err)
-	assert.False(t, lock.Held(), "a failed DeployVersion must release the lock")
+	assert.False(t, lock.Held(), "a rejected DeployVersion must not acquire the lock")
 }
 
 // The "pending-build" placeholder an older client writes must render as empty

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -79,14 +79,14 @@ func (d *DeploymentServer) lockInfoFor(ctx context.Context, holder *deploylifecy
 		// The lock is app-scoped, so cluster for display comes from the blocking
 		// record rather than the lock.
 		info.SetClusterId(rec.Deployment.ClusterId)
-		info.SetCurrentPhase(rec.Deployment.Phase)
+		info.SetCurrentPhase(string(rec.Phase()))
 		info.SetBlockingDeploymentShortId(shortIDFromRPCEntity(rec.Entity))
 
 		if email := rec.Deployment.DeployedBy.UserEmail; email != "" &&
 			email != "unknown@example.com" && email != "user@example.com" {
 			displayEmail = email
 		}
-		if ts, err := time.Parse(time.RFC3339, rec.Deployment.DeployedBy.Timestamp); err == nil {
+		if ts := rec.StartedAt(); !ts.IsZero() {
 			info.SetStartedAt(standard.ToTimestamp(ts))
 		}
 	}
@@ -100,17 +100,6 @@ func (d *DeploymentServer) lockInfoFor(ctx context.Context, holder *deploylifecy
 func (d *DeploymentServer) reportLockBlocked(ctx context.Context, results lockBlockable, holder *deploylifecycle.Holder) {
 	results.SetLockInfo(d.lockInfoFor(ctx, holder))
 	results.SetError("deployment blocked by existing in-progress deployment")
-}
-
-// releaseDeployLock drops the deploy lock held by a deployment that has just
-// settled through one of the deprecated client-driven methods. A failure to
-// release is logged, not returned: the record already reached its terminal
-// state, and the lock will expire on its own.
-func (d *DeploymentServer) releaseDeployLock(ctx context.Context, appName, deploymentID string) {
-	if err := d.tracker.Locks().Release(ctx, appName, deploymentID); err != nil {
-		d.Log.Error("failed to release deploy lock",
-			"deployment_id", deploymentID, "app", appName, "error", err)
-	}
 }
 
 func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment_v1alpha.DeploymentCreateDeployment) error {
@@ -145,6 +134,7 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 	// error fails closed — skipping the check on a transient store error would
 	// let a cross-app version slip through.
 	appVersionID := args.AppVersionId()
+	canonicalVersionID := ""
 	var appVersion core_v1alpha.AppVersion
 	switch err := d.getAppVersion(ctx, appVersionID, &appVersion); {
 	case err == nil:
@@ -152,6 +142,7 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 			return verifyErr
 		}
 		appVersionID = string(appVersion.ID)
+		canonicalVersionID = appVersionID
 	case !errors.Is(err, cond.ErrNotFound{}):
 		d.Log.Error("Failed to look up app version", "app_version_id", appVersionID, "error", err)
 		return cond.Error("failed to look up app version")
@@ -162,13 +153,14 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 		gitInfo = gitInfoFromRPC(args.GitInfo())
 	}
 
-	// Begin creates the record and takes the deploy lock atomically, replacing
-	// the old list-then-create-with-timeout dance. The "pending-build" sentinel
-	// the older CLI passes is normalized away — app_version is optional now.
+	// Begin admits the deployment under the app-scoped lock. The "pending-build"
+	// sentinel an older CLI passes is normalized away because app_version is
+	// optional until the build produces one.
 	rec, err := d.tracker.Begin(ctx, deploylifecycle.BeginParams{
 		AppName:    appName,
 		ClusterID:  clusterId,
-		AppVersion: normalizeAppVersion(appVersionID, ""),
+		Operation:  deploylifecycle.OperationBuild,
+		AppVersion: canonicalVersionID,
 		GitInfo:    gitInfo,
 	})
 	if err != nil {
@@ -208,77 +200,49 @@ func (d *DeploymentServer) UpdateDeploymentStatus(ctx context.Context, req *depl
 	deploymentId := args.DeploymentId()
 	newStatus := args.Status()
 
-	// Validate against the single source of truth so the accepted set and the
-	// error message can never drift (the old inline message omitted "cancelled").
-	if _, err := deploylifecycle.ParseStatus(newStatus); err != nil {
+	status, err := deploylifecycle.ParseStatus(newStatus)
+	if err != nil {
 		return err
 	}
+	if status == deploylifecycle.StatusInterrupted {
+		return cond.ValidationFailure("invalid-status", "interrupted is reserved for deployment reconciliation")
+	}
 
-	// Get existing deployment
-	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
+	rec, err := d.tracker.Store().Get(ctx, deploymentId)
 	if err != nil {
 		d.Log.Error("Failed to get deployment", "deployment_id", deploymentId, "error", err)
 		return cond.NotFound("deployment", deploymentId)
 	}
-
-	// Decode to Deployment struct
-	var deployment core_v1alpha.Deployment
-	decodeEntity(deploymentResp.Entity(), &deployment)
-
-	if !rpc.AllowApp(ctx, deployment.AppName) {
-		return rpc.AppAccessError(ctx, deployment.AppName)
+	if !rpc.AllowApp(ctx, rec.Deployment.AppName) {
+		return rpc.AppAccessError(ctx, rec.Deployment.AppName)
 	}
-
-	// Check if deployment is in a state that can be updated
-	if deployment.Status != "in_progress" {
-		return cond.ValidationFailure("invalid-state",
-			fmt.Sprintf("cannot update deployment in %s state", deployment.Status))
-	}
-
-	// Update deployment status
-	deployment.Status = newStatus
-
-	// Only set CompletedAt if moving to a terminal state
-	if newStatus != "in_progress" {
-		deployment.CompletedAt = time.Now().Format(time.RFC3339)
-	}
-
-	// Update error message if failed
-	if newStatus == "failed" && args.HasErrorMessage() {
-		deployment.ErrorMessage = args.ErrorMessage()
-	}
-
-	// If marking as active, mark all other active deployments for this app/cluster as succeeded
-	if newStatus == "active" {
-		err = d.markPreviousActiveAs(ctx, deployment.AppName, deploymentId, "succeeded")
-		if err != nil {
-			d.Log.Error("Failed to mark previous active deployments as succeeded", "error", err)
-			// Don't fail the whole operation, just log the error
+	switch status {
+	case deploylifecycle.StatusInProgress:
+		// Older clients reassert running after creation. Lifecycle progress and
+		// lock renewal are server-owned now, so a valid self-transition remains an
+		// intentionally idempotent no-op during the compatibility window.
+		err = deploylifecycle.Transition(rec.Status(), deploylifecycle.StatusInProgress)
+	case deploylifecycle.StatusActive, deploylifecycle.StatusSucceeded, deploylifecycle.StatusRolledBack:
+		err = d.tracker.Activate(ctx, deploymentId)
+	case deploylifecycle.StatusFailed:
+		message := ""
+		if args.HasErrorMessage() {
+			message = args.ErrorMessage()
 		}
+		err = d.tracker.Fail(ctx, deploymentId, message)
+	case deploylifecycle.StatusCancelled:
+		err = d.tracker.Cancel(ctx, deploymentId, "")
+	case deploylifecycle.StatusInterrupted:
+		return cond.ValidationFailure("invalid-status", "interrupted is reserved for deployment reconciliation")
 	}
-
-	// Update entity
-	updateAttrs := deployment.Encode()
-	updateEntity := &entityserver_v1alpha.Entity{}
-	updateEntity.SetId(deploymentId)
-	updateEntity.SetAttrs(updateAttrs)
-	updateEntity.SetRevision(deploymentResp.Entity().Revision())
-
-	_, err = d.EAC.Put(ctx, updateEntity)
 	if err != nil {
-		d.Log.Error("Failed to update deployment entity", "error", err)
-		return cond.Error("failed to update deployment")
+		return err
 	}
-
-	// The deployment has left in_progress, so release the deploy lock this
-	// record's Begin took. Release is a no-op if a newer deployment already
-	// holds it.
-	if newStatus != "in_progress" {
-		d.releaseDeployLock(ctx, deployment.AppName, deploymentId)
+	rec, err = d.tracker.Store().Get(ctx, deploymentId)
+	if err != nil {
+		return err
 	}
-
-	// Convert to RPC response
-	deploymentInfo := d.toDeploymentInfo(&deployment)
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Updated deployment status",
@@ -310,45 +274,23 @@ func (d *DeploymentServer) UpdateDeploymentPhase(ctx context.Context, req *deplo
 		return err
 	}
 
-	// Get existing deployment
-	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
+	rec, err := d.tracker.Store().Get(ctx, deploymentId)
 	if err != nil {
 		d.Log.Error("Failed to get deployment", "deployment_id", deploymentId, "error", err)
 		return cond.NotFound("deployment", deploymentId)
 	}
 
-	// Decode to Deployment struct
-	var deployment core_v1alpha.Deployment
-	decodeEntity(deploymentResp.Entity(), &deployment)
-
-	if !rpc.AllowApp(ctx, deployment.AppName) {
-		return rpc.AppAccessError(ctx, deployment.AppName)
+	if !rpc.AllowApp(ctx, rec.Deployment.AppName) {
+		return rpc.AppAccessError(ctx, rec.Deployment.AppName)
 	}
-
-	// Check if deployment is in a state that can be updated
-	if deployment.Status != "in_progress" {
-		return cond.ValidationFailure("invalid-state",
-			fmt.Sprintf("cannot update phase for deployment in %s state", deployment.Status))
+	if err := d.tracker.SetPhase(ctx, deploymentId, deploylifecycle.Phase(newPhase)); err != nil {
+		return err
 	}
-
-	// Update deployment phase
-	deployment.Phase = newPhase
-
-	// Update entity
-	updateAttrs := deployment.Encode()
-	updateEntity := &entityserver_v1alpha.Entity{}
-	updateEntity.SetId(deploymentId)
-	updateEntity.SetAttrs(updateAttrs)
-	updateEntity.SetRevision(deploymentResp.Entity().Revision())
-
-	_, err = d.EAC.Put(ctx, updateEntity)
+	rec, err = d.tracker.Store().Get(ctx, deploymentId)
 	if err != nil {
-		d.Log.Error("Failed to update deployment entity", "error", err)
-		return cond.Error("failed to update deployment")
+		return err
 	}
-
-	// Convert to RPC response
-	deploymentInfo := d.toDeploymentInfo(&deployment)
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Updated deployment phase",
@@ -369,65 +311,35 @@ func (d *DeploymentServer) UpdateFailedDeployment(ctx context.Context, req *depl
 
 	deploymentId := args.DeploymentId()
 	errorMessage := ""
-	buildLogs := ""
 
 	if args.HasErrorMessage() {
 		errorMessage = args.ErrorMessage()
 	}
-	if args.HasBuildLogs() {
-		buildLogs = args.BuildLogs()
-	}
 
-	// Get existing deployment
-	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
+	rec, err := d.tracker.Store().Get(ctx, deploymentId)
 	if err != nil {
 		d.Log.Error("Failed to get deployment", "deployment_id", deploymentId, "error", err)
 		return cond.NotFound("deployment", deploymentId)
 	}
 
-	// Decode to Deployment struct
-	var deployment core_v1alpha.Deployment
-	decodeEntity(deploymentResp.Entity(), &deployment)
-
-	if !rpc.AllowApp(ctx, deployment.AppName) {
-		return rpc.AppAccessError(ctx, deployment.AppName)
+	if !rpc.AllowApp(ctx, rec.Deployment.AppName) {
+		return rpc.AppAccessError(ctx, rec.Deployment.AppName)
 	}
-
-	// Update deployment with failure information
-	// Don't overwrite cancelled status
-	if deployment.Status != "cancelled" {
-		deployment.Status = "failed"
+	// build_logs remains in the deprecated RPC request for old clients, but the
+	// complete build stream belongs in VictoriaLogs rather than this entity.
+	if err := d.tracker.Fail(ctx, deploymentId, errorMessage); err != nil {
+		return err
 	}
-	deployment.ErrorMessage = errorMessage
-	deployment.BuildLogs = buildLogs
-	deployment.CompletedAt = time.Now().Format(time.RFC3339)
-
-	// The "pending-build" placeholder is left in place and normalized away on
-	// read, rather than rewritten to a "failed-<id>" sentinel.
-
-	// Update entity
-	updateAttrs := deployment.Encode()
-	updateEntity := &entityserver_v1alpha.Entity{}
-	updateEntity.SetId(deploymentId)
-	updateEntity.SetAttrs(updateAttrs)
-	updateEntity.SetRevision(deploymentResp.Entity().Revision())
-
-	_, err = d.EAC.Put(ctx, updateEntity)
+	rec, err = d.tracker.Store().Get(ctx, deploymentId)
 	if err != nil {
-		d.Log.Error("Failed to update deployment entity", "error", err)
-		return cond.Error("failed to update deployment")
+		return err
 	}
-
-	// A failed (or already-cancelled) deployment holds the lock no longer.
-	d.releaseDeployLock(ctx, deployment.AppName, deploymentId)
-
-	// Convert to RPC response
-	deploymentInfo := d.toDeploymentInfo(&deployment)
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Updated failed deployment",
 		"deployment_id", deploymentId,
-		"app_version", string(deployment.AppVersion))
+		"app_version", rec.AppVersion())
 
 	return nil
 }
@@ -464,7 +376,7 @@ func (d *DeploymentServer) ListDeployments(ctx context.Context, req *deployment_
 	// Batch-resolve app version short IDs
 	versionIDs := make([]string, 0, len(deployments))
 	for _, dwe := range deployments {
-		versionIDs = append(versionIDs, dwe.deployment.AppVersion)
+		versionIDs = append(versionIDs, (&deploylifecycle.Record{Deployment: dwe.deployment}).AppVersion())
 	}
 	versionShortIDs := d.resolveShortIDs(ctx, versionIDs)
 
@@ -491,24 +403,18 @@ func (d *DeploymentServer) GetDeploymentById(ctx context.Context, req *deploymen
 
 	deploymentId := args.DeploymentId()
 
-	// Get deployment
-	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
+	rec, err := d.tracker.Store().Get(ctx, deploymentId)
 	if err != nil {
 		d.Log.Error("Failed to get deployment", "deployment_id", deploymentId, "error", err)
 		return cond.NotFound("deployment", deploymentId)
 	}
 
-	// Decode to Deployment struct
-	var deployment core_v1alpha.Deployment
-	decodeEntity(deploymentResp.Entity(), &deployment)
-
-	if !rpc.AllowApp(ctx, deployment.AppName) {
-		return rpc.AppAccessError(ctx, deployment.AppName)
+	if !rpc.AllowApp(ctx, rec.Deployment.AppName) {
+		return rpc.AppAccessError(ctx, rec.Deployment.AppName)
 	}
-
-	deploymentInfo := d.toDeploymentInfo(&deployment)
-	versionShortIDs := d.resolveShortIDs(ctx, []string{deployment.AppVersion})
-	enrichDeploymentShortIDs(deploymentInfo, deploymentResp.Entity(), versionShortIDs)
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
+	versionShortIDs := d.resolveShortIDs(ctx, []string{rec.AppVersion()})
+	enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
 
 	return nil
@@ -529,19 +435,14 @@ func (d *DeploymentServer) UpdateDeploymentAppVersion(ctx context.Context, req *
 	deploymentId := args.DeploymentId()
 	appVersionId := args.AppVersionId()
 
-	// Get existing deployment
-	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
+	rec, err := d.tracker.Store().Get(ctx, deploymentId)
 	if err != nil {
 		d.Log.Error("Failed to get deployment", "deployment_id", deploymentId, "error", err)
 		return cond.NotFound("deployment", deploymentId)
 	}
 
-	// Decode to Deployment struct
-	var deployment core_v1alpha.Deployment
-	decodeEntity(deploymentResp.Entity(), &deployment)
-
-	if !rpc.AllowApp(ctx, deployment.AppName) {
-		return rpc.AppAccessError(ctx, deployment.AppName)
+	if !rpc.AllowApp(ctx, rec.Deployment.AppName) {
+		return rpc.AppAccessError(ctx, rec.Deployment.AppName)
 	}
 
 	// If the new version resolves to a real AppVersion, it must belong to the
@@ -554,7 +455,7 @@ func (d *DeploymentServer) UpdateDeploymentAppVersion(ctx context.Context, req *
 	var appVersion core_v1alpha.AppVersion
 	switch err := d.getAppVersion(ctx, appVersionId, &appVersion); {
 	case err == nil:
-		if verifyErr := d.verifyVersionOwnedByApp(ctx, &appVersion, deployment.AppName); verifyErr != nil {
+		if verifyErr := d.verifyVersionOwnedByApp(ctx, &appVersion, rec.Deployment.AppName); verifyErr != nil {
 			return verifyErr
 		}
 		appVersionId = string(appVersion.ID)
@@ -563,24 +464,14 @@ func (d *DeploymentServer) UpdateDeploymentAppVersion(ctx context.Context, req *
 		return cond.Error("failed to look up app version")
 	}
 
-	// Update app version
-	deployment.AppVersion = appVersionId
-
-	// Update entity
-	updateAttrs := deployment.Encode()
-	updateEntity := &entityserver_v1alpha.Entity{}
-	updateEntity.SetId(deploymentId)
-	updateEntity.SetAttrs(updateAttrs)
-	updateEntity.SetRevision(deploymentResp.Entity().Revision())
-
-	_, err = d.EAC.Put(ctx, updateEntity)
-	if err != nil {
-		d.Log.Error("Failed to update deployment entity", "error", err)
-		return cond.Error("failed to update deployment")
+	if err := d.tracker.SetAppVersion(ctx, deploymentId, appVersionId); err != nil {
+		return err
 	}
-
-	// Convert to RPC response
-	deploymentInfo := d.toDeploymentInfo(&deployment)
+	rec, err = d.tracker.Store().Get(ctx, deploymentId)
+	if err != nil {
+		return err
+	}
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Updated deployment app version",
@@ -609,19 +500,34 @@ func (d *DeploymentServer) GetActiveDeployment(ctx context.Context, req *deploym
 		return rpc.AppAccessError(ctx, appName)
 	}
 
-	// Find active deployment
-	deployments, err := d.listDeploymentsInternal(ctx, appName, "active", 1)
+	app, _, err := d.tracker.Store().AppByName(ctx, appName)
+	if err != nil && !errors.Is(err, cond.ErrNotFound{}) {
+		return err
+	}
+	if err == nil && app.ActiveDeployment != "" {
+		rec, err := d.tracker.Store().Get(ctx, string(app.ActiveDeployment))
+		if err != nil {
+			return err
+		}
+		deploymentInfo := d.toDeploymentInfo(rec.Deployment)
+		versionShortIDs := d.resolveShortIDs(ctx, []string{rec.AppVersion()})
+		enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
+		results.SetDeployment(deploymentInfo)
+		return nil
+	}
+
+	// Before the app-pointer migration reaches this app, serve the one retained
+	// legacy active row. Canonical writers always take the branch above.
+	legacy, err := d.listDeploymentsInternal(ctx, appName, "active", 1)
 	if err != nil {
 		return err
 	}
-
-	if len(deployments) == 0 {
+	if len(legacy) == 0 {
 		return cond.NotFound("active-deployment", fmt.Sprintf("%s/%s", appName, clusterId))
 	}
-
-	dwe := deployments[0]
+	dwe := legacy[0]
 	deploymentInfo := d.toDeploymentInfo(dwe.deployment)
-	versionShortIDs := d.resolveShortIDs(ctx, []string{dwe.deployment.AppVersion})
+	versionShortIDs := d.resolveShortIDs(ctx, []string{(&deploylifecycle.Record{Deployment: dwe.deployment}).AppVersion()})
 	enrichDeploymentShortIDs(deploymentInfo, dwe.entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
 
@@ -701,9 +607,12 @@ func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment
 		return rpc.AppAccessError(ctx, deployment.AppName)
 	}
 
-	// Verify deployment is in_progress
-	if deployment.Status != "in_progress" {
-		results.SetError(fmt.Sprintf("deployment is not in progress (status: %s)", deployment.Status))
+	rec, err := d.tracker.Store().Get(ctx, deploymentId)
+	if err != nil {
+		return cond.Error("failed to get deployment")
+	}
+	if rec.Status() != deploylifecycle.StatusInProgress {
+		results.SetError(fmt.Sprintf("deployment is not in progress (status: %s)", rec.Status()))
 		return nil
 	}
 
@@ -780,9 +689,20 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	if err := d.verifyVersionOwnedByApp(ctx, &appVersion, appName); err != nil {
 		return err
 	}
+	if _, _, err := d.tracker.Store().AppByName(ctx, appName); err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			results.SetError(fmt.Sprintf("app %q not found", appName))
+			return nil
+		}
+		d.Log.Error("Failed to look up app", "app", appName, "error", err)
+		results.SetError("failed to look up app")
+		return nil
+	}
+	isEphemeral := args.HasEphemeralLabel() && args.EphemeralLabel() != ""
 
-	// If env vars are provided, create a derived version with merged variables
-	if args.HasEnvVars() && len(args.EnvVars()) > 0 {
+	// Ephemeral versions do not participate in deployment attempts, so their
+	// optional derivation remains wholly inside the ephemeral path.
+	if isEphemeral && args.HasEnvVars() && len(args.EnvVars()) > 0 {
 		derivedVersion, err := d.createDerivedVersion(ctx, &appVersion, args.EnvVars())
 		if err != nil {
 			d.Log.Error("Failed to create derived version with env vars", "error", err)
@@ -795,8 +715,6 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 			"original", args.AppVersionId(), "derived", appVersionId,
 			"env_var_count", len(args.EnvVars()))
 	}
-
-	isEphemeral := args.HasEphemeralLabel() && args.EphemeralLabel() != ""
 
 	if isEphemeral {
 		// Ephemeral deploy: update version with ephemeral fields, skip activation.
@@ -875,17 +793,17 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 
 	// --- Normal (non-ephemeral) deploy path below ---
 
-	// Find the source deployment — the most recent deployment with this
-	// app_version_id — for git info and rollback provenance.
+	// Find the parent deployment: the most recent deployment with this
+	// app_version_id. It supplies git info and rollback lineage.
 	var gitInfo core_v1alpha.GitInfo
-	var sourceDeploymentID string
+	var parentDeploymentID string
 	if allDeployments, listErr := d.listDeploymentsInternal(ctx, appName, "", 100); listErr != nil {
-		d.Log.Error("Failed to list deployments for source lookup", "error", listErr)
+		d.Log.Error("Failed to list deployments for parent lookup", "error", listErr)
 	} else {
 		for _, dwe := range allDeployments {
-			if _, ok := sourceVersionIds[dwe.deployment.AppVersion]; ok {
+			if _, ok := sourceVersionIds[(&deploylifecycle.Record{Deployment: dwe.deployment}).AppVersion()]; ok {
 				gitInfo = dwe.deployment.GitInfo
-				sourceDeploymentID = string(dwe.deployment.ID)
+				parentDeploymentID = string(dwe.deployment.ID)
 				break // listDeploymentsInternal returns newest first
 			}
 		}
@@ -893,12 +811,17 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 
 	// Begin creates the record and takes the deploy lock atomically, contending
 	// with any server-owned build for the same app+cluster.
+	operation := deploylifecycle.OperationRedeploy
+	if isRollback {
+		operation = deploylifecycle.OperationRollback
+	}
 	rec, err := d.tracker.Begin(ctx, deploylifecycle.BeginParams{
 		AppName:            appName,
 		ClusterID:          clusterId,
+		Operation:          operation,
 		AppVersion:         appVersionId,
 		GitInfo:            gitInfo,
-		SourceDeploymentID: sourceDeploymentID,
+		ParentDeploymentID: parentDeploymentID,
 	})
 	if err != nil {
 		if holder, ok := deploylifecycle.HolderFrom(err); ok {
@@ -912,6 +835,21 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 
 	deployment := rec.Deployment
 	newDeploymentId := string(deployment.ID)
+	if args.HasEnvVars() && len(args.EnvVars()) > 0 {
+		derivedVersion, deriveErr := d.createDerivedVersion(ctx, &appVersion, args.EnvVars())
+		if deriveErr != nil {
+			_ = d.tracker.FailIfUnsettled(context.WithoutCancel(ctx), newDeploymentId, deriveErr.Error())
+			results.SetError(fmt.Sprintf("failed to apply env vars: %v", deriveErr))
+			return nil
+		}
+		appVersion = *derivedVersion
+		appVersionId = string(derivedVersion.ID)
+		if err := d.tracker.SetAppVersion(ctx, newDeploymentId, appVersionId); err != nil {
+			_ = d.tracker.FailIfUnsettled(context.WithoutCancel(ctx), newDeploymentId, err.Error())
+			results.SetError(fmt.Sprintf("failed to record derived version: %v", err))
+			return nil
+		}
+	}
 
 	// Every terminal settle below runs on a detached context: once we start
 	// settling, a client that cancels the RPC must not strand the record
@@ -936,28 +874,17 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 		d.Log.Error("Failed to set activating phase", "error", phaseErr)
 	}
 
-	if err := d.AppClient.SetActiveVersion(ctx, appName, string(appVersion.ID)); err != nil {
-		d.Log.Error("Failed to set active version", "error", err, "app", appName, "version_id", string(appVersion.ID))
-
-		failMsg := fmt.Sprintf("failed to activate version: %v", err)
-		if failErr := d.tracker.Fail(settleCtx, newDeploymentId, failMsg, ""); failErr != nil {
-			d.Log.Error("Failed to mark deployment as failed; releasing lock", "error", failErr)
-			d.releaseDeployLock(settleCtx, appName, newDeploymentId)
-		}
-
-		results.SetError(failMsg)
-		return nil
-	}
-
 	activate := d.tracker.Activate
 	if isRollback {
 		activate = d.tracker.ActivateRollback
 	}
-	// SetActiveVersion already made the version live. If the settle still fails,
-	// release the lock directly so later deploys aren't blocked for the full TTL.
 	if err := activate(settleCtx, newDeploymentId); err != nil {
-		d.Log.Error("Failed to activate deployment; releasing lock", "error", err)
-		d.releaseDeployLock(settleCtx, appName, newDeploymentId)
+		d.Log.Error("Failed to activate deployment", "error", err)
+		if failErr := d.tracker.Fail(settleCtx, newDeploymentId, err.Error()); failErr != nil {
+			d.Log.Error("Failed to settle activation failure", "error", failErr)
+		}
+		results.SetError(fmt.Sprintf("failed to activate version: %v", err))
+		return nil
 	}
 
 	// Re-read so the response reflects the settled state.
@@ -967,7 +894,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	}
 
 	deploymentInfo := d.toDeploymentInfo(deployment)
-	versionShortIDs := d.resolveShortIDs(ctx, []string{deployment.AppVersion})
+	versionShortIDs := d.resolveShortIDs(ctx, []string{rec.AppVersion()})
 	enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
 
@@ -1016,9 +943,21 @@ func (d *DeploymentServer) SetEnvVars(ctx context.Context, req *deployment_v1alp
 		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive(), Backend: v.Backend()}
 	}
 
-	// Call shared helper to create new version
-	mutResult, err := appclient.SetEnvVars(ctx, d.EC, d.Secrets, appName, nil, vars, service)
+	rec, err := d.tracker.Begin(ctx, deploylifecycle.BeginParams{
+		AppName: appName, ClusterID: clusterId, Operation: deploylifecycle.OperationConfigChange,
+	})
 	if err != nil {
+		if holder, ok := deploylifecycle.HolderFrom(err); ok {
+			d.reportLockBlocked(ctx, results, holder)
+			return nil
+		}
+		return err
+	}
+	attemptID := string(rec.Deployment.ID)
+	activate := d.configActivator(attemptID)
+	mutResult, err := appclient.SetEnvVarsWithActivator(ctx, d.EC, d.Secrets, appName, nil, vars, service, activate)
+	if err != nil {
+		_ = d.tracker.FailIfUnsettled(context.WithoutCancel(ctx), attemptID, err.Error())
 		d.Log.Error("Failed to set env vars", "error", err, "app", appName)
 		results.SetError(fmt.Sprintf("failed to set env vars: %v", err))
 		return nil
@@ -1027,7 +966,7 @@ func (d *DeploymentServer) SetEnvVars(ctx context.Context, req *deployment_v1alp
 	results.SetVersionId(mutResult.VersionID)
 
 	// Create deployment record and handle lock/activation (shared with DeployVersion)
-	deployErr := d.createEnvVarDeployment(ctx, appName, clusterId, mutResult, results)
+	deployErr := d.createEnvVarDeployment(ctx, appName, clusterId, mutResult, rec, results)
 	if deployErr != nil {
 		return deployErr
 	}
@@ -1061,9 +1000,20 @@ func (d *DeploymentServer) DeleteEnvVars(ctx context.Context, req *deployment_v1
 		service = args.Service()
 	}
 
-	// Call shared helper to create new version
-	delResult, err := appclient.DeleteEnvVars(ctx, d.EC, d.Secrets, appName, nil, args.Keys(), service)
+	rec, err := d.tracker.Begin(ctx, deploylifecycle.BeginParams{
+		AppName: appName, ClusterID: clusterId, Operation: deploylifecycle.OperationConfigChange,
+	})
 	if err != nil {
+		if holder, ok := deploylifecycle.HolderFrom(err); ok {
+			d.reportLockBlocked(ctx, results, holder)
+			return nil
+		}
+		return err
+	}
+	attemptID := string(rec.Deployment.ID)
+	delResult, err := appclient.DeleteEnvVarsWithActivator(ctx, d.EC, d.Secrets, appName, nil, args.Keys(), service, d.configActivator(attemptID))
+	if err != nil {
+		_ = d.tracker.FailIfUnsettled(context.WithoutCancel(ctx), attemptID, err.Error())
 		d.Log.Error("Failed to delete env vars", "error", err, "app", appName)
 		results.SetError(fmt.Sprintf("failed to delete env vars: %v", err))
 		return nil
@@ -1074,7 +1024,7 @@ func (d *DeploymentServer) DeleteEnvVars(ctx context.Context, req *deployment_v1
 	results.SetDeletedSources(&deletedSources)
 
 	// Create deployment record and handle lock/activation
-	deployErr := d.createEnvVarDeployment(ctx, appName, clusterId, &delResult.MutateResult, results)
+	deployErr := d.createEnvVarDeployment(ctx, appName, clusterId, &delResult.MutateResult, rec, results)
 	if deployErr != nil {
 		return deployErr
 	}
@@ -1093,45 +1043,20 @@ type envVarDeployResults interface {
 // createEnvVarDeployment handles the deployment record creation, lock checking,
 // and access info population shared by SetEnvVars and DeleteEnvVars.
 func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, clusterId string,
-	mutResult *appclient.MutateResult, results envVarDeployResults) error {
+	mutResult *appclient.MutateResult, rec *deploylifecycle.Record, results envVarDeployResults) error {
 
 	appVersionId := mutResult.VersionID
 	if mutResult.AppVersion != nil && mutResult.AppVersion.ID != "" {
 		appVersionId = string(mutResult.AppVersion.ID)
 	}
 
-	// An env-var change has no build, so the record goes straight from Begin to
-	// active. Begin takes the deploy lock, contending with any server-owned
-	// build for the same app+cluster.
-	rec, err := d.tracker.Begin(ctx, deploylifecycle.BeginParams{
-		AppName:    appName,
-		ClusterID:  clusterId,
-		AppVersion: appVersionId,
-	})
-	if err != nil {
-		if holder, ok := deploylifecycle.HolderFrom(err); ok {
-			d.reportLockBlocked(ctx, results, holder)
-			return nil
-		}
-		d.Log.Error("Failed to create deployment", "error", err)
-		results.SetError("failed to create deployment")
-		return nil
-	}
-
 	newDeploymentId := string(rec.Deployment.ID)
 
-	// The new version is already applied by the caller; settle immediately,
-	// which marks the previous active deployment succeeded and releases the lock.
-	// Settle on a detached context and release the lock as a backstop so a
-	// cancelled RPC or transient store error can't strand the record in_progress
-	// with the lock held (see DeployVersion for the same reasoning).
+	// The custom env-var activator already committed both app pointers and the
+	// outcome. Re-read on a detached context so the response survives a client
+	// cancellation racing the final store read.
 	settleCtx, cancelSettle := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancelSettle()
-	if err := d.tracker.Activate(settleCtx, newDeploymentId); err != nil {
-		d.Log.Error("Failed to activate env var deployment; releasing lock", "error", err)
-		d.releaseDeployLock(settleCtx, appName, newDeploymentId)
-	}
-
 	deployment := rec.Deployment
 	if settled, getErr := d.tracker.Store().Get(settleCtx, newDeploymentId); getErr == nil {
 		deployment = settled.Deployment
@@ -1139,7 +1064,7 @@ func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, 
 	}
 
 	deploymentInfo := d.toDeploymentInfo(deployment)
-	versionShortIDs := d.resolveShortIDs(ctx, []string{deployment.AppVersion})
+	versionShortIDs := d.resolveShortIDs(ctx, []string{rec.AppVersion()})
 	enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
 
@@ -1153,6 +1078,18 @@ func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, 
 		"version", appVersionId)
 
 	return nil
+}
+
+func (d *DeploymentServer) configActivator(attemptID string) appclient.VersionActivator {
+	return func(ctx context.Context, _ *core_v1alpha.App, revision int64, version entity.Id) error {
+		if err := d.tracker.SetAppVersion(ctx, attemptID, string(version)); err != nil {
+			return err
+		}
+		if err := d.tracker.SetPhase(ctx, attemptID, deploylifecycle.PhaseActivating); err != nil {
+			return err
+		}
+		return d.tracker.ActivateAtRevision(ctx, attemptID, revision)
+	}
 }
 
 // getAccessInfo queries routes to determine how the app can be accessed
@@ -1220,11 +1157,13 @@ func (d *DeploymentServer) getAccessInfo(ctx context.Context, appName string, ep
 func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName, status string, limit int) ([]deploymentWithEntity, error) {
 	// Backed by the shared indexed store, which selects an index from the
 	// filters instead of scanning every deployment ever created.
-	records, err := d.tracker.Store().List(ctx, deploylifecycle.Query{
-		AppName: appName,
-		Status:  deploylifecycle.Status(status),
-		Limit:   limit,
-	})
+	query := deploylifecycle.Query{AppName: appName, Limit: limit}
+	if status == string(deploylifecycle.StatusActive) {
+		query.LegacyStatus = deploylifecycle.StatusActive
+	} else {
+		query.Status = deploylifecycle.Status(status)
+	}
+	records, err := d.tracker.Store().List(ctx, query)
 	if err != nil {
 		d.Log.Error("Failed to list deployments", "error", err)
 		return nil, cond.Error("failed to list deployments")
@@ -1235,19 +1174,6 @@ func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName,
 		deployments = append(deployments, deploymentWithEntity{deployment: rec.Deployment, entity: rec.Entity})
 	}
 	return deployments, nil
-}
-
-// normalizeAppVersion drops the legacy placeholder values older clients wrote
-// into app_version before a build had produced one. The field is optional now,
-// so these are reported as empty rather than migrated.
-func normalizeAppVersion(version, deploymentID string) string {
-	if version == "pending-build" {
-		return ""
-	}
-	if deploymentID != "" && version == "failed-"+deploymentID {
-		return ""
-	}
-	return version
 }
 
 // gitInfoFromRPC converts the deployment-service git shape into the core entity
@@ -1275,40 +1201,45 @@ func gitInfoFromRPC(gi *deployment_v1alpha.GitInfo) core_v1alpha.GitInfo {
 
 func (d *DeploymentServer) toDeploymentInfo(deployment *core_v1alpha.Deployment) *deployment_v1alpha.DeploymentInfo {
 	info := &deployment_v1alpha.DeploymentInfo{}
+	rec := &deploylifecycle.Record{Deployment: deployment}
 
 	info.SetId(string(deployment.ID))
 	info.SetAppName(deployment.AppName)
 	// Normalize legacy placeholder versions to empty so history renders "—"
 	// rather than "pending-build" or "failed-<id>".
-	info.SetAppVersionId(normalizeAppVersion(deployment.AppVersion, string(deployment.ID)))
+	info.SetAppVersionId(rec.AppVersion())
 	info.SetClusterId(deployment.ClusterId)
-	info.SetStatus(deployment.Status)
-	info.SetPhase(deployment.Phase)
+	status := rec.Status()
+	// Keep the old RPC vocabulary: a succeeded attempt that currently owns the
+	// app pointer is presented as active to downgrade-era clients.
+	if status == deploylifecycle.StatusSucceeded {
+		status = deploylifecycle.Status(deployment.Status)
+		if status == "" {
+			status = deploylifecycle.StatusSucceeded
+		}
+	}
+	info.SetStatus(string(status))
+	info.SetPhase(string(rec.Phase()))
 	info.SetDeployedByUserId(deployment.DeployedBy.UserId)
 	info.SetDeployedByUserName(deployment.DeployedBy.UserName)
 	info.SetDeployedByUserEmail(deployment.DeployedBy.UserEmail)
 
 	// Parse timestamps
-	if deployedAt, err := time.Parse(time.RFC3339, deployment.DeployedBy.Timestamp); err == nil {
+	if deployedAt := rec.StartedAt(); !deployedAt.IsZero() {
 		info.SetDeployedAt(standard.ToTimestamp(deployedAt))
 	}
-	if deployment.CompletedAt != "" {
-		if completedAt, err := time.Parse(time.RFC3339, deployment.CompletedAt); err == nil {
-			info.SetCompletedAt(standard.ToTimestamp(completedAt))
-		}
+	if completedAt := rec.CompletedAt(); !completedAt.IsZero() {
+		info.SetCompletedAt(standard.ToTimestamp(completedAt))
 	}
 
 	// Add error information if available
 	if deployment.ErrorMessage != "" {
 		info.SetErrorMessage(deployment.ErrorMessage)
 	}
-	if deployment.BuildLogs != "" {
-		info.SetBuildLogs(deployment.BuildLogs)
-	}
 
-	// Add source deployment ID if available (rollback/redeploy provenance)
-	if deployment.SourceDeploymentId != "" {
-		info.SetSourceDeploymentId(deployment.SourceDeploymentId)
+	// Preserve the existing wire field for clients that display lineage.
+	if parentID := rec.ParentDeploymentID(); parentID != "" {
+		info.SetSourceDeploymentId(parentID)
 	}
 
 	// Add git info if available
@@ -1420,13 +1351,6 @@ type deploymentWithEntity struct {
 	entity     *entityserver_v1alpha.Entity
 }
 
-// markPreviousActiveAs settles the deployments that were active for this app,
-// leaving currentDeploymentId alone. Backed by the shared store's status-indexed
-// implementation.
-func (d *DeploymentServer) markPreviousActiveAs(ctx context.Context, appName, currentDeploymentId, targetStatus string) error {
-	return d.tracker.Store().MarkPreviousActiveAs(ctx, appName, currentDeploymentId, deploylifecycle.Status(targetStatus))
-}
-
 // decodeEntity is a helper to decode RPC entity to struct
 func decodeEntity(rpcEntity *entityserver_v1alpha.Entity, target any) {
 	type decoder interface {
@@ -1522,6 +1446,7 @@ func (d *DeploymentServer) createDerivedVersion(ctx context.Context, base *core_
 		AdminToken:     base.AdminToken,
 		Manifest:       base.Manifest,
 		ManifestDigest: base.ManifestDigest,
+		Source:         base.Source,
 	}
 
 	// Merge env vars into config

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -36,10 +36,9 @@ type DeploymentServer struct {
 	// env change records the exact secret version it saw.
 	Secrets secret.Resolver
 
-	// tracker owns the deployment record state machine and the deploy lock. The
-	// build server holds its own Tracker over the same entity store, and both
-	// acquire the same app-scoped lock, so a client that drives a record through
-	// the deprecated RPCs still contends with a server-owned build.
+	// tracker owns the deployment record state machine and the deploy lock for
+	// non-build rollouts and for settling records created before the build server
+	// took over. The build server holds its own Tracker over the same entity store.
 	tracker *deploylifecycle.Tracker
 }
 
@@ -102,87 +101,9 @@ func (d *DeploymentServer) reportLockBlocked(ctx context.Context, results lockBl
 	results.SetError("deployment blocked by existing in-progress deployment")
 }
 
-func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment_v1alpha.DeploymentCreateDeployment) error {
-	args := req.Args()
-	results := req.Results()
-
-	// Validate required fields
-	if !args.HasAppName() || args.AppName() == "" {
-		return cond.ValidationFailure("missing-field", "app_name is required")
-	}
-	if !args.HasClusterId() || args.ClusterId() == "" {
-		return cond.ValidationFailure("missing-field", "cluster_id is required")
-	}
-	if !args.HasAppVersionId() || args.AppVersionId() == "" {
-		return cond.ValidationFailure("missing-field", "app_version_id is required")
-	}
-
-	appName := args.AppName()
-	clusterId := args.ClusterId()
-
-	if !rpc.AllowApp(ctx, appName) {
-		return rpc.AppAccessError(ctx, appName)
-	}
-
-	// If the referenced version resolves to a real AppVersion, it must belong to
-	// this app — AllowApp confined the target app, not the source version, so
-	// without this a caller could point a deployment at another app's built
-	// version. The normal flow passes a "pending-build" placeholder here (no
-	// entity yet) and attaches the real version later via
-	// UpdateDeploymentAppVersion, which enforces the same ownership; so a
-	// not-found version is left alone rather than rejected. Any other lookup
-	// error fails closed — skipping the check on a transient store error would
-	// let a cross-app version slip through.
-	appVersionID := args.AppVersionId()
-	canonicalVersionID := ""
-	var appVersion core_v1alpha.AppVersion
-	switch err := d.getAppVersion(ctx, appVersionID, &appVersion); {
-	case err == nil:
-		if verifyErr := d.verifyVersionOwnedByApp(ctx, &appVersion, appName); verifyErr != nil {
-			return verifyErr
-		}
-		appVersionID = string(appVersion.ID)
-		canonicalVersionID = appVersionID
-	case !errors.Is(err, cond.ErrNotFound{}):
-		d.Log.Error("Failed to look up app version", "app_version_id", appVersionID, "error", err)
-		return cond.Error("failed to look up app version")
-	}
-
-	var gitInfo core_v1alpha.GitInfo
-	if args.HasGitInfo() {
-		gitInfo = gitInfoFromRPC(args.GitInfo())
-	}
-
-	// Begin admits the deployment under the app-scoped lock. The "pending-build"
-	// sentinel an older CLI passes is normalized away because app_version is
-	// optional until the build produces one.
-	rec, err := d.tracker.Begin(ctx, deploylifecycle.BeginParams{
-		AppName:    appName,
-		ClusterID:  clusterId,
-		Operation:  deploylifecycle.OperationBuild,
-		AppVersion: canonicalVersionID,
-		GitInfo:    gitInfo,
-	})
-	if err != nil {
-		if holder, ok := deploylifecycle.HolderFrom(err); ok {
-			d.reportLockBlocked(ctx, results, holder)
-			return nil
-		}
-		d.Log.Error("Failed to create deployment", "error", err)
-		return cond.Error("failed to create deployment")
-	}
-
-	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
-	versionShortIDs := d.resolveShortIDs(ctx, []string{rec.Deployment.AppVersion})
-	enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
-	results.SetDeployment(deploymentInfo)
-
-	d.Log.Info("Created deployment",
-		"deployment_id", rec.Deployment.ID,
-		"app", appName,
-		"cluster", clusterId)
-
-	return nil
+func (*DeploymentServer) CreateDeployment(_ context.Context, _ *deployment_v1alpha.DeploymentCreateDeployment) error {
+	return cond.ValidationFailure("client-upgrade-required",
+		"this server requires a newer miren client; run 'miren upgrade' and try again")
 }
 
 func (d *DeploymentServer) UpdateDeploymentStatus(ctx context.Context, req *deployment_v1alpha.DeploymentUpdateDeploymentStatus) error {
@@ -1174,29 +1095,6 @@ func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName,
 		deployments = append(deployments, deploymentWithEntity{deployment: rec.Deployment, entity: rec.Entity})
 	}
 	return deployments, nil
-}
-
-// gitInfoFromRPC converts the deployment-service git shape into the core entity
-// shape stored on the record.
-func gitInfoFromRPC(gi *deployment_v1alpha.GitInfo) core_v1alpha.GitInfo {
-	if gi == nil {
-		return core_v1alpha.GitInfo{}
-	}
-
-	info := core_v1alpha.GitInfo{
-		Sha:               gi.Sha(),
-		Branch:            gi.Branch(),
-		Message:           gi.CommitMessage(),
-		Author:            gi.CommitAuthorName(),
-		IsDirty:           gi.IsDirty(),
-		WorkingTreeHash:   gi.WorkingTreeHash(),
-		CommitAuthorEmail: gi.CommitAuthorEmail(),
-		Repository:        gi.Repository(),
-	}
-	if gi.HasCommitTimestamp() && gi.CommitTimestamp() != nil {
-		info.CommitTimestamp = standard.FromTimestamp(gi.CommitTimestamp()).Format(time.RFC3339)
-	}
-	return info
 }
 
 func (d *DeploymentServer) toDeploymentInfo(deployment *core_v1alpha.Deployment) *deployment_v1alpha.DeploymentInfo {

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -2,8 +2,8 @@ package deployment
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,106 +29,25 @@ func newTestDeploymentServer(t *testing.T, logger *slog.Logger, inmem *testutils
 	return NewDeploymentServer(logger, inmem.EAC, ec, ac, "", nil)
 }
 
-func TestCreateDeploymentWithGitInfo(t *testing.T) {
+func TestCreateDeploymentRequiresClientUpgrade(t *testing.T) {
 	ctx := context.Background()
-
-	// Setup in-memory entity server
 	inmem, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	// Create deployment server
-	logger := slog.Default()
-	server, err := newTestDeploymentServer(t, logger, inmem)
+	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
 	if err != nil {
-		t.Fatalf("Failed to create deployment server: %v", err)
+		t.Fatalf("create deployment server: %v", err)
 	}
-
-	// Create RPC client
 	client := &deployment_v1alpha.DeploymentClient{
 		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
 	}
 
-	tests := []struct {
-		name          string
-		gitInfo       *deployment_v1alpha.GitInfo
-		expectedDirty bool
-		expectedHash  string
-	}{
-		{
-			name: "clean git state",
-			gitInfo: func() *deployment_v1alpha.GitInfo {
-				gi := &deployment_v1alpha.GitInfo{}
-				gi.SetSha("e0bdb661891c2e4f5e7e6c5c5d5c5d5c5d5c5d5c")
-				gi.SetBranch("main")
-				gi.SetIsDirty(false)
-				gi.SetCommitMessage("Initial commit")
-				gi.SetCommitAuthorName("Test User")
-				return gi
-			}(),
-			expectedDirty: false,
-			expectedHash:  "",
-		},
-		{
-			name: "dirty git state",
-			gitInfo: func() *deployment_v1alpha.GitInfo {
-				gi := &deployment_v1alpha.GitInfo{}
-				gi.SetSha("e0bdb661891c2e4f5e7e6c5c5d5c5d5c5d5c5d5c")
-				gi.SetBranch("feature-branch")
-				gi.SetIsDirty(true)
-				gi.SetWorkingTreeHash("abc12345")
-				gi.SetCommitMessage("Work in progress")
-				gi.SetCommitAuthorName("Test User")
-				return gi
-			}(),
-			expectedDirty: true,
-			expectedHash:  "abc12345",
-		},
-		{
-			name:          "no git info",
-			gitInfo:       nil,
-			expectedDirty: false,
-			expectedHash:  "",
-		},
+	_, err = client.CreateDeployment(ctx, "test-app", "test-cluster", "pending-build", nil)
+	if err == nil {
+		t.Fatal("expected CreateDeployment to require a client upgrade")
 	}
-
-	for i, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create deployment with unique app name to avoid deployment lock conflicts
-			appName := fmt.Sprintf("test-app-%d", i)
-			results, err := client.CreateDeployment(ctx, appName, "test-cluster", "v1.0.0", tt.gitInfo)
-			if err != nil {
-				t.Fatalf("CreateDeployment failed: %v", err)
-			}
-
-			// Verify the deployment was created with correct git info
-			if !results.HasDeployment() {
-				t.Fatal("Expected deployment in results")
-			}
-
-			deploymentInfo := results.Deployment()
-
-			if tt.gitInfo == nil {
-				if deploymentInfo.HasGitInfo() {
-					t.Error("Expected no git info, but got some")
-				}
-			} else {
-				if !deploymentInfo.HasGitInfo() {
-					t.Fatal("Expected git info, but got none")
-				}
-
-				gitInfo := deploymentInfo.GitInfo()
-
-				// Check IsDirty flag
-				if gitInfo.IsDirty() != tt.expectedDirty {
-					t.Errorf("Expected IsDirty = %v, got %v", tt.expectedDirty, gitInfo.IsDirty())
-				}
-
-				// Check WorkingTreeHash
-				if gitInfo.WorkingTreeHash() != tt.expectedHash {
-					t.Errorf("Expected WorkingTreeHash = %s, got %s", tt.expectedHash, gitInfo.WorkingTreeHash())
-				}
-			}
-		})
+	if !strings.Contains(err.Error(), "run 'miren upgrade'") {
+		t.Fatalf("expected actionable upgrade error, got %v", err)
 	}
 }
 
@@ -237,70 +156,6 @@ func TestToDeploymentInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			info := server.toDeploymentInfo(tt.deployment)
 			tt.checkFunc(t, info)
-		})
-	}
-}
-
-func TestCreateDeploymentErrorCases(t *testing.T) {
-	ctx := context.Background()
-
-	// Setup in-memory entity server
-	inmem, cleanup := testutils.NewInMemEntityServer(t)
-	defer cleanup()
-
-	// Create deployment server
-	logger := slog.Default()
-	server, err := newTestDeploymentServer(t, logger, inmem)
-	if err != nil {
-		t.Fatalf("Failed to create deployment server: %v", err)
-	}
-
-	// Create RPC client
-	client := &deployment_v1alpha.DeploymentClient{
-		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
-	}
-
-	tests := []struct {
-		name          string
-		appName       string
-		clusterId     string
-		appVersionId  string
-		expectedError string
-	}{
-		{
-			name:          "missing app name",
-			appName:       "",
-			clusterId:     "test-cluster",
-			appVersionId:  "v1.0.0",
-			expectedError: "app_name is required",
-		},
-		{
-			name:          "missing cluster id",
-			appName:       "test-app",
-			clusterId:     "",
-			appVersionId:  "v1.0.0",
-			expectedError: "cluster_id is required",
-		},
-		{
-			name:          "missing app version id",
-			appName:       "test-app",
-			clusterId:     "test-cluster",
-			appVersionId:  "",
-			expectedError: "app_version_id is required",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.CreateDeployment(ctx, tt.appName, tt.clusterId, tt.appVersionId, nil)
-
-			if err == nil {
-				t.Fatal("Expected error but got none")
-			}
-
-			if !containsError(err.Error(), tt.expectedError) {
-				t.Errorf("Expected error containing '%s', got '%s'", tt.expectedError, err.Error())
-			}
 		})
 	}
 }
@@ -1250,15 +1105,13 @@ func TestDeployVersion(t *testing.T) {
 			t.Fatalf("Failed to create app version: %v", err)
 		}
 
-		// Establish a blocking in-progress deployment that actually holds the
-		// deploy lock, via the same path a real deploy uses. A bare in_progress
-		// record no longer blocks — the lock does.
-		blockRes, err := client.CreateDeployment(ctx, "locked-app", "cluster1", "pending-build", nil)
+		// Establish a blocking in-progress deployment through the server-owned
+		// lifecycle. A bare in_progress record no longer blocks; the lock does.
+		_, err = server.tracker.Begin(ctx, deploylifecycle.BeginParams{
+			AppName: "locked-app", ClusterID: "cluster1", Operation: deploylifecycle.OperationBuild,
+		})
 		if err != nil {
 			t.Fatalf("Failed to create blocking deployment: %v", err)
-		}
-		if blockRes.HasError() && blockRes.Error() != "" {
-			t.Fatalf("Blocking deployment unexpectedly failed: %s", blockRes.Error())
 		}
 
 		// Try to deploy — should be blocked

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -12,6 +12,7 @@ import (
 	deployment_v1alpha "miren.dev/runtime/api/deployment/deployment_v1alpha"
 	aes "miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
@@ -19,7 +20,7 @@ import (
 )
 
 // newTestDeploymentServer creates a DeploymentServer with test dependencies.
-// The returned appClient uses the same in-memory entity store for SetActiveVersion calls.
+// The app client and lifecycle tracker share the same in-memory entity store.
 func newTestDeploymentServer(t *testing.T, logger *slog.Logger, inmem *testutils.InMemEntityServer) (*DeploymentServer, error) {
 	t.Helper()
 	localClient := rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(inmem.Server))
@@ -877,13 +878,26 @@ func TestUpdateDeploymentStatusToInProgress(t *testing.T) {
 		t.Fatalf("Failed to create deployment server: %v", err)
 	}
 
-	// First create a deployment directly in entity store for testing
+	appID, err := inmem.Client.Create(ctx, "test-app", &core_v1alpha.App{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	versionID, err := inmem.Client.Create(ctx, "test-app-v1", &core_v1alpha.AppVersion{App: appID, Version: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First create a deployment directly in entity store for testing.
 	testDeployment := &core_v1alpha.Deployment{
+		App:        appID,
+		Version:    versionID,
+		Operation:  string(deploylifecycle.OperationBuild),
+		Phase:      string(deploylifecycle.PhasePreparing),
+		StartedAt:  time.Now(),
 		AppName:    "test-app",
 		ClusterId:  "test-cluster",
 		AppVersion: "v1.0.0",
 		Status:     "in_progress",
-		Phase:      "preparing",
 		DeployedBy: core_v1alpha.DeployedBy{
 			UserId:    "test-user",
 			UserEmail: "test@example.com",
@@ -898,6 +912,10 @@ func TestUpdateDeploymentStatusToInProgress(t *testing.T) {
 		t.Fatalf("Failed to create test deployment: %v", err)
 	}
 	testDeployment.ID = deploymentId
+	_, err = server.tracker.Locks().Acquire(ctx, "test-app", string(deploymentId))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Create RPC client
 	client := &deployment_v1alpha.DeploymentClient{
@@ -921,7 +939,7 @@ func TestUpdateDeploymentStatusToInProgress(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error when updating completed deployment back to in_progress")
 	}
-	if !containsString(err.Error(), "cannot update deployment in active state") {
+	if !containsString(err.Error(), "cannot transition deployment from succeeded to") {
 		t.Errorf("Unexpected error message: %v", err)
 	}
 


### PR DESCRIPTION
Deployment records currently mix an attempt's history with the app's serving state. A successful attempt is later rewritten when another deployment activates, rollback mutates old history, and several writers can bypass the same lifecycle invariants.

This makes each deployment one canonical attempt. Operation, provenance, initiator, phase, and terminal outcome live on the attempt; `active_version` and `active_deployment` say what the app currently serves. Build, redeploy, rollback, and config changes now pass through one tracker. It reserves the deployment ID that will own the lock, acquires the expiring App-owned lock, then publishes the attempt. Activation reads that same App revision and uses it as its CAS boundary.

A gentle controller migrates legacy records in bounded, restart-safe passes and continuously reconciles abandoned attempts and the activation settlement crash window. Canonical-first reads plus legacy dual writes preserve the downgrade window. Canonical attempts reuse `completed_at` and record lineage through `parent_deployment`. Embedded build logs are removed from entities and retained failure summaries are bounded.

The controller participates in the typed boot graph as a side-effect component. It starts after the coordinator opens its entity store and launches its background loop without holding `Runtime.Start` or unrelated services open.

Builds on #1100.

Refs MIR-1645
