### PR TITLE
Resolve and inherit metadata from first-class images

### DIFF
--- a/blackbox/image_source_test.go
+++ b/blackbox/image_source_test.go
@@ -4,9 +4,14 @@ package blackbox
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/distribution/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -52,10 +57,82 @@ func TestDeployImageOnlyNoDockerfile(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(r.Stdout), &sandboxes))
 
 	for _, sb := range sandboxes {
-		if len(sb.Spec.Container) > 0 && sb.Spec.Container[0].Image == "docker.io/library/nginx:alpine" {
+		if len(sb.Spec.Container) > 0 && strings.HasPrefix(sb.Spec.Container[0].Image, "docker.io/library/nginx@sha256:") {
 			assert.Contains(t, sb.ID, name)
 			return
 		}
 	}
-	t.Fatal("no sandbox is running the direct nginx image")
+	t.Fatal("no sandbox is running the digest-pinned nginx image")
+}
+
+// TestDeployImageInheritsMetadata builds a fixture into Miren's own registry,
+// then deploys that tag as a first-class image. The second app must inherit the
+// image config while launching the exact manifest that supplied it.
+func TestDeployImageInheritsMetadata(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	sourceName := harness.DeployApp(t, m, harness.AppOptions{Testdata: "direct-image-metadata"})
+	_, sourceImage := sandboxForImageSource(t, m, sourceName)
+	require.NotContains(t, sourceImage, "@", "the source fixture should expose the mutable registry tag")
+
+	dir, err := os.MkdirTemp(c.RepoRoot, ".blackbox-direct-image-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".miren"), 0o755))
+	appConfig := fmt.Sprintf("name = \"direct-runtime\"\n\n[services.web]\nimage = %q\n", sourceImage)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".miren", "app.toml"), []byte(appConfig), 0o644))
+
+	name := harness.UniqueAppName(t, "direct-runtime")
+	t.Cleanup(func() {
+		if r := m.Run("app", "delete", name, "-f"); !r.Success() {
+			t.Errorf("failed to delete app %s during cleanup: %s", name, strings.TrimSpace(r.Stderr))
+		}
+	})
+	m.MustRun("deploy", "-a", name, "-d", m.ContainerPath(dir), "-f")
+	harness.WaitForAppReady(t, m, name, 2*time.Minute)
+
+	sandboxID, runtimeImage := sandboxForImageSource(t, m, name)
+	named, err := reference.ParseNormalizedNamed(sourceImage)
+	require.NoError(t, err)
+	repository := reference.TrimNamed(named).String()
+	assert.True(t, strings.HasPrefix(runtimeImage, repository+"@sha256:"),
+		"runtime image %q should pin source repository %q", runtimeImage, repository)
+
+	pwd := m.MustRun("sandbox", "exec", sandboxID, "--", "pwd")
+	assert.Equal(t, "/srv/direct-image", strings.TrimSpace(pwd.Stdout))
+	port := m.MustRun("sandbox", "exec", sandboxID, "--", "printenv", "PORT")
+	assert.Equal(t, "4321", strings.TrimSpace(port.Stdout))
+
+	statusJSON := m.MustRun("app", "status", "-a", name, "--format", "json")
+	var status struct {
+		Source struct {
+			Kind  string `json:"kind"`
+			Value string `json:"value"`
+		} `json:"source"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(statusJSON.Stdout), &status))
+	assert.Equal(t, "image", status.Source.Kind)
+	assert.Equal(t, sourceImage, status.Source.Value)
+}
+
+func sandboxForImageSource(t *testing.T, m *harness.Miren, appName string) (string, string) {
+	t.Helper()
+	r := m.MustRun("sandbox", "list", "--format", "json")
+	var sandboxes []struct {
+		ID   string `json:"id"`
+		Spec struct {
+			Container []struct {
+				Image string `json:"image"`
+			} `json:"container"`
+		} `json:"spec"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(r.Stdout), &sandboxes))
+	for _, sb := range sandboxes {
+		if strings.Contains(sb.ID, appName) && len(sb.Spec.Container) > 0 {
+			return sb.ID, sb.Spec.Container[0].Image
+		}
+	}
+	t.Fatalf("no sandbox found for app %s", appName)
+	return "", ""
 }

