### PR TITLE
Preserve deployment short IDs through lock reservation

### DIFF
--- a/pkg/deploylifecycle/legacy_lock.go
+++ b/pkg/deploylifecycle/legacy_lock.go
@@ -15,11 +15,12 @@ import (
 // older binary only checks deploy-lock/<app>. Writing both prevents an upgrade
 // or downgrade boundary from splitting mutual exclusion across two locations.
 const (
-	legacyLockKind         = entity.Id("dev.miren.core/deployment_lock")
-	legacyLockAppName      = entity.Id("dev.miren.core/deployment_lock.app_name")
-	legacyLockDeploymentID = entity.Id("dev.miren.core/deployment_lock.deployment_id")
-	legacyLockAcquiredAt   = entity.Id("dev.miren.core/deployment_lock.acquired_at")
-	legacyLockExpiresAt    = entity.Id("dev.miren.core/deployment_lock.expires_at")
+	legacyLockKind           = entity.Id("dev.miren.core/deployment_lock")
+	lockOwnerReservationKind = entity.Id("dev.miren.core/deployment_lock_owner_reservation")
+	legacyLockAppName        = entity.Id("dev.miren.core/deployment_lock.app_name")
+	legacyLockDeploymentID   = entity.Id("dev.miren.core/deployment_lock.deployment_id")
+	legacyLockAcquiredAt     = entity.Id("dev.miren.core/deployment_lock.acquired_at")
+	legacyLockExpiresAt      = entity.Id("dev.miren.core/deployment_lock.expires_at")
 )
 
 func init() {
@@ -29,6 +30,7 @@ func init() {
 	// the canonical API.
 	schema.Register("dev.miren.core.deployment-lock-compat", "v1alpha", func(sb *schema.SchemaBuilder) {
 		sb.Singleton(string(legacyLockKind))
+		sb.Singleton(string(lockOwnerReservationKind))
 		sb.String("app_name", string(legacyLockAppName), schema.Indexed)
 		sb.String("deployment_id", string(legacyLockDeploymentID))
 		sb.Time("acquired_at", string(legacyLockAcquiredAt))

--- a/pkg/deploylifecycle/store.go
+++ b/pkg/deploylifecycle/store.go
@@ -20,12 +20,16 @@ import (
 // they are normalized away on read rather than migrated.
 const pendingBuildSentinel = "pending-build"
 
-// lockReservationStatus is written on the otherwise anonymous entity that
+// lockReservationStatus is written on the private transition entity that
 // reserves a deployment ID for the lock owner. It is deliberately not a
 // public lifecycle status: an older runtime only needs to see a non-terminal
-// record while the compatibility lock points at the ID. Omitting entity/kind
-// and app_name keeps the reservation out of deployment history and migration.
+// record while the compatibility lock points at the ID.
 const lockReservationStatus = "_locking"
+
+type lockOwnerReservation struct {
+	revision int64
+	shortID  string
+}
 
 // Record is a deployment entity together with what a caller needs to write it
 // back: the revision it was read at, and the raw entity for short-id rendering.
@@ -257,31 +261,53 @@ func (s *Store) Create(ctx context.Context, dep *core_v1alpha.Deployment) (*Reco
 	return s.Get(ctx, string(dep.ID))
 }
 
-// ReserveLockOwner creates an anonymous placeholder for a deployment ID before
-// lock acquisition. During a rolling upgrade, an older runtime treats a legacy
-// lock whose deployment record is missing as abandoned and steals it. The
-// placeholder closes that publication window without making an unsuccessful
-// lock attempt appear in deployment history.
-func (s *Store) ReserveLockOwner(ctx context.Context, deploymentID entity.Id) (int64, error) {
+// ReserveLockOwner creates a private transition entity for a deployment ID
+// before lock acquisition. During a rolling upgrade, an older runtime treats a
+// legacy lock whose deployment record is missing as abandoned and steals it.
+// The transition entity closes that publication window without making an
+// unsuccessful lock attempt appear in deployment history.
+func (s *Store) ReserveLockOwner(ctx context.Context, deploymentID entity.Id) (*lockOwnerReservation, error) {
 	attrs := []entity.Attr{
 		entity.Ref(entity.DBId, deploymentID),
+		entity.Ref(entity.EntityKind, lockOwnerReservationKind),
 		entity.String(core_v1alpha.DeploymentStatusId, string(lockReservationStatus)),
 	}
 	res, err := s.eac.Ensure(ctx, attrs)
 	if err != nil {
-		return 0, fmt.Errorf("failed to reserve deployment lock owner: %w", err)
+		return nil, fmt.Errorf("failed to reserve deployment lock owner: %w", err)
 	}
 	if !res.Created() {
-		return 0, cond.Conflict("deployment-id", string(deploymentID))
+		return nil, cond.Conflict("deployment-id", string(deploymentID))
 	}
-	return res.Revision(), nil
+
+	rec, err := s.Get(ctx, string(deploymentID))
+	if err != nil {
+		s.discardLockOwnerReservation(ctx, deploymentID, "read-back failed")
+		return nil, fmt.Errorf("failed to read deployment lock owner reservation: %w", err)
+	}
+	shortID := rec.Entity.Entity().ShortId()
+	if shortID == "" {
+		s.discardLockOwnerReservation(ctx, deploymentID, "short id missing")
+		return nil, fmt.Errorf("deployment lock owner reservation has no short id")
+	}
+	return &lockOwnerReservation{revision: rec.Revision, shortID: shortID}, nil
+}
+
+func (s *Store) discardLockOwnerReservation(ctx context.Context, deploymentID entity.Id, reason string) {
+	if _, err := s.eac.Delete(ctx, string(deploymentID)); err != nil && !errors.Is(err, cond.ErrNotFound{}) {
+		s.log.Error("failed to discard deployment lock owner reservation",
+			"deployment_id", deploymentID, "reason", reason, "error", err)
+	}
 }
 
 // PublishLockOwner atomically replaces a lock-owner reservation with the full
 // deployment record after both the compatibility and canonical locks are held.
-func (s *Store) PublishLockOwner(ctx context.Context, dep *core_v1alpha.Deployment, revision int64) (*Record, error) {
-	attrs := append(dep.Encode(), entity.Ref(entity.DBId, dep.ID))
-	if _, err := s.eac.Replace(ctx, attrs, revision); err != nil {
+func (s *Store) PublishLockOwner(ctx context.Context, dep *core_v1alpha.Deployment, reservation *lockOwnerReservation) (*Record, error) {
+	attrs := append(dep.Encode(),
+		entity.Ref(entity.DBId, dep.ID),
+		entity.String(entity.DBShortId, reservation.shortID),
+	)
+	if _, err := s.eac.Replace(ctx, attrs, reservation.revision); err != nil {
 		return nil, fmt.Errorf("failed to publish deployment lock owner: %w", err)
 	}
 	return s.Get(ctx, string(dep.ID))

--- a/pkg/deploylifecycle/store_test.go
+++ b/pkg/deploylifecycle/store_test.go
@@ -11,10 +11,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/rpc"
 )
+
+type failingRPCMethodClient struct {
+	rpc.Client
+	method string
+	err    error
+}
+
+func (c *failingRPCMethodClient) Call(ctx context.Context, method string, args, result any) error {
+	if method == c.method {
+		return c.err
+	}
+	return c.Client.Call(ctx, method, args, result)
+}
 
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
@@ -208,9 +223,21 @@ func TestLockReservationIsPrivateUntilPublished(t *testing.T) {
 	s := newTestStore(t)
 	id := entity.Id("deployment/reserved")
 
-	revision, err := s.ReserveLockOwner(ctx, id)
+	reservation, err := s.ReserveLockOwner(ctx, id)
 	require.NoError(t, err)
-	assert.Positive(t, revision)
+	require.NotNil(t, reservation)
+	assert.Positive(t, reservation.revision)
+	assert.NotEmpty(t, reservation.shortID)
+
+	reserved, err := s.eac.Get(ctx, string(id))
+	require.NoError(t, err)
+	assert.True(t, entity.Is(reserved.Entity().Entity(), lockOwnerReservationKind))
+	assert.False(t, entity.Is(reserved.Entity().Entity(), core_v1alpha.KindDeployment))
+
+	resolved, err := s.eac.List(ctx, entity.String(entity.DBShortId, reservation.shortID))
+	require.NoError(t, err)
+	require.Len(t, resolved.Values(), 1)
+	assert.Equal(t, string(id), resolved.Values()[0].Id())
 
 	status, err := s.Status(ctx, string(id))
 	require.NoError(t, err)
@@ -229,14 +256,39 @@ func TestLockReservationIsPrivateUntilPublished(t *testing.T) {
 		StartedAt: time.Now(),
 		Status:    string(StatusInProgress),
 	}
-	rec, err := s.PublishLockOwner(ctx, dep, revision)
+	rec, err := s.PublishLockOwner(ctx, dep, reservation)
 	require.NoError(t, err)
 	assert.Equal(t, StatusInProgress, rec.Status())
+	assert.Equal(t, reservation.shortID, rec.Entity.Entity().ShortId())
+	assert.True(t, entity.Is(rec.Entity.Entity(), core_v1alpha.KindDeployment))
+	assert.False(t, entity.Is(rec.Entity.Entity(), lockOwnerReservationKind))
 
 	listed, err = s.List(ctx, Query{})
 	require.NoError(t, err)
 	require.Len(t, listed, 1)
 	assert.Equal(t, id, listed[0].Deployment.ID)
+}
+
+func TestLockReservationIsDiscardedWhenReadBackFails(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	readErr := errors.New("read failed")
+	eac := entityserver_v1alpha.NewEntityAccessClient(&failingRPCMethodClient{
+		Client: inmem.EAC.Client,
+		method: "get",
+		err:    readErr,
+	})
+	s := NewStore(testutils.TestLogger(t), eac)
+	id := entity.Id("deployment/failed-read-back")
+
+	_, err := s.ReserveLockOwner(ctx, id)
+	require.ErrorIs(t, err, readErr)
+
+	_, err = inmem.EAC.Get(ctx, string(id))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cond.ErrNotFound{})
 }
 
 // The Store satisfies the lock manager's StatusLookup without an adapter, which

--- a/pkg/deploylifecycle/tracker.go
+++ b/pkg/deploylifecycle/tracker.go
@@ -200,7 +200,7 @@ func (t *Tracker) Begin(ctx context.Context, params BeginParams) (*Record, error
 	}
 
 	deploymentID := string(dep.ID)
-	lockReservationRevision, err := t.store.ReserveLockOwner(ctx, dep.ID)
+	lockReservation, err := t.store.ReserveLockOwner(ctx, dep.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (t *Tracker) Begin(ctx context.Context, params BeginParams) (*Record, error
 		return nil, err
 	}
 
-	rec, err := t.store.PublishLockOwner(ctx, dep, lockReservationRevision)
+	rec, err := t.store.PublishLockOwner(ctx, dep, lockReservation)
 	if err != nil {
 		if releaseErr := t.locks.Release(ctx, params.AppName, deploymentID); releaseErr != nil {
 			t.log.Error("failed to release lock after deployment publication failed", "error", releaseErr)

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -360,6 +360,9 @@ func (m *MockStore) EnsureEntity(ctx context.Context, entity *Entity, opts ...En
 	}
 
 	// Create new entity
+	if err := m.ensureShortIdLocked(entity); err != nil {
+		return nil, false, err
+	}
 	entity.SetRevision(1)
 	entity.SetCreatedAt(m.Now())
 	entity.SetUpdatedAt(m.Now())

--- a/pkg/entity/store_conformance_test.go
+++ b/pkg/entity/store_conformance_test.go
@@ -314,6 +314,37 @@ func TestStoreConformance_EnsureEntity(t *testing.T) {
 	})
 }
 
+func TestStoreConformance_EnsureAndReplaceKindedEntityCarriesShortID(t *testing.T) {
+	runStoreConformance(t, func(t *testing.T, store Store) {
+		ctx := t.Context()
+		initialKind := Id("conf/kind.ensure-short-id")
+		replacementKind := Id("conf/kind.replace-short-id")
+		_, err := store.CreateEntity(ctx, New(Any(Ident, initialKind)))
+		require.NoError(t, err)
+		_, err = store.CreateEntity(ctx, New(Any(Ident, replacementKind)))
+		require.NoError(t, err)
+
+		ent, created, err := store.EnsureEntity(ctx, New(
+			Ref(DBId, Id("conf-ensure-short-id")),
+			Ref(EntityKind, initialKind),
+		))
+		require.NoError(t, err)
+		assert.True(t, created)
+		shortID := ent.ShortId()
+		require.NotEmpty(t, shortID)
+
+		replaced, err := store.ReplaceEntity(ctx, New(
+			Ref(DBId, ent.Id()),
+			Ref(EntityKind, replacementKind),
+			String(DBShortId, shortID),
+		), WithFromRevision(ent.GetRevision()))
+		require.NoError(t, err)
+		assert.Equal(t, shortID, replaced.ShortId())
+		assert.False(t, Is(replaced, initialKind))
+		assert.True(t, Is(replaced, replacementKind))
+	})
+}
+
 func TestStoreConformance_EnsureRequiresDBId(t *testing.T) {
 	runStoreConformance(t, func(t *testing.T, store Store) {
 		_, _, err := store.EnsureEntity(t.Context(), New(


### PR DESCRIPTION
Deployment lock admission briefly creates a private entity so downgraded runtimes can see that the prospective lock owner is alive. Because that reservation had no kind, it skipped the entity store's automatic short-ID allocation, and publishing it left the deployment without a usable short handle.

Model the reservation as its own private compatibility kind, then carry its allocated short ID into the deployment when the lock is published. The reservation still stays out of deployment history, and store conformance coverage now keeps Ensure behavior aligned between the mock and etcd implementations.

Closes MIR-1703