### PR TITLE
Default web ports from image EXPOSE

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -804,6 +805,9 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.ConfigSpec {
 	}
 
 	spec.Services = buildServicesConfig(ac, procfileServices, res != nil, webDefault)
+	if res != nil {
+		defaultServicePortFromImage(&spec, res.ExposedPorts)
+	}
 	spec.Tasks = buildTasksConfig(ac, inputs.Log)
 
 	// Merge env vars: preserve manual vars from existing services
@@ -828,6 +832,42 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.ConfigSpec {
 	spec.Variables = mergeCliEnvVars(spec.Variables, inputs.CliEnvVars)
 
 	return spec
+}
+
+// defaultServicePortFromImage folds a single TCP EXPOSE declaration into the
+// resolved web service config. Persisting the resolved scalar port means every
+// launcher path gets the same container port and PORT value without needing to
+// carry transient build metadata any further.
+func defaultServicePortFromImage(spec *core_v1alpha.ConfigSpec, exposedPorts []string) {
+	port, ok := singleExposedTCPPort(exposedPorts)
+	if !ok {
+		return
+	}
+
+	for i := range spec.Services {
+		svc := &spec.Services[i]
+		if svc.Name != "web" || svc.Image != "" || svc.Port != 0 || len(svc.Ports) != 0 {
+			continue
+		}
+		svc.Port = port
+	}
+}
+
+func singleExposedTCPPort(exposedPorts []string) (int64, bool) {
+	if len(exposedPorts) != 1 {
+		return 0, false
+	}
+
+	portText, protocol, hasProtocol := strings.Cut(exposedPorts[0], "/")
+	if hasProtocol && !strings.EqualFold(protocol, "tcp") {
+		return 0, false
+	}
+
+	port, err := strconv.ParseInt(portText, 10, 64)
+	if err != nil || port < 1 || port > 65535 {
+		return 0, false
+	}
+	return port, true
 }
 
 func buildVariablesFromAppConfig(appConfig *appconfig.AppConfig) []core_v1alpha.ConfigSpecVariables {

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
@@ -1523,22 +1522,92 @@ func TestBuildVersionConfig(t *testing.T) {
 	}
 }
 