--- a/components/ocireg/registry.go
+++ b/components/ocireg/registry.go
@@ -325,24 +325,11 @@ func (h *RegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // getManifest handles GET requests for manifests
 func (h *RegistryHandler) getManifest(w http.ResponseWriter, r *http.Request, reference string) {
-	var artifact core_v1alpha.Artifact
-
-	if strings.HasPrefix(reference, "sha256:") {
-		err := h.ec.OneAtIndex(r.Context(), entity.String(core_v1alpha.ArtifactManifestDigestId, reference), &artifact)
-		if err != nil {
-			h.log.Error("Error getting artifact by digest", "digest", reference, "error", err)
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		h.log.Info("Found app version by digest", "digest", reference, "appVer", artifact.ID)
-	} else {
-		err := h.ec.Get(r.Context(), reference, &artifact)
-		if err != nil {
-			h.log.Error("Error getting artifact", "reference", reference, "error", err)
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
+	artifact, err := h.getArtifactForManifest(r.Context(), reference)
+	if err != nil {
+		h.log.Error("Error getting artifact", "reference", reference, "error", err)
+		w.WriteHeader(http.StatusNotFound)
+		return
 	}
 
 	data := []byte(artifact.Manifest)
@@ -370,15 +357,13 @@ func (h *RegistryHandler) getManifest(w http.ResponseWriter, r *http.Request, re
 
 // headManifest handles HEAD requests for manifests
 func (h *RegistryHandler) headManifest(w http.ResponseWriter, r *http.Request, reference string) {
-	var appVer core_v1alpha.Artifact
-
-	err := h.ec.Get(r.Context(), reference, &appVer)
+	artifact, err := h.getArtifactForManifest(r.Context(), reference)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
-	data := []byte(appVer.Manifest)
+	data := []byte(artifact.Manifest)
 	/*
 		manifestPath := filepath.Join(h.storageRoot, "manifests", name, reference)
 
@@ -396,6 +381,17 @@ func (h *RegistryHandler) headManifest(w http.ResponseWriter, r *http.Request, r
 	w.Header().Set("Docker-Content-Digest", "sha256:"+hex.EncodeToString(sum[:]))
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
 	w.WriteHeader(http.StatusOK)
+}
+
+func (h *RegistryHandler) getArtifactForManifest(ctx context.Context, reference string) (core_v1alpha.Artifact, error) {
+	var artifact core_v1alpha.Artifact
+	if strings.HasPrefix(reference, "sha256:") {
+		err := h.ec.OneAtIndex(ctx, entity.String(core_v1alpha.ArtifactManifestDigestId, reference), &artifact)
+		return artifact, err
+	}
+
+	err := h.ec.Get(ctx, reference, &artifact)
+	return artifact, err
 }
 
 // putManifest handles PUT requests for manifests

--- a/components/ocireg/registry_test.go
+++ b/components/ocireg/registry_test.go
@@ -199,6 +199,34 @@ func TestGetManifest_ByDigest(t *testing.T) {
 	assert.Equal(t, manifestData, body)
 }
 
+func TestHeadManifest_ByDigest(t *testing.T) {
+	entServer, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	manifestData := []byte(`{"schemaVersion":2}`)
+	sum := sha256.Sum256(manifestData)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	artifact := core_v1alpha.Artifact{
+		Manifest:       string(manifestData),
+		ManifestDigest: digest,
+	}
+	_, err := entServer.Client.Create(context.Background(), "test-artifact", &artifact)
+	require.NoError(t, err)
+
+	handler := NewRegistryHandler(t.TempDir(), testutils.TestLogger(t), entServer.Client)
+	req := httptest.NewRequest(http.MethodHead, fmt.Sprintf("/v2/test-app/manifests/%s", digest), nil)
+	rec := httptest.NewRecorder()
+
+	handler.headManifest(rec, req, digest)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, digest, rec.Header().Get("Docker-Content-Digest"))
+	assert.Equal(t, fmt.Sprintf("%d", len(manifestData)), rec.Header().Get("Content-Length"))
+	assert.Empty(t, rec.Body.Bytes())
+}
+
 func TestGetManifest_ByReference(t *testing.T) {
 	// Setup in-memory entity server
 	entServer, cleanup := testutils.NewInMemEntityServer(t)

--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
+	github.com/distribution/reference v0.6.0
 	github.com/dnsimple/dnsimple-go/v4 v4.0.0 // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -115,6 +115,11 @@ type Builder struct {
 
 	WorkloadIssuer *workloadidentity.Issuer
 
+	// imageMetadataResolver is injectable for focused direct-image tests. A nil
+	// value creates a fresh registry resolver per deployment so mutable tags are
+	// never served from a cross-deployment metadata cache.
+	imageMetadataResolver imageMetadataResolver
+
 	// Secrets resolves backend-sourced variables so a minted ConfigVersion
 	// records the exact secret version it saw. Nil on a cluster with no secret
 	// backends registered, in which case a config that references one fails
@@ -753,6 +758,12 @@ type ConfigInputs struct {
 	// BuildResult contains entrypoint, working dir, and image entrypoint/cmd from the build
 	BuildResult *BuildResult
 
+	// SourceKind and SourceValue identify the configured build source. For an
+	// image source, SourceValue remains the user-facing tag while BuildResult
+	// describes the separately resolved runtime image.
+	SourceKind  string
+	SourceValue string
+
 	// AppConfig is the parsed app.toml configuration (may be nil)
 	AppConfig *appconfig.AppConfig
 
@@ -815,7 +826,11 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.ConfigSpec {
 			"file", appconfig.AppConfigPath)
 	}
 
-	spec.Services = buildServicesConfig(ac, procfileServices, res != nil, webDefault)
+	ensureWeb := res != nil && inputs.SourceKind != "image"
+	spec.Services = buildServicesConfig(ac, procfileServices, ensureWeb, webDefault)
+	if inputs.SourceKind == "image" {
+		inheritPrimaryImage(&spec, inputs.SourceValue)
+	}
 	if res != nil {
 		defaultServicePortFromImage(&spec, res.ExposedPorts)
 	}
@@ -843,6 +858,22 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.ConfigSpec {
 	spec.Variables = mergeCliEnvVars(spec.Variables, inputs.CliEnvVars)
 
 	return spec
+}
+
+// inheritPrimaryImage removes service-level references to the selected image
+// source from the effective config. Those services then inherit the pinned
+// AppVersion image exactly like services backed by a Miren-built artifact.
+func inheritPrimaryImage(spec *core_v1alpha.ConfigSpec, source string) {
+	if source == "" {
+		return
+	}
+	source = containerdx.NormalizeImageReference(source)
+	for i := range spec.Services {
+		if spec.Services[i].Image != "" &&
+			containerdx.NormalizeImageReference(spec.Services[i].Image) == source {
+			spec.Services[i].Image = ""
+		}
+	}
 }
 
 // defaultServicePortFromImage folds a single TCP EXPOSE declaration into the
@@ -1638,6 +1669,7 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 		b.sendErrorStatus(ctx, status, "No supported stack detected for app %s: %v", name, err)
 		return nil, err
 	}
+	sourceKind, sourceValue := sourceFromBuildStack(buildStack)
 
 	setupSpan.SetAttributes(attribute.String("miren.build.stack", buildStack.Stack))
 	setupSpan.End()
@@ -1652,7 +1684,11 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 	var res *BuildResult
 	var artifactName string
 	if buildStack.Stack == "image" {
-		mrv.ImageUrl = containerdx.NormalizeImageReference(buildStack.Input)
+		mrv.ImageUrl, res, err = b.resolveDirectImage(ctx, buildStack.Input)
+		if err != nil {
+			b.sendErrorStatus(ctx, status, "Failed to resolve image: %v", err)
+			return nil, err
+		}
 		NewRPCStatusSender(status, b.Log).SendImage(mrv.ImageUrl)
 		b.Log.Info("using upstream image directly", "app", name, "image", mrv.ImageUrl)
 	} else {
@@ -1729,6 +1765,8 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 	// Build the version config from all inputs
 	configSpec := buildVersionConfig(ConfigInputs{
 		BuildResult:      res,
+		SourceKind:       sourceKind,
+		SourceValue:      sourceValue,
 		AppConfig:        ac,
 		ProcfileServices: procfileServices,
 		ExistingConfig:   existingCfg,
@@ -1837,8 +1875,11 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 	}
 	mrv.ConfigVersion = cvid
 	mrv.Config = core_v1alpha.Config{}
+	if res != nil {
+		mrv.ManifestDigest = res.ManifestDigest
+	}
 	deploy.setSource(mrv)
-	mrv.Source.Kind, mrv.Source.Value = sourceFromBuildStack(buildStack)
+	mrv.Source.Kind, mrv.Source.Value = sourceKind, sourceValue
 
 	id, err := b.ec.Create(createVerCtx, mrv.Version, mrv)
 	if err != nil {

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -254,6 +254,8 @@ type prepareConfigIn struct {
 	ProcfileServices map[string]string                    `json:"procfile_services,omitempty" saga:"procfile_services,optional"`
 	ExistingConfig   string                               `json:"existing_config_json" saga:"existing_config_json"`
 	CLIEnvVars       []*build_v1alpha.EnvironmentVariable `json:"cli_env_vars,omitempty" saga:"cli_env_vars,optional"`
+	SourceKind       string                               `json:"source_kind,omitempty" saga:"source_kind,optional"`
+	SourceValue      string                               `json:"source_value,omitempty" saga:"source_value,optional"`
 }
 
 type prepareConfigOut struct {
@@ -272,6 +274,8 @@ func prepareConfig(ctx context.Context, in prepareConfigIn) (prepareConfigOut, e
 
 	spec := buildVersionConfig(ConfigInputs{
 		BuildResult:      in.BuildResult,
+		SourceKind:       in.SourceKind,
+		SourceValue:      in.SourceValue,
 		AppConfig:        in.AppConfig,
 		ProcfileServices: in.ProcfileServices,
 		ExistingConfig:   existing,
@@ -449,6 +453,7 @@ type createVersionIn struct {
 	AppID              string `json:"app_id" saga:"app_id"`
 	VersionName        string `json:"version_name" saga:"version_name"`
 	FinalImageURL      string `json:"final_image_url" saga:"final_image_url"`
+	ManifestDigest     string `json:"manifest_digest,omitempty" saga:"manifest_digest,optional"`
 	ArtifactID         string `json:"artifact_id" saga:"artifact_id,optional"`
 	AdminToken         string `json:"admin_token" saga:"admin_token"`
 	ConfigVersionID    string `json:"config_version_id" saga:"config_version_id"`
@@ -469,13 +474,14 @@ func createVersion(ctx context.Context, in createVersionIn) (createVersionOut, e
 	b := deps.builder
 
 	av := &core_v1alpha.AppVersion{
-		App:           entity.Id(in.AppID),
-		Version:       in.VersionName,
-		ImageUrl:      in.FinalImageURL,
-		AdminToken:    in.AdminToken,
-		Artifact:      entity.Id(in.ArtifactID),
-		ConfigVersion: entity.Id(in.ConfigVersionID),
-		Config:        core_v1alpha.Config{},
+		App:            entity.Id(in.AppID),
+		Version:        in.VersionName,
+		ImageUrl:       in.FinalImageURL,
+		ManifestDigest: in.ManifestDigest,
+		AdminToken:     in.AdminToken,
+		Artifact:       entity.Id(in.ArtifactID),
+		ConfigVersion:  entity.Id(in.ConfigVersionID),
+		Config:         core_v1alpha.Config{},
 	}
 	if in.GitInfo != "" {
 		var gitInfo core_v1alpha.GitInfo

--- a/servers/build/build_saga_buildkit.go
+++ b/servers/build/build_saga_buildkit.go
@@ -11,7 +11,6 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/appconfig"
-	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/saga"
@@ -67,9 +66,17 @@ func buildImage(ctx context.Context, in buildImageIn) (buildImageOut, error) {
 	status := deps.statuses.SenderFor(in.StreamID)
 
 	if in.BuildStack.Stack == "image" {
-		image := containerdx.NormalizeImageReference(in.BuildStack.Input)
+		image, res, err := b.resolveDirectImage(ctx, in.BuildStack.Input)
+		if err != nil {
+			status.SendError("Failed to resolve image: %v", err)
+			return buildImageOut{}, err
+		}
 		status.SendImage(image)
-		return buildImageOut{FinalImageURL: image}, nil
+		return buildImageOut{
+			ManifestDigest: res.ManifestDigest,
+			FinalImageURL:  image,
+			BuildResult:    res,
+		}, nil
 	}
 
 	if b.BuildKit == nil {

--- a/servers/build/build_saga_test.go
+++ b/servers/build/build_saga_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -51,11 +52,15 @@ func newSagaTestHarness(t *testing.T) *sagaTestHarness {
 
 	rpcClient := rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(inmem.Server))
 	builder := &Builder{
-		Log:        log,
-		EAS:        inmem.EAC,
-		ec:         entityserver.NewClient(log, inmem.EAC),
-		appClient:  app.NewClient(log, rpcClient),
-		TempDir:    tempDir,
+		Log:       log,
+		EAS:       inmem.EAC,
+		ec:        entityserver.NewClient(log, inmem.EAC),
+		appClient: app.NewClient(log, rpcClient),
+		TempDir:   tempDir,
+		imageMetadataResolver: &staticImageMetadataResolver{
+			digest: digest.Digest(testDirectImageDigest),
+			config: []byte(`{"config":{"WorkingDir":"/srv/app","ExposedPorts":{"4321/tcp":{}}}}`),
+		},
 		cacheLocks: newAppLocks(),
 		deploy:     deploylifecycle.NewTracker(log, inmem.EAC),
 	}
@@ -174,7 +179,6 @@ func imageOnlyTarball(t *testing.T) map[string]string {
 
 [services.web]
 image = "nginx:alpine"
-port = 80
 `,
 	}
 }
@@ -275,7 +279,8 @@ func TestBuildSaga_ImageOnly_SkipsBuildKitAndCreatesVersion(t *testing.T) {
 
 	var version core_v1alpha.AppVersion
 	require.NoError(t, h.builder.ec.GetById(ctx, application.ActiveVersion, &version))
-	assert.Equal(t, "docker.io/library/nginx:alpine", version.ImageUrl)
+	assert.Equal(t, "docker.io/library/nginx@"+testDirectImageDigest, version.ImageUrl)
+	assert.Equal(t, testDirectImageDigest, version.ManifestDigest)
 	assert.Empty(t, version.Artifact, "direct-image versions do not invent an Artifact")
 	assert.Equal(t, "image", version.Source.Kind)
 	assert.Equal(t, "docker.io/library/nginx:alpine", version.Source.Value)
@@ -284,9 +289,11 @@ func TestBuildSaga_ImageOnly_SkipsBuildKitAndCreatesVersion(t *testing.T) {
 	require.NoError(t, h.builder.ec.GetById(ctx, version.ConfigVersion, &configVersion))
 	require.Len(t, configVersion.Spec.Services, 1)
 	assert.Equal(t, "web", configVersion.Spec.Services[0].Name)
-	assert.Equal(t, "nginx:alpine", configVersion.Spec.Services[0].Image)
+	assert.Empty(t, configVersion.Spec.Services[0].Image, "the primary service inherits the pinned version image")
+	assert.Equal(t, int64(4321), configVersion.Spec.Services[0].Port)
+	assert.Equal(t, "/srv/app", configVersion.Spec.StartDirectory)
 	assert.Empty(t, configVersion.Spec.Services[0].Command)
-	assert.Contains(t, rec.Images, "docker.io/library/nginx:alpine")
+	assert.Contains(t, rec.Images, "docker.io/library/nginx@"+testDirectImageDigest)
 }
 
 func TestBuildSaga_AutoStackRecordsDetectedSource(t *testing.T) {

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -1611,6 +1611,48 @@ func TestBuildVersionConfigDefaultsWebPortFromImage(t *testing.T) {
 	}
 }
 
+func TestBuildVersionConfigInheritsPrimaryDirectImage(t *testing.T) {
+	spec := buildVersionConfig(ConfigInputs{
+		BuildResult: &BuildResult{
+			WorkingDir:   "/srv/app",
+			ExposedPorts: []string{"4321/tcp"},
+		},
+		SourceKind:  "image",
+		SourceValue: "docker.io/example/app:latest",
+		AppConfig: &appconfig.AppConfig{Services: map[string]*appconfig.ServiceConfig{
+			"web":    {Image: "example/app:latest"},
+			"worker": {Image: "docker.io/example/app:latest", Command: "work"},
+			"db":     {Image: "postgres:17"},
+		}},
+	})
+
+	assert.Equal(t, "/srv/app", spec.StartDirectory)
+	require.Len(t, spec.Services, 3)
+	services := make(map[string]core_v1alpha.ConfigSpecServices, len(spec.Services))
+	for _, svc := range spec.Services {
+		services[svc.Name] = svc
+	}
+	assert.Empty(t, services["web"].Image)
+	assert.Equal(t, int64(4321), services["web"].Port)
+	assert.Empty(t, services["worker"].Image)
+	assert.Equal(t, "postgres:17", services["db"].Image)
+}
+
+func TestBuildVersionConfigDirectWorkerImageDoesNotSynthesizeWeb(t *testing.T) {
+	spec := buildVersionConfig(ConfigInputs{
+		BuildResult: &BuildResult{WorkingDir: "/worker"},
+		SourceKind:  "image",
+		SourceValue: "example/worker:latest",
+		AppConfig: &appconfig.AppConfig{Services: map[string]*appconfig.ServiceConfig{
+			"worker": {Image: "example/worker:latest"},
+		}},
+	})
+
+	require.Len(t, spec.Services, 1)
+	assert.Equal(t, "worker", spec.Services[0].Name)
+	assert.Empty(t, spec.Services[0].Image)
+}
+
 func TestApplyImageConfig(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/servers/build/direct_image.go
+++ b/servers/build/direct_image.go
@@ -1,0 +1,192 @@
+package build
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/util/contentutil"
+	"github.com/moby/buildkit/util/imageutil"
+	digest "github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"miren.dev/runtime/components/ocireg"
+	"miren.dev/runtime/pkg/containerdx"
+	"miren.dev/runtime/pkg/workloadidentity"
+)
+
+const (
+	maxManifestIndexNesting    = 3
+	directImageRegistryTimeout = 60 * time.Second
+)
+
+type imageMetadataResolver interface {
+	Resolve(ctx context.Context, ref string, platform ocispecs.Platform) (digest.Digest, []byte, error)
+}
+
+type registryImageMetadataResolver struct {
+	resolver remotes.Resolver
+}
+
+func (r registryImageMetadataResolver) Resolve(ctx context.Context, ref string, platform ocispecs.Platform) (digest.Digest, []byte, error) {
+	buffer := contentutil.NewBuffer()
+	topLevelDigest, config, err := imageutil.Config(ctx, ref, r.resolver, buffer, nil, &platform)
+	if err != nil {
+		return "", nil, err
+	}
+
+	manifestDigest, err := selectedManifestDigest(ctx, buffer, topLevelDigest)
+	if err != nil {
+		return "", nil, fmt.Errorf("finding selected manifest: %w", err)
+	}
+	return manifestDigest, config, nil
+}
+
+// selectedManifestDigest follows the content imageutil.Config fetched for its
+// platform selection. LimitManifests leaves only the chosen branch of an index
+// in the buffer, so this recovers the exact manifest whose config was returned
+// rather than pinning the (potentially multi-platform) index above it.
+func selectedManifestDigest(ctx context.Context, provider content.Provider, dgst digest.Digest) (digest.Digest, error) {
+	return selectedManifestDigestAtDepth(ctx, provider, dgst, 0)
+}
+
+func selectedManifestDigestAtDepth(ctx context.Context, provider content.Provider, dgst digest.Digest, depth int) (digest.Digest, error) {
+	desc := ocispecs.Descriptor{Digest: dgst}
+	ra, err := provider.ReaderAt(ctx, desc)
+	if err != nil {
+		return "", err
+	}
+	desc.Size = ra.Size()
+	mediaType, err := imageutil.DetectManifestMediaType(ra)
+	ra.Close()
+	if err != nil {
+		return "", err
+	}
+	desc.MediaType = mediaType
+
+	if images.IsManifestType(desc.MediaType) {
+		return desc.Digest, nil
+	}
+	if !images.IsIndexType(desc.MediaType) {
+		return "", fmt.Errorf("unexpected media type %q for %s", desc.MediaType, desc.Digest)
+	}
+	if depth >= maxManifestIndexNesting {
+		return "", fmt.Errorf("manifest index nesting exceeds maximum depth %d", maxManifestIndexNesting)
+	}
+
+	data, err := content.ReadBlob(ctx, provider, desc)
+	if err != nil {
+		return "", err
+	}
+	var index ocispecs.Index
+	if err := json.Unmarshal(data, &index); err != nil {
+		return "", fmt.Errorf("decoding image index: %w", err)
+	}
+	var selected []ocispecs.Descriptor
+	for _, child := range index.Manifests {
+		ra, err := provider.ReaderAt(ctx, child)
+		if err != nil {
+			continue
+		}
+		ra.Close()
+		selected = append(selected, child)
+	}
+	if len(selected) != 1 {
+		return "", fmt.Errorf("expected one selected child in fetched index %s, found %d", desc.Digest, len(selected))
+	}
+	return selectedManifestDigestAtDepth(ctx, provider, selected[0].Digest, depth+1)
+}
+
+func (b *Builder) resolveDirectImage(ctx context.Context, input string) (string, *BuildResult, error) {
+	source := containerdx.NormalizeImageReference(input)
+	// Miren does not model a separate target sandbox platform yet. Match source
+	// builds, which also resolve and emit images for the server's native platform.
+	pl := platforms.Normalize(platforms.DefaultSpec())
+	manifestDigest, config, err := b.directImageMetadataResolver().Resolve(ctx, source, pl)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolving image %s: %w", source, err)
+	}
+
+	res := &BuildResult{ManifestDigest: manifestDigest.String()}
+	if err := applyImageConfig(res, config); err != nil {
+		return "", nil, fmt.Errorf("reading config for image %s: %w", source, err)
+	}
+	if res.WorkingDir == "" {
+		res.WorkingDir = "/"
+	}
+
+	named, err := reference.ParseNormalizedNamed(source)
+	if err != nil {
+		return "", nil, fmt.Errorf("parsing resolved image name %s: %w", source, err)
+	}
+	pinned, err := reference.WithDigest(reference.TrimNamed(named), manifestDigest)
+	if err != nil {
+		return "", nil, fmt.Errorf("pinning image %s: %w", source, err)
+	}
+	return pinned.String(), res, nil
+}
+
+func (b *Builder) directImageMetadataResolver() imageMetadataResolver {
+	if b.imageMetadataResolver != nil {
+		return b.imageMetadataResolver
+	}
+	return registryImageMetadataResolver{
+		resolver: docker.NewResolver(docker.ResolverOptions{
+			Hosts: b.directImageRegistryHosts,
+		}),
+	}
+}
+
+func (b *Builder) directImageRegistryHosts(host string) ([]docker.RegistryHost, error) {
+	if host != ocireg.Host && host != "cluster.local" {
+		return []docker.RegistryHost{containerdx.DefaultRegistryHost(host)}, nil
+	}
+
+	registryHost, err := b.clusterRegistryHost()
+	if err != nil {
+		return nil, err
+	}
+	return []docker.RegistryHost{registryHost}, nil
+}
+
+func (b *Builder) clusterRegistryHost() (docker.RegistryHost, error) {
+	if b.Resolver == nil {
+		return docker.RegistryHost{}, fmt.Errorf("network resolver is not configured for %s", ocireg.Host)
+	}
+	addr, err := b.Resolver.LookupHost("cluster.local")
+	if err != nil {
+		return docker.RegistryHost{}, fmt.Errorf("resolving cluster registry: %w", err)
+	}
+	if !addr.IsValid() {
+		return docker.RegistryHost{}, fmt.Errorf("cluster registry address is unavailable")
+	}
+
+	registryHost := docker.RegistryHost{
+		Client:       &http.Client{Timeout: directImageRegistryTimeout},
+		Host:         addr.String() + ":5000",
+		Scheme:       "http",
+		Path:         "/v2",
+		Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
+	}
+	if b.WorkloadIssuer == nil {
+		return registryHost, nil
+	}
+
+	token, err := b.WorkloadIssuer.IssueSystemWorkloadToken(
+		workloadidentity.SystemWorkloadBuildKit,
+		workloadidentity.TokenOptions{Audience: []string{ocireg.Audience}},
+	)
+	if err != nil {
+		return docker.RegistryHost{}, fmt.Errorf("issuing registry token: %w", err)
+	}
+	registryHost.Header = http.Header{"Authorization": []string{"Bearer " + token}}
+	return registryHost, nil
+}

--- a/servers/build/direct_image_test.go
+++ b/servers/build/direct_image_test.go
@@ -1,0 +1,161 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/moby/buildkit/util/contentutil"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDirectImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type staticImageMetadataResolver struct {
+	digest digest.Digest
+	config []byte
+	err    error
+	ref    string
+}
+
+func (r *staticImageMetadataResolver) Resolve(_ context.Context, ref string, _ ocispecs.Platform) (digest.Digest, []byte, error) {
+	r.ref = ref
+	return r.digest, r.config, r.err
+}
+
+func TestResolveDirectImage(t *testing.T) {
+	resolver := &staticImageMetadataResolver{
+		digest: digest.Digest(testDirectImageDigest),
+		config: []byte(`{
+			"config": {
+				"WorkingDir": "/srv/app",
+				"ExposedPorts": {"4321/tcp": {}},
+				"Entrypoint": ["/entrypoint"],
+				"Cmd": ["serve"]
+			}
+		}`),
+	}
+	b := &Builder{imageMetadataResolver: resolver}
+
+	image, result, err := b.resolveDirectImage(t.Context(), "example/app:latest")
+	require.NoError(t, err)
+
+	assert.Equal(t, "docker.io/example/app:latest", resolver.ref)
+	assert.Equal(t, "docker.io/example/app@"+testDirectImageDigest, image)
+	assert.Equal(t, testDirectImageDigest, result.ManifestDigest)
+	assert.Equal(t, "/srv/app", result.WorkingDir)
+	assert.Equal(t, []string{"4321/tcp"}, result.ExposedPorts)
+	assert.Empty(t, result.Entrypoint, "the image entrypoint remains in OCI config for exec-form launch")
+	assert.Empty(t, result.Command, "the image command remains in OCI config for exec-form launch")
+}
+
+func TestResolveDirectImageDefaultsWorkingDirectoryToRoot(t *testing.T) {
+	b := &Builder{imageMetadataResolver: &staticImageMetadataResolver{
+		digest: digest.Digest(testDirectImageDigest),
+		config: []byte(`{"config": {}}`),
+	}}
+
+	_, result, err := b.resolveDirectImage(t.Context(), "busybox:latest")
+	require.NoError(t, err)
+	assert.Equal(t, "/", result.WorkingDir)
+}
+
+func TestResolveDirectImageFailsClosed(t *testing.T) {
+	t.Run("resolver error", func(t *testing.T) {
+		b := &Builder{imageMetadataResolver: &staticImageMetadataResolver{err: errors.New("registry unavailable")}}
+		_, _, err := b.resolveDirectImage(t.Context(), "busybox:latest")
+		require.ErrorContains(t, err, "registry unavailable")
+	})
+
+	t.Run("invalid config", func(t *testing.T) {
+		b := &Builder{imageMetadataResolver: &staticImageMetadataResolver{
+			digest: digest.Digest(testDirectImageDigest),
+			config: []byte(`not json`),
+		}}
+		_, _, err := b.resolveDirectImage(t.Context(), "busybox:latest")
+		require.ErrorContains(t, err, "reading config")
+	})
+}
+
+func TestSelectedManifestDigest(t *testing.T) {
+	t.Run("follows the one fetched platform branch", func(t *testing.T) {
+		buffer := contentutil.NewBuffer()
+		manifest := writeImageJSONBlob(t, buffer, ocispecs.MediaTypeImageManifest, ocispecs.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ocispecs.MediaTypeImageManifest,
+		})
+		other := ocispecs.Descriptor{
+			MediaType: ocispecs.MediaTypeImageManifest,
+			Digest:    digest.FromString("not fetched"),
+			Size:      1,
+		}
+		index := writeImageJSONBlob(t, buffer, ocispecs.MediaTypeImageIndex, ocispecs.Index{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ocispecs.MediaTypeImageIndex,
+			Manifests: []ocispecs.Descriptor{other, manifest},
+		})
+
+		got, err := selectedManifestDigest(t.Context(), buffer, index.Digest)
+		require.NoError(t, err)
+		assert.Equal(t, manifest.Digest, got)
+	})
+
+	t.Run("rejects multiple fetched branches", func(t *testing.T) {
+		buffer := contentutil.NewBuffer()
+		first := writeImageJSONBlob(t, buffer, ocispecs.MediaTypeImageManifest, ocispecs.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ocispecs.MediaTypeImageManifest,
+		})
+		second := writeImageJSONBlob(t, buffer, ocispecs.MediaTypeImageManifest, map[string]any{
+			"schemaVersion": 2,
+			"mediaType":     ocispecs.MediaTypeImageManifest,
+			"annotations":   map[string]string{"distinct": "manifest"},
+		})
+		index := writeImageJSONBlob(t, buffer, ocispecs.MediaTypeImageIndex, ocispecs.Index{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ocispecs.MediaTypeImageIndex,
+			Manifests: []ocispecs.Descriptor{first, second},
+		})
+
+		_, err := selectedManifestDigest(t.Context(), buffer, index.Digest)
+		require.ErrorContains(t, err, "expected one selected child")
+	})
+
+	t.Run("bounds nested indexes", func(t *testing.T) {
+		buffer := contentutil.NewBuffer()
+		child := writeImageJSONBlob(t, buffer, ocispecs.MediaTypeImageManifest, ocispecs.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ocispecs.MediaTypeImageManifest,
+		})
+		for range maxManifestIndexNesting + 1 {
+			child = writeImageJSONBlob(t, buffer, ocispecs.MediaTypeImageIndex, ocispecs.Index{
+				Versioned: specs.Versioned{SchemaVersion: 2},
+				MediaType: ocispecs.MediaTypeImageIndex,
+				Manifests: []ocispecs.Descriptor{child},
+			})
+		}
+
+		_, err := selectedManifestDigest(t.Context(), buffer, child.Digest)
+		require.ErrorContains(t, err, "manifest index nesting exceeds maximum depth")
+	})
+}
+
+func writeImageJSONBlob(t *testing.T, buffer contentutil.Buffer, mediaType string, value any) ocispecs.Descriptor {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	desc := ocispecs.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+	}
+	require.NoError(t, content.WriteBlob(t.Context(), buffer, desc.Digest.Encoded(), bytes.NewReader(data), desc))
+	return desc
+}

--- a/testdata/direct-image-metadata/.miren/app.toml
+++ b/testdata/direct-image-metadata/.miren/app.toml
@@ -1,0 +1,1 @@
+name = "direct-image-metadata"

--- a/testdata/direct-image-metadata/Dockerfile.miren
+++ b/testdata/direct-image-metadata/Dockerfile.miren
@@ -1,0 +1,11 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache python3
+
+WORKDIR /srv/direct-image
+COPY serve.sh /usr/local/bin/serve
+COPY index.html .
+RUN chmod +x /usr/local/bin/serve
+
+EXPOSE 4321
+ENTRYPOINT ["/usr/local/bin/serve"]

--- a/testdata/direct-image-metadata/index.html
+++ b/testdata/direct-image-metadata/index.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>direct image metadata</title>
+<h1>direct image metadata inherited</h1>

--- a/testdata/direct-image-metadata/serve.sh
+++ b/testdata/direct-image-metadata/serve.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+echo "direct-image-metadata: cwd=$(pwd) port=$PORT"
+exec python3 -m http.server "$PORT"


### PR DESCRIPTION
First-class image deploys treated their configured tag as the runtime image and skipped OCI config resolution. That meant they lost the image’s working directory and exposed port, while the service-level image also bypassed the version-level image used by source builds.

This resolves the selected platform manifest during deployment, pins the runtime image by digest, and feeds its config into the same `BuildResult` path as a source build. Services using the primary image now inherit it from `AppVersion`; the configured tag remains in `Source`, and `Artifact` remains empty for images Miren did not build.

The internal registry now answers manifest `HEAD` requests by digest as well, so a Miren-built image can be redeployed as a first-class image through the same pinned path.

Closes MIR-1696