### PR TITLE
Point builds at miren's bridge DNS instead of public DNS

### DIFF
--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,6 +49,10 @@ type Config struct {
 
 	// RegistryHost is the hostname for the cluster-local registry (e.g., cluster.local:5000)
 	RegistryHost string
+
+	// DNSNameservers are the nameserver addresses build steps resolve against.
+	// See generateConfig for why we override buildkit's default here.
+	DNSNameservers []string
 }
 
 // Component manages a persistent BuildKit daemon as a containerd container,
@@ -145,7 +150,7 @@ func (c *Component) Start(ctx context.Context, config Config) error {
 	}
 
 	// Generate buildkitd.toml config
-	configContent := c.generateConfig(gcKeepStorage, gcKeepDuration, config.RegistryHost)
+	configContent := c.generateConfig(gcKeepStorage, gcKeepDuration, config.RegistryHost, config.DNSNameservers)
 	configPath := filepath.Join(dataPath, "buildkitd.toml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		return fmt.Errorf("failed to write buildkit config: %w", err)
@@ -310,9 +315,25 @@ func (c *Component) Client(ctx context.Context) (*buildkitclient.Client, error) 
 //     least-recently-used first. This is what breaks the pinning above, since
 //     removing a fresh leaf frees the ancestors under it.
 //  4. Last resort: sweep internal and frontend cache too, to hold the line.
-func (c *Component) generateConfig(gcKeepStorage, gcKeepDuration int64, registryHost string) string {
+//
+// The [dns] section points buildkit at miren's bridge DNS server. Without it,
+// buildkit strips the host's loopback stub resolver (e.g. systemd-resolved's
+// 127.0.0.53) from build steps and falls back to public DNS, breaking builds
+// behind an internal or egress-filtered resolver (MIR-1643). The bridge address
+// is reachable from the host netns and forwards to the host's real upstream.
+// With no nameserver supplied we emit no [dns] section.
+func (c *Component) generateConfig(gcKeepStorage, gcKeepDuration int64, registryHost string, dnsNameservers []string) string {
 	if registryHost == "" {
 		registryHost = "cluster.local:5000"
+	}
+
+	dnsSection := ""
+	if len(dnsNameservers) > 0 {
+		quoted := make([]string, len(dnsNameservers))
+		for i, ns := range dnsNameservers {
+			quoted[i] = fmt.Sprintf("%q", ns)
+		}
+		dnsSection = fmt.Sprintf("\n[dns]\n  nameservers = [ %s ]\n", strings.Join(quoted, ", "))
 	}
 
 	return fmt.Sprintf(`# BuildKit daemon configuration
@@ -322,7 +343,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 
 [log]
   format = "text"
-
+%[4]s
 [grpc]
   address = [ "unix:///run/buildkit/buildkitd.sock" ]
   uid = 0
@@ -360,7 +381,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 [registry."%[3]s"]
   insecure = true
   http = true
-`, gcKeepStorage, gcKeepDuration, registryHost)
+`, gcKeepStorage, gcKeepDuration, registryHost, dnsSection)
 }
 
 // writeHostsFile creates or updates the custom /etc/hosts file for the BuildKit container.

--- a/components/buildkit/config_test.go
+++ b/components/buildkit/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGenerateConfig(t *testing.T) {
 	c := &Component{}
-	config := c.generateConfig(10*1024*1024*1024, 86400, "registry.example.com:5000")
+	config := c.generateConfig(10*1024*1024*1024, 86400, "registry.example.com:5000", nil)
 
 	// gcPolicyBlocks splits the config into its individual gcpolicy bodies
 	// (text from one "[[worker.oci.gcpolicy]]" header to the next section).
@@ -83,17 +83,36 @@ func TestGenerateConfig(t *testing.T) {
 
 	t.Run("uses default registry host when empty", func(t *testing.T) {
 		r := require.New(t)
-		defaultConfig := c.generateConfig(10*1024*1024*1024, 86400, "")
+		defaultConfig := c.generateConfig(10*1024*1024*1024, 86400, "", nil)
 		r.Contains(defaultConfig, `[registry."cluster.local:5000"]`)
 	})
 
-	t.Run("does not hardcode DNS nameservers", func(t *testing.T) {
+	t.Run("omits the dns section when no nameservers are supplied", func(t *testing.T) {
 		r := require.New(t)
-		// MIR-1643: DNS is delegated to buildkitd, which derives each build's
-		// resolv.conf from the host. A hardcoded nameserver directive would
-		// override that and break builds on hosts with an internal resolver.
-		r.NotContains(config, "nameservers=")
+		// With no nameserver we leave buildkit's default resolv.conf handling in
+		// place rather than hardcoding public DNS.
+		r.NotContains(config, "[dns]")
+		r.NotContains(config, "nameservers")
 		r.NotContains(config, "1.1.1.1")
 		r.NotContains(config, "8.8.8.8")
+	})
+
+	t.Run("emits a dns section pointing at the supplied nameservers", func(t *testing.T) {
+		r := require.New(t)
+		// MIR-1643: build RUN steps run in the host netns, but buildkit strips
+		// the host's loopback stub resolver (e.g. 127.0.0.53) and substitutes
+		// public DNS, which breaks builds behind an internal/egress-filtered
+		// resolver. We override that by pointing builds at miren's bridge DNS.
+		withDNS := c.generateConfig(10*1024*1024*1024, 86400, "", []string{"10.8.13.1"})
+		r.Contains(withDNS, "[dns]")
+		r.Contains(withDNS, `nameservers = [ "10.8.13.1" ]`)
+		// It must not fall back to public DNS.
+		r.NotContains(withDNS, "8.8.8.8")
+	})
+
+	t.Run("quotes multiple nameservers as a toml array", func(t *testing.T) {
+		r := require.New(t)
+		withDNS := c.generateConfig(10*1024*1024*1024, 86400, "", []string{"10.8.13.1", "fd47:ace::1"})
+		r.Contains(withDNS, `nameservers = [ "10.8.13.1", "fd47:ace::1" ]`)
 	})
 }

--- a/components/server/boot_buildkit.go
+++ b/components/server/boot_buildkit.go
@@ -34,12 +34,12 @@ func buildkitInputs(options StartOptions) buildkitBootInputs {
 	return buildkitBootInputs{config: options.Config.Buildkit, dataPath: options.Config.Server.GetDataPath()}
 }
 
-func newBuildkitBoot(inputs buildkitBootInputs, containerd boot.Output[containerdBootOutput], registryHostMapping boot.Output[registryHostMappingBootOutput], observability boot.Output[observabilityBootOutput]) *buildkitBoot {
+func newBuildkitBoot(inputs buildkitBootInputs, containerd boot.Output[containerdBootOutput], registryHostMapping boot.Output[registryHostMappingBootOutput], network boot.Output[networkBootOutput], observability boot.Output[observabilityBootOutput]) *buildkitBoot {
 	b := &buildkitBoot{inputs: inputs}
 	stop := boot.WithStop(b.stop, componentStopTimeout)
 	switch {
 	case inputs.config.GetStartEmbedded():
-		b.component, b.output = boot.Provide3("buildkit", containerd, registryHostMapping, observability, b.startEmbedded, stop)
+		b.component, b.output = boot.Provide4("buildkit", containerd, registryHostMapping, network, observability, b.startEmbedded, stop)
 	case inputs.config.GetSocketPath() != "":
 		b.component, b.output = boot.Provide1("buildkit", observability, b.start, stop)
 	default:
@@ -64,7 +64,7 @@ func (b *buildkitBoot) startDisabled(context.Context) (buildkitBootOutput, error
 	return buildkitBootOutput{}, nil
 }
 
-func (b *buildkitBoot) startEmbedded(ctx context.Context, containerd containerdBootOutput, hostMapping registryHostMappingBootOutput, observability observabilityBootOutput) (buildkitBootOutput, error) {
+func (b *buildkitBoot) startEmbedded(ctx context.Context, containerd containerdBootOutput, hostMapping registryHostMappingBootOutput, network networkBootOutput, observability observabilityBootOutput) (buildkitBootOutput, error) {
 	b.observability = observability
 	log := observability.log
 	log.Info("starting embedded buildkit daemon", "socket-dir", b.inputs.config.GetSocketDir())
@@ -83,12 +83,20 @@ func (b *buildkitBoot) startEmbedded(ctx context.Context, containerd containerdB
 	if socketDir == "" {
 		socketDir = filepath.Join(b.inputs.dataPath, "buildkit", "socket")
 	}
+	// Point build steps at miren's bridge DNS server so they resolve against the
+	// host's real upstream (and *.app.miren) instead of the public DNS buildkit
+	// would otherwise substitute for the host's loopback stub resolver.
+	var dnsNameservers []string
+	if network.routerAddress.IsValid() {
+		dnsNameservers = []string{network.routerAddress.String()}
+	}
 	if err := b.result.component.Start(ctx, buildkit.Config{
 		SocketDir:      socketDir,
 		RegistryIP:     hostMapping.registryIP.String(),
 		GCKeepStorage:  int64(gcStorage.Bytes()),
 		GCKeepDuration: int64(gcDuration.Seconds()),
 		RegistryHost:   ocireg.Host,
+		DNSNameservers: dnsNameservers,
 	}); err != nil {
 		return buildkitBootOutput{}, err
 	}

--- a/components/server/startup.go
+++ b/components/server/startup.go
@@ -73,7 +73,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 	etcd := newEtcdBoot(etcdInputs(options), ipDiscovery.output, containerd.output, observability.output)
 	network := newNetworkBoot(networkInputs(options), etcd.output, observability.output)
 	registryHostMapping := newRegistryHostMappingBoot(registryHostMappingInputs(hostMapper), network.output)
-	buildkit := newBuildkitBoot(buildkitInputs(options), containerd.output, registryHostMapping.output, observability.output)
+	buildkit := newBuildkitBoot(buildkitInputs(options), containerd.output, registryHostMapping.output, network.output, observability.output)
 	coordinator := newCoordinatorBoot(
 		coordinatorInputs(options, resolver, secretRegistry, address),
 		ipDiscovery.output,


### PR DESCRIPTION
## Problem

Container image builds silently resolve DNS against public servers (`8.8.8.8` / `8.8.4.4`) instead of the host's configured resolver. On a host that uses a systemd-resolved stub — `nameserver 127.0.0.53` in `/etc/resolv.conf` — with an internal-only or egress-filtered upstream, builds can't resolve names at all. Reported by a user whose build environment couldn't do DNS.

## Root cause

Build `RUN` steps run in the host network namespace (with no CNI config, buildkit's "auto" mode falls back to host networking), but buildkit generates each build's resolv.conf as if it were sandboxed. The step's `NetMode` is `UNSET`, not `HOST`, so `GetResolvConf` strips every loopback nameserver (the whole `127.0.0.0/8` range, `127.0.0.53` included) and, finding none left, substitutes `8.8.8.8`/`8.8.4.4`. It can't recover the real upstream either, since `/run/systemd/resolve/resolv.conf` isn't mounted into buildkitd — only the host's `/etc/resolv.conf` is, via `oci.WithHostResolvconf`.

So even though the build sits in the very netns where `127.0.0.53` would resolve, buildkit discards it and hardcodes public DNS — the "breaks builds on hosts with an internal resolver" case the earlier MIR-1643 note meant to avoid.

## Fix

Add a `[dns]` section to the generated `buildkitd.toml` pointing at miren's own bridge DNS server, wired in from the network boot node's router address. That resolver already serves runtime sandboxes: it forwards to the host's real upstream and answers `*.app.miren`. The bridge gateway is a local interface in the host netns, so build steps reach it, and buildkit keeps it (not a loopback, so the filter leaves it alone). External buildkit daemons are untouched.

## Verification

- Unit tests (`TestGenerateConfig`) and server boot/startup tests pass; `golangci-lint run ./...` reports 0 issues.
- End to end in the dev env — rebuilt, restarted, ran a real Dockerfile build:
  - Before: `RUN cat /etc/resolv.conf` → `nameserver 8.8.8.8`
  - After: `nameserver 10.8.13.1`, and `nslookup example.com` resolves through it (`exit=0`)

Fixes MIR-1695