### PR TITLE
Route embedded BuildKit DNS through interface

### DIFF
--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -48,6 +48,9 @@ type Config struct {
 
 	// RegistryHost is the hostname for the cluster-local registry (e.g., cluster.local:5000)
 	RegistryHost string
+
+	// DNSServer is the Miren interface DNS server used by build containers.
+	DNSServer string
 }
 
 // Component manages a persistent BuildKit daemon as a containerd container,
@@ -145,7 +148,7 @@ func (c *Component) Start(ctx context.Context, config Config) error {
 	}
 
 	// Generate buildkitd.toml config
-	configContent := c.generateConfig(gcKeepStorage, gcKeepDuration, config.RegistryHost)
+	configContent := c.generateConfig(gcKeepStorage, gcKeepDuration, config.RegistryHost, config.DNSServer)
 	configPath := filepath.Join(dataPath, "buildkitd.toml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		return fmt.Errorf("failed to write buildkit config: %w", err)
@@ -310,7 +313,7 @@ func (c *Component) Client(ctx context.Context) (*buildkitclient.Client, error) 
 //     least-recently-used first. This is what breaks the pinning above, since
 //     removing a fresh leaf frees the ancestors under it.
 //  4. Last resort: sweep internal and frontend cache too, to hold the line.
-func (c *Component) generateConfig(gcKeepStorage, gcKeepDuration int64, registryHost string) string {
+func (c *Component) generateConfig(gcKeepStorage, gcKeepDuration int64, registryHost, dnsServer string) string {
 	if registryHost == "" {
 		registryHost = "cluster.local:5000"
 	}
@@ -322,6 +325,9 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 
 [log]
   format = "text"
+
+[dns]
+  nameservers = [ "%[4]s" ]
 
 [grpc]
   address = [ "unix:///run/buildkit/buildkitd.sock" ]
@@ -360,7 +366,7 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 [registry."%[3]s"]
   insecure = true
   http = true
-`, gcKeepStorage, gcKeepDuration, registryHost)
+`, gcKeepStorage, gcKeepDuration, registryHost, dnsServer)
 }
 
 // writeHostsFile creates or updates the custom /etc/hosts file for the BuildKit container.

--- a/components/buildkit/config_test.go
+++ b/components/buildkit/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGenerateConfig(t *testing.T) {
 	c := &Component{}
-	config := c.generateConfig(10*1024*1024*1024, 86400, "registry.example.com:5000")
+	config := c.generateConfig(10*1024*1024*1024, 86400, "registry.example.com:5000", "10.8.0.1")
 
 	// gcPolicyBlocks splits the config into its individual gcpolicy bodies
 	// (text from one "[[worker.oci.gcpolicy]]" header to the next section).
@@ -83,16 +83,14 @@ func TestGenerateConfig(t *testing.T) {
 
 	t.Run("uses default registry host when empty", func(t *testing.T) {
 		r := require.New(t)
-		defaultConfig := c.generateConfig(10*1024*1024*1024, 86400, "")
+		defaultConfig := c.generateConfig(10*1024*1024*1024, 86400, "", "10.8.0.1")
 		r.Contains(defaultConfig, `[registry."cluster.local:5000"]`)
 	})
 
-	t.Run("does not hardcode DNS nameservers", func(t *testing.T) {
+	t.Run("uses the configured Miren interface DNS server", func(t *testing.T) {
 		r := require.New(t)
-		// MIR-1643: DNS is delegated to buildkitd, which derives each build's
-		// resolv.conf from the host. A hardcoded nameserver directive would
-		// override that and break builds on hosts with an internal resolver.
-		r.NotContains(config, "nameservers=")
+		r.Contains(config, "[dns]")
+		r.Contains(config, `nameservers = [ "10.8.0.1" ]`)
 		r.NotContains(config, "1.1.1.1")
 		r.NotContains(config, "8.8.8.8")
 	})

--- a/components/server/boot_buildkit.go
+++ b/components/server/boot_buildkit.go
@@ -34,12 +34,12 @@ func buildkitInputs(options StartOptions) buildkitBootInputs {
 	return buildkitBootInputs{config: options.Config.Buildkit, dataPath: options.Config.Server.GetDataPath()}
 }
 
-func newBuildkitBoot(inputs buildkitBootInputs, containerd boot.Output[containerdBootOutput], registryHostMapping boot.Output[registryHostMappingBootOutput], observability boot.Output[observabilityBootOutput]) *buildkitBoot {
+func newBuildkitBoot(inputs buildkitBootInputs, containerd boot.Output[containerdBootOutput], network boot.Output[networkBootOutput], registryHostMapping boot.Output[registryHostMappingBootOutput], observability boot.Output[observabilityBootOutput]) *buildkitBoot {
 	b := &buildkitBoot{inputs: inputs}
 	stop := boot.WithStop(b.stop, componentStopTimeout)
 	switch {
 	case inputs.config.GetStartEmbedded():
-		b.component, b.output = boot.Provide3("buildkit", containerd, registryHostMapping, observability, b.startEmbedded, stop)
+		b.component, b.output = boot.Provide4("buildkit", containerd, network, registryHostMapping, observability, b.startEmbedded, stop)
 	case inputs.config.GetSocketPath() != "":
 		b.component, b.output = boot.Provide1("buildkit", observability, b.start, stop)
 	default:
@@ -64,7 +64,7 @@ func (b *buildkitBoot) startDisabled(context.Context) (buildkitBootOutput, error
 	return buildkitBootOutput{}, nil
 }
 
-func (b *buildkitBoot) startEmbedded(ctx context.Context, containerd containerdBootOutput, hostMapping registryHostMappingBootOutput, observability observabilityBootOutput) (buildkitBootOutput, error) {
+func (b *buildkitBoot) startEmbedded(ctx context.Context, containerd containerdBootOutput, network networkBootOutput, hostMapping registryHostMappingBootOutput, observability observabilityBootOutput) (buildkitBootOutput, error) {
 	b.observability = observability
 	log := observability.log
 	log.Info("starting embedded buildkit daemon", "socket-dir", b.inputs.config.GetSocketDir())
@@ -89,6 +89,7 @@ func (b *buildkitBoot) startEmbedded(ctx context.Context, containerd containerdB
 		GCKeepStorage:  int64(gcStorage.Bytes()),
 		GCKeepDuration: int64(gcDuration.Seconds()),
 		RegistryHost:   ocireg.Host,
+		DNSServer:      network.routerAddress.String(),
 	}); err != nil {
 		return buildkitBootOutput{}, err
 	}

--- a/components/server/startup.go
+++ b/components/server/startup.go
@@ -73,7 +73,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 	etcd := newEtcdBoot(etcdInputs(options), ipDiscovery.output, containerd.output, observability.output)
 	network := newNetworkBoot(networkInputs(options), etcd.output, observability.output)
 	registryHostMapping := newRegistryHostMappingBoot(registryHostMappingInputs(hostMapper), network.output)
-	buildkit := newBuildkitBoot(buildkitInputs(options), containerd.output, registryHostMapping.output, observability.output)
+	buildkit := newBuildkitBoot(buildkitInputs(options), containerd.output, network.output, registryHostMapping.output, observability.output)
 	coordinator := newCoordinatorBoot(
 		coordinatorInputs(options, resolver, secretRegistry, address),
 		ipDiscovery.output,


### PR DESCRIPTION
## Why this change

BuildKit currently derives each build container’s resolver list from the host. That bypasses the DNS server Miren already runs at the runner interface, so build-time lookups cannot use Miren’s sandbox and service-name resolution.

## Approach and choices

The embedded BuildKit boot now depends on the network boot output and passes its router address to BuildKit. That router address is the same address `SandboxController.Init` configures as the bridge DNS listener on port 53. BuildKit writes it as its sole `[dns]` nameserver, so every build container uses the Miren resolver.

The change is deliberately limited to the embedded daemon. An externally managed BuildKit daemon retains its existing resolver configuration because runtime does not own that process. The DNS address is derived from the active leased subnet instead of being a static address, which keeps it correct when a runner’s network lease changes.

## Review guide

- Confirm that the runner subnet router address is the right handoff for the DNS service.
- Check the additional boot-graph edge: BuildKit must wait until network setup has produced that address.
- Check that keeping external BuildKit untouched is the desired compatibility boundary.

## Validation

- `go test ./components/buildkit -run '^TestGenerateConfig$'`
- `go test ./components/server -run '^TestBuildkitWithoutConfiguredDaemonPublishesEmptyOutput$'`
- `go vet ./components/buildkit ./components/server`
- `make generate-check`
- `go test ./components/buildkit` was attempted, but its container-backed tests cannot access `/run/containerd/containerd.sock` in this sandbox (`permission denied`).