-func TestExtractWorkingDirFromImageConfig(t *testing.T) {
+func TestBuildVersionConfigDefaultsWebPortFromImage(t *testing.T) {
+	tests := []struct {
+		name         string
+		exposedPorts []string
+		service      *appconfig.ServiceConfig
+		wantPort     int64
+		wantPorts    int
+	}{
+		{
+			name:         "single TCP port",
+			exposedPorts: []string{"4000/tcp"},
+			wantPort:     4000,
+		},
+		{
+			name:         "bare port defaults to TCP",
+			exposedPorts: []string{"2368"},
+			wantPort:     2368,
+		},
+		{
+			name:         "explicit scalar port wins",
+			exposedPorts: []string{"4000/tcp"},
+			service:      &appconfig.ServiceConfig{Port: 8080},
+			wantPort:     8080,
+		},
+		{
+			name:         "explicit port list wins",
+			exposedPorts: []string{"4000/tcp"},
+			service: &appconfig.ServiceConfig{Ports: []appconfig.PortConfig{
+				{Port: 8080, Name: "http", Type: "http"},
+			}},
+			wantPorts: 1,
+		},
+		{
+			name:         "multiple exposed ports are ambiguous",
+			exposedPorts: []string{"4000/tcp", "4001/tcp"},
+		},
+		{
+			name:         "UDP port is not an HTTP default",
+			exposedPorts: []string{"5353/udp"},
+		},
+		{
+			name:         "custom service image does not inherit app image metadata",
+			exposedPorts: []string{"4000/tcp"},
+			service:      &appconfig.ServiceConfig{Image: "example.com/custom:latest"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ac *appconfig.AppConfig
+			if tt.service != nil {
+				ac = &appconfig.AppConfig{Services: map[string]*appconfig.ServiceConfig{"web": tt.service}}
+			}
+
+			spec := buildVersionConfig(ConfigInputs{
+				BuildResult: &BuildResult{ExposedPorts: tt.exposedPorts},
+				AppConfig:   ac,
+			})
+
+			require.Len(t, spec.Services, 1)
+			assert.Equal(t, "web", spec.Services[0].Name)
+			assert.Equal(t, tt.wantPort, spec.Services[0].Port)
+			assert.Len(t, spec.Services[0].Ports, tt.wantPorts)
+		})
+	}
+}
+
+func TestApplyImageConfig(t *testing.T) {
 	tests := []struct {
 		name       string
 		configJSON string
 		wantDir    string
+		wantPorts  []string
 	}{
 		{
 			name: "standard Dockerfile with WORKDIR /app",
 			configJSON: `{
 				"config": {
 					"WorkingDir": "/app",
+					"ExposedPorts": {"8080/tcp": {}, "4000/tcp": {}},
 					"Env": ["PATH=/usr/local/bin:/usr/bin:/bin"],
 					"Cmd": ["node", "server.js"]
 				}
 			}`,
-			wantDir: "/app",
+			wantDir:   "/app",
+			wantPorts: []string{"4000/tcp", "8080/tcp"},
 		},
 		{
 			name: "custom working directory",
@@ -1593,15 +1662,11 @@ func TestExtractWorkingDirFromImageConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// This mimics the parsing logic used in BuildImage for Dockerfile builds
-			var imgConfig struct {
-				Config struct {
-					WorkingDir string `json:"WorkingDir"`
-				} `json:"config"`
-			}
-			err := json.Unmarshal([]byte(tt.configJSON), &imgConfig)
+			var res BuildResult
+			err := applyImageConfig(&res, []byte(tt.configJSON))
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantDir, imgConfig.Config.WorkingDir)
+			assert.Equal(t, tt.wantDir, res.WorkingDir)
+			assert.Equal(t, tt.wantPorts, res.ExposedPorts)
 		})
 	}
 }

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 
@@ -321,7 +322,37 @@ type BuildResult struct {
 	Command         string // The command (from image CMD)
 	ManifestDigest  string
 	WorkingDir      string
+	ExposedPorts    []string // OCI port/protocol keys, such as "4000/tcp"
 	DetectionEvents []stackbuild.DetectionEvent
+}
+
+func exposedPortNames(ports map[string]struct{}) []string {
+	if len(ports) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(ports))
+	for port := range ports {
+		names = append(names, port)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func applyImageConfig(res *BuildResult, data []byte) error {
+	var imgConfig struct {
+		Config struct {
+			WorkingDir   string              `json:"WorkingDir"`
+			ExposedPorts map[string]struct{} `json:"ExposedPorts"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(data, &imgConfig); err != nil {
+		return err
+	}
+
+	res.WorkingDir = imgConfig.Config.WorkingDir
+	res.ExposedPorts = exposedPortNames(imgConfig.Config.ExposedPorts)
+	return nil
 }
 
 func (b *Buildkit) BuildImage(
@@ -396,6 +427,7 @@ func (b *Buildkit) BuildImage(
 		}
 
 		res.WorkingDir = stack.Image().Config.WorkingDir
+		res.ExposedPorts = exposedPortNames(stack.Image().Config.ExposedPorts)
 
 		def, err = state.Marshal(ctx)
 		if err != nil {
@@ -549,18 +581,11 @@ func (b *Buildkit) BuildImage(
 			res.ManifestDigest = digest
 		}
 
-		// Extract working directory, entrypoint, and command from the image config
-		// for Dockerfile builds. The config comes from the gateway result metadata
+		// Extract working directory and exposed ports from the image config for
+		// Dockerfile builds. The config comes from the gateway result metadata
 		// captured during the solve above.
 		if len(inlineImageConfig) > 0 {
-			var imgConfig struct {
-				Config struct {
-					WorkingDir string `json:"WorkingDir"`
-				} `json:"config"`
-			}
-			if err := json.Unmarshal(inlineImageConfig, &imgConfig); err == nil {
-				res.WorkingDir = imgConfig.Config.WorkingDir
-			} else {
+			if err := applyImageConfig(&res, inlineImageConfig); err != nil {
 				b.Log.Warn("failed to parse image config", "error", err)
 			}
 			// We intentionally do not flatten the image's ENTRYPOINT/CMD into a

--- a/servers/build/buildkit_test.go
+++ b/servers/build/buildkit_test.go
@@ -317,6 +317,7 @@ func TestBuildImageWorkingDir(t *testing.T) {
 	testDir := t.TempDir()
 	dockerfile := `FROM alpine:latest
 WORKDIR /custom/workdir
+EXPOSE 4000
 RUN echo "test" > /custom/workdir/test.txt
 `
 	err := os.WriteFile(filepath.Join(testDir, "Dockerfile.miren"), []byte(dockerfile), 0644)
@@ -346,6 +347,7 @@ RUN echo "test" > /custom/workdir/test.txt
 	// Verify the working directory was extracted
 	require.NotEmpty(t, res.ManifestDigest, "ManifestDigest should be set")
 	assert.Equal(t, "/custom/workdir", res.WorkingDir, "WorkingDir should match the WORKDIR in Dockerfile")
+	assert.Equal(t, []string{"4000/tcp"}, res.ExposedPorts, "ExposedPorts should match EXPOSE in Dockerfile")
 }
 
 func TestBuildImageWorkingDirRoot(t *testing.T) {


### PR DESCRIPTION
Images already advertise their listening port through `EXPOSE`, but Miren ignored it and always resolved an unspecified web port to 3000. Common upstream images therefore needed duplicate port config or waited for the alternative-port fallback.

Builds now carry OCI exposed-port metadata into the resolved service config. A single TCP declaration fills an otherwise unspecified web port, while explicit port config still wins and ambiguous declarations stay conservative. Persisting the result as the ordinary scalar port keeps routing, health checks, and `$PORT` on the same value.

A Docker-backed smoke deploy with `EXPOSE 4321` came up directly on 4321 and served through the default HTTPS route.

Closes MIR-1445