### PR TITLE
Render only the serving deployment as active

### DIFF
--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -132,11 +133,9 @@ func AppHistory(ctx *Context, opts struct {
 	AppCentric
 	FormatOptions
 
-	Limit      int    `short:"n" long:"limit" description:"Maximum number of deployments to show" default:"10"`
-	All        bool   `long:"all" description:"Show all deployments (ignore limit)"`
-	Status     string `short:"s" long:"status" description:"Filter by status (active, failed, rolled_back)"`
-	HideFailed bool   `long:"hide-failed" description:"Hide failed deployments"`
-	Detailed   bool   `long:"detailed" description:"Show all columns including git information"`
+	Limit    int  `short:"n" long:"limit" description:"Maximum number of deployments to show" default:"10"`
+	All      bool `long:"all" description:"Show all deployments (ignore limit)"`
+	Detailed bool `long:"detailed" description:"Show all columns including git information"`
 }) error {
 	depCl, err := ctx.RPCClient("dev.miren.runtime/deployment")
 	if err != nil {
@@ -146,22 +145,15 @@ func AppHistory(ctx *Context, opts struct {
 
 	limit := int32(opts.Limit)
 	if opts.All {
-		limit = 0
+		limit = math.MaxInt32
 	}
 
-	result, err := depClient.ListDeployments(ctx, opts.App, ctx.ClusterName, opts.Status, limit)
+	result, err := depClient.ListDeployments(ctx, opts.App, ctx.ClusterName, "", limit)
 	if err != nil {
 		return fmt.Errorf("failed to list deployments: %w", err)
 	}
 
 	deployments := result.Deployments()
-
-	// Filter out failed deployments if requested
-	if opts.HideFailed {
-		deployments = filterDeployments(deployments, func(d *deployment_v1alpha.DeploymentInfo) bool {
-			return d.Status() != "failed"
-		})
-	}
 
 	// Sort by time (most recent first)
 	sortDeployments(deployments)
@@ -172,7 +164,7 @@ func AppHistory(ctx *Context, opts struct {
 	}
 
 	if len(deployments) == 0 {
-		printNoDeploymentsMessage(ctx, opts.App, opts.Status, opts.HideFailed)
+		printNoDeploymentsMessage(ctx, opts.App)
 		return nil
 	}
 
@@ -195,25 +187,8 @@ func AppHistory(ctx *Context, opts struct {
 	return nil
 }
 
-func printNoDeploymentsMessage(ctx *Context, app string, status string, hiddenFailed bool) {
-	ctx.Printf("No deployments found for app '%s' on cluster '%s'", app, ctx.ClusterName)
-	if status != "" {
-		ctx.Printf(" with status '%s'", status)
-	}
-	if hiddenFailed {
-		ctx.Printf(" (failed deployments hidden)")
-	}
-	ctx.Printf("\n")
-}
-
-func filterDeployments(deps []*deployment_v1alpha.DeploymentInfo, keep func(*deployment_v1alpha.DeploymentInfo) bool) []*deployment_v1alpha.DeploymentInfo {
-	var filtered []*deployment_v1alpha.DeploymentInfo
-	for _, d := range deps {
-		if keep(d) {
-			filtered = append(filtered, d)
-		}
-	}
-	return filtered
+func printNoDeploymentsMessage(ctx *Context, app string) {
+	ctx.Printf("No deployments found for app '%s' on cluster '%s'\n", app, ctx.ClusterName)
 }
 
 func sortDeployments(deployments []*deployment_v1alpha.DeploymentInfo) {

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -255,10 +255,6 @@ miren deploy --analyze
 			Name: "Show detailed history with git info",
 			Body: "miren app history --detailed",
 		}),
-		WithExample(mflags.Example{
-			Name: "Show only active deployments, limited to 5",
-			Body: "miren app history --status active --limit 5",
-		}),
 	))
 	d.Dispatch("app versions", Infer("app versions", "List app versions with status", AppVersions,
 		WithExample(mflags.Example{

--- a/docs/docs/command/app-history.md
+++ b/docs/docs/command/app-history.md
@@ -19,10 +19,8 @@ miren app history [flags]
 - `--all` — Show all deployments (ignore limit)
 - `--detailed` — Show all columns including git information
 - `--format` — Output format (text, json) (default: `text`)
-- `--hide-failed` — Hide failed deployments
 - `--json` — Shorthand for --format json
 - `--limit, -n` — Maximum number of deployments to show (default: `10`)
-- `--status, -s` — Filter by status (active, failed, rolled_back)
 
 ## Config Options
 
@@ -52,12 +50,6 @@ miren app history
 
 ```bash
 miren app history --detailed
-```
-
-**Show only active deployments, limited to 5:**
-
-```bash
-miren app history --status active --limit 5
 ```
 
 ## See also

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -163,7 +163,11 @@ func (d *DeploymentServer) UpdateDeploymentStatus(ctx context.Context, req *depl
 	if err != nil {
 		return err
 	}
-	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
+	// New clients activate with succeeded; active and rolled_back are legacy aliases for the same transition.
+	serving := status == deploylifecycle.StatusActive ||
+		status == deploylifecycle.StatusSucceeded ||
+		status == deploylifecycle.StatusRolledBack
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment, serving)
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Updated deployment status",
@@ -211,7 +215,7 @@ func (d *DeploymentServer) UpdateDeploymentPhase(ctx context.Context, req *deplo
 	if err != nil {
 		return err
 	}
-	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment, false)
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Updated deployment phase",
@@ -255,7 +259,7 @@ func (d *DeploymentServer) UpdateFailedDeployment(ctx context.Context, req *depl
 	if err != nil {
 		return err
 	}
-	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment, false)
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Updated failed deployment",
@@ -300,11 +304,27 @@ func (d *DeploymentServer) ListDeployments(ctx context.Context, req *deployment_
 		versionIDs = append(versionIDs, (&deploylifecycle.Record{Deployment: dwe.deployment}).AppVersion())
 	}
 	versionShortIDs := d.resolveShortIDs(ctx, versionIDs)
+	activeDeployments := make(map[string]entity.Id)
+	resolvedApps := make(map[string]struct{})
+	for _, dwe := range deployments {
+		deployAppName := dwe.deployment.AppName
+		if _, resolved := resolvedApps[deployAppName]; resolved {
+			continue
+		}
+		resolvedApps[deployAppName] = struct{}{}
+		activeDeployment, err := d.activeDeploymentID(ctx, deployAppName)
+		if err != nil {
+			return err
+		}
+		activeDeployments[deployAppName] = activeDeployment
+	}
 
 	// Convert to deployment info list
 	deploymentInfos := make([]*deployment_v1alpha.DeploymentInfo, 0, len(deployments))
 	for _, dwe := range deployments {
-		info := d.toDeploymentInfo(dwe.deployment)
+		activeDeployment := activeDeployments[dwe.deployment.AppName]
+		serving := activeDeployment != "" && activeDeployment == dwe.deployment.ID
+		info := d.toDeploymentInfo(dwe.deployment, serving)
 		enrichDeploymentShortIDs(info, dwe.entity, versionShortIDs)
 		deploymentInfos = append(deploymentInfos, info)
 	}
@@ -333,7 +353,12 @@ func (d *DeploymentServer) GetDeploymentById(ctx context.Context, req *deploymen
 	if !rpc.AllowApp(ctx, rec.Deployment.AppName) {
 		return rpc.AppAccessError(ctx, rec.Deployment.AppName)
 	}
-	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
+	activeDeployment, err := d.activeDeploymentID(ctx, rec.Deployment.AppName)
+	if err != nil {
+		return err
+	}
+	serving := activeDeployment != "" && activeDeployment == rec.Deployment.ID
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment, serving)
 	versionShortIDs := d.resolveShortIDs(ctx, []string{rec.AppVersion()})
 	enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
@@ -392,7 +417,7 @@ func (d *DeploymentServer) UpdateDeploymentAppVersion(ctx context.Context, req *
 	if err != nil {
 		return err
 	}
-	deploymentInfo := d.toDeploymentInfo(rec.Deployment)
+	deploymentInfo := d.toDeploymentInfo(rec.Deployment, false)
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Updated deployment app version",
@@ -430,7 +455,7 @@ func (d *DeploymentServer) GetActiveDeployment(ctx context.Context, req *deploym
 		if err != nil {
 			return err
 		}
-		deploymentInfo := d.toDeploymentInfo(rec.Deployment)
+		deploymentInfo := d.toDeploymentInfo(rec.Deployment, true)
 		versionShortIDs := d.resolveShortIDs(ctx, []string{rec.AppVersion()})
 		enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
 		results.SetDeployment(deploymentInfo)
@@ -447,7 +472,7 @@ func (d *DeploymentServer) GetActiveDeployment(ctx context.Context, req *deploym
 		return cond.NotFound("active-deployment", fmt.Sprintf("%s/%s", appName, clusterId))
 	}
 	dwe := legacy[0]
-	deploymentInfo := d.toDeploymentInfo(dwe.deployment)
+	deploymentInfo := d.toDeploymentInfo(dwe.deployment, true)
 	versionShortIDs := d.resolveShortIDs(ctx, []string{(&deploylifecycle.Record{Deployment: dwe.deployment}).AppVersion()})
 	enrichDeploymentShortIDs(deploymentInfo, dwe.entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
@@ -703,7 +728,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 			AppVersion: string(ephID),
 			ClusterId:  clusterId,
 			Status:     "active",
-		})
+		}, true)
 		results.SetDeployment(deploymentInfo)
 
 		accessInfo := d.getAccessInfo(ctx, appName, ephLabel)
@@ -814,7 +839,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 		rec = settled
 	}
 
-	deploymentInfo := d.toDeploymentInfo(deployment)
+	deploymentInfo := d.toDeploymentInfo(deployment, true)
 	versionShortIDs := d.resolveShortIDs(ctx, []string{rec.AppVersion()})
 	enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
@@ -984,7 +1009,7 @@ func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, 
 		rec = settled
 	}
 
-	deploymentInfo := d.toDeploymentInfo(deployment)
+	deploymentInfo := d.toDeploymentInfo(deployment, true)
 	versionShortIDs := d.resolveShortIDs(ctx, []string{rec.AppVersion()})
 	enrichDeploymentShortIDs(deploymentInfo, rec.Entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
@@ -1097,7 +1122,18 @@ func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName,
 	return deployments, nil
 }
 
-func (d *DeploymentServer) toDeploymentInfo(deployment *core_v1alpha.Deployment) *deployment_v1alpha.DeploymentInfo {
+func (d *DeploymentServer) activeDeploymentID(ctx context.Context, appName string) (entity.Id, error) {
+	app, _, err := d.tracker.Store().AppByName(ctx, appName)
+	if errors.Is(err, cond.ErrNotFound{}) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return app.ActiveDeployment, nil
+}
+
+func (d *DeploymentServer) toDeploymentInfo(deployment *core_v1alpha.Deployment, serving bool) *deployment_v1alpha.DeploymentInfo {
 	info := &deployment_v1alpha.DeploymentInfo{}
 	rec := &deploylifecycle.Record{Deployment: deployment}
 
@@ -1110,11 +1146,8 @@ func (d *DeploymentServer) toDeploymentInfo(deployment *core_v1alpha.Deployment)
 	status := rec.Status()
 	// Keep the old RPC vocabulary: a succeeded attempt that currently owns the
 	// app pointer is presented as active to downgrade-era clients.
-	if status == deploylifecycle.StatusSucceeded {
-		status = deploylifecycle.Status(deployment.Status)
-		if status == "" {
-			status = deploylifecycle.StatusSucceeded
-		}
+	if serving && status == deploylifecycle.StatusSucceeded {
+		status = deploylifecycle.StatusActive
 	}
 	info.SetStatus(string(status))
 	info.SetPhase(string(rec.Phase()))

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -154,8 +154,65 @@ func TestToDeploymentInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			info := server.toDeploymentInfo(tt.deployment)
+			info := server.toDeploymentInfo(tt.deployment, true)
 			tt.checkFunc(t, info)
+		})
+	}
+}
+
+func TestToDeploymentInfoStatus(t *testing.T) {
+	server := &DeploymentServer{}
+	tests := []struct {
+		name       string
+		deployment *core_v1alpha.Deployment
+		serving    bool
+		want       string
+	}{
+		{
+			name:       "serving legacy active deployment",
+			deployment: &core_v1alpha.Deployment{ID: "deployment/current", Status: "active"},
+			serving:    true,
+			want:       "active",
+		},
+		{
+			name:       "stale legacy active deployment",
+			deployment: &core_v1alpha.Deployment{ID: "deployment/stale", Status: "active"},
+			want:       "succeeded",
+		},
+		{
+			name:       "legacy rolled back deployment",
+			deployment: &core_v1alpha.Deployment{ID: "deployment/rolled-back", Status: "rolled_back"},
+			want:       "succeeded",
+		},
+		{
+			name: "serving canonical succeeded deployment",
+			deployment: &core_v1alpha.Deployment{
+				ID: "deployment/canonical-current", Outcome: "succeeded", Status: "active",
+			},
+			serving: true,
+			want:    "active",
+		},
+		{
+			name: "stale canonical succeeded deployment",
+			deployment: &core_v1alpha.Deployment{
+				ID: "deployment/canonical-stale", Outcome: "succeeded", Status: "active",
+			},
+			want: "succeeded",
+		},
+		{
+			name:       "failed deployment remains failed even if pointed to",
+			deployment: &core_v1alpha.Deployment{ID: "deployment/failed", Status: "failed"},
+			serving:    true,
+			want:       "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := server.toDeploymentInfo(tt.deployment, tt.serving).Status()
+			if got != tt.want {
+				t.Fatalf("status = %q, want %q", got, tt.want)
+			}
 		})
 	}
 }
@@ -269,6 +326,64 @@ func TestListDeployments(t *testing.T) {
 				t.Errorf("Expected %d deployments, got %d", tt.expectedCount, len(deployments))
 			}
 		})
+	}
+}
+
+func TestListDeploymentsMarksOnlyServingLegacyDeploymentActive(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
+	if err != nil {
+		t.Fatalf("create deployment server: %v", err)
+	}
+	client := &deployment_v1alpha.DeploymentClient{
+		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
+	}
+
+	var deploymentIDs []entity.Id
+	for i, deployedAt := range []time.Time{
+		time.Now().Add(-2 * time.Hour),
+		time.Now().Add(-time.Hour),
+		time.Now(),
+	} {
+		id, err := inmem.Client.Create(ctx, "history-deployment-"+string(rune('a'+i)), &core_v1alpha.Deployment{
+			AppName:    "history-app",
+			ClusterId:  "test-cluster",
+			AppVersion: "version",
+			Status:     "active",
+			DeployedBy: core_v1alpha.DeployedBy{Timestamp: deployedAt.Format(time.RFC3339)},
+		})
+		if err != nil {
+			t.Fatalf("create deployment: %v", err)
+		}
+		deploymentIDs = append(deploymentIDs, id)
+	}
+
+	servingID := deploymentIDs[1]
+	if _, err := inmem.Client.Create(ctx, "history-app", &core_v1alpha.App{
+		ActiveDeployment: servingID,
+	}); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+
+	result, err := client.ListDeployments(ctx, "history-app", "test-cluster", "", 20)
+	if err != nil {
+		t.Fatalf("list deployments: %v", err)
+	}
+	if len(result.Deployments()) != len(deploymentIDs) {
+		t.Fatalf("got %d deployments, want %d", len(result.Deployments()), len(deploymentIDs))
+	}
+
+	for _, deployment := range result.Deployments() {
+		want := "succeeded"
+		if deployment.Id() == string(servingID) {
+			want = "active"
+		}
+		if got := deployment.Status(); got != want {
+			t.Errorf("deployment %q status = %q, want %q", deployment.Id(), got, want)
+		}
 	}
 }
 
@@ -1081,13 +1196,23 @@ func TestDeployVersion(t *testing.T) {
 			t.Errorf("Expected rollback to retain canonical version %q, got %q", version1ID, newDep.AppVersionId())
 		}
 
-		// Verify the previous active deployment was marked as rolled_back
+		previous, err := server.tracker.Store().Get(ctx, string(activeDepId))
+		if err != nil {
+			t.Fatalf("Failed to get previous deployment record: %v", err)
+		}
+		if previous.Deployment.Status != "rolled_back" {
+			t.Errorf("Expected legacy status 'rolled_back', got %s", previous.Deployment.Status)
+		}
+
+		// The previous deployment still succeeded as an attempt. Serving state
+		// moved to the new rollback deployment, so the RPC reports the canonical
+		// outcome rather than its legacy rolled_back bookkeeping status.
 		prevResult, err := client.GetDeploymentById(ctx, string(activeDepId))
 		if err != nil {
 			t.Fatalf("Failed to get previous deployment: %v", err)
 		}
-		if prevResult.Deployment().Status() != "rolled_back" {
-			t.Errorf("Expected previous deployment status 'rolled_back', got %s", prevResult.Deployment().Status())
+		if prevResult.Deployment().Status() != "succeeded" {
+			t.Errorf("Expected previous deployment status 'succeeded', got %s", prevResult.Deployment().Status())
 		}
 	})
 


### PR DESCRIPTION
Legacy deployment rows can retain stale `active` statuses after another deployment takes over. The history RPC canonicalized those rows to successful attempts, then restored the raw status, so `miren app history` could show several active deployments even though `app.active_deployment` named only one.

This makes the app pointer the serving signal: only the successful attempt it names is presented as active; the rest stay succeeded. It also drops the CLI’s `--status` and `--hide-failed` filters, whose mixed attempt/serving semantics and interaction with limits could not give reliable results. Structured consumers can filter `--all --format json`; the RPC filter remains for compatibility.

Closes MIR-1701
