### PR TITLE
Make deployment records drive build cancellation

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -43,6 +43,43 @@ import (
 
 var deployTracer = otel.Tracer("miren.dev/runtime/cli/deploy")
 
+func isDeploymentCancelled(err error) bool {
+	remote, ok := errors.AsType[cond.ErrRemote](err)
+	return ok && remote.Category == "deployment" && remote.Code == "cancelled"
+}
+
+type deploymentCancellationOutcome int
+
+const (
+	deploymentCancellationUnknown deploymentCancellationOutcome = iota
+	deploymentCancellationConfirmed
+	deploymentCancellationCompleted
+)
+
+// reconcileDeploymentCancellation resolves a failed or ambiguous cancellation
+// request against the authoritative deployment record. The deploy may have
+// finished between the client's interrupt and the server handling its request.
+func reconcileDeploymentCancellation(
+	ctx context.Context,
+	deploymentID string,
+	getter deploymentStatusGetter,
+	cancelErr error,
+) (deploymentCancellationOutcome, error) {
+	status, statusErr := getter.GetStatus(ctx, deploymentID)
+	if statusErr != nil {
+		return deploymentCancellationUnknown, fmt.Errorf("%w; re-reading deployment status: %v", cancelErr, statusErr)
+	}
+
+	switch status {
+	case "cancelled":
+		return deploymentCancellationConfirmed, nil
+	case "succeeded", "active":
+		return deploymentCancellationCompleted, nil
+	default:
+		return deploymentCancellationUnknown, cancelErr
+	}
+}
+
 func Deploy(ctx *Context, opts struct {
 	AppCentric
 
@@ -421,10 +458,18 @@ func Deploy(ctx *Context, opts struct {
 	// status arm). A mutex guards it because that arm is handled in a stream
 	// goroutine while the main goroutine reads it for the summary.
 	var deploymentMu sync.Mutex
+	deploymentIDReady := make(chan struct{})
+	var deploymentIDReadyOnce sync.Once
+	if deploymentId != "" {
+		deploymentIDReadyOnce.Do(func() { close(deploymentIDReady) })
+	}
 	setDeploymentID := func(id string) {
 		deploymentMu.Lock()
 		deploymentId = id
 		deploymentMu.Unlock()
+		if id != "" {
+			deploymentIDReadyOnce.Do(func() { close(deploymentIDReady) })
+		}
 	}
 	getDeploymentID := func() string {
 		deploymentMu.Lock()
@@ -432,9 +477,9 @@ func Deploy(ctx *Context, opts struct {
 		return deploymentId
 	}
 
-	// The cancellation poller starts once we know the deployment id, which is
-	// immediately on the legacy path and on the first deployment status arm on
-	// the server-owned path.
+	// Older servers need the CLI to poll the record and cancel its local build
+	// context. Newer servers watch their own record, so their cancellation does
+	// not depend on this process staying connected.
 	var (
 		pollerOnce          sync.Once
 		externallyCancelled atomic.Bool
@@ -460,25 +505,64 @@ func Deploy(ctx *Context, opts struct {
 	// Helper to check if we were externally cancelled
 	wasExternallyCancelled := externallyCancelled.Load
 
-	// onDeployment records the server-created deployment on the server-owned
-	// path: it captures the id and starts the cancellation poller the first time
-	// the build reports it.
+	// onDeployment records the server-created deployment ID. The CLI needs it
+	// for summaries and to turn a local Ctrl-C into an explicit cancellation.
 	//
-	// Degradation note: on the server-owned path this is the ONLY thing that
-	// starts the poller and sets deploymentId. The server emits the deployment
-	// arm at the very start of the build (right after it takes the lock), so in
-	// practice it always arrives. But if it never does — a dropped arm, or a
-	// server that advertises the param yet never emits it — external
-	// `miren deploy cancel` cannot interrupt this CLI build and --summary-json's
-	// deploy_id is empty. The deploy itself is unaffected: the server still owns
-	// and settles the record. This is an accepted degradation, not a failure.
+	// On the server-owned path this is the only thing that sets deploymentId.
+	// Ctrl-C waits for this handoff before sending the explicit cancellation, so
+	// it never claims success while detached work can still be running.
 	onDeployment := func(id, phase string) {
 		if id == "" {
 			return
 		}
 		setDeploymentID(id)
-		startPoller(id)
+		if !serverOwnsDeployment {
+			startPoller(id)
+		}
 		ctx.Log.Info("Server-owned deployment", "deployment_id", id, "phase", phase)
+	}
+
+	requestDeploymentCancellation := func() (deploymentCancellationOutcome, error) {
+		cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx.Context), 10*time.Second)
+		defer cancel()
+
+		id := getDeploymentID()
+		if id == "" {
+			select {
+			case <-deploymentIDReady:
+				id = getDeploymentID()
+			case <-cancelCtx.Done():
+				return deploymentCancellationUnknown, fmt.Errorf("waiting for the server to report the deployment ID: %w", cancelCtx.Err())
+			}
+		}
+		if id == "" {
+			return deploymentCancellationUnknown, fmt.Errorf("server reported an empty deployment ID")
+		}
+
+		client := depClient
+		if ctx.Err() != nil {
+			fresh, connectErr := ctx.rpcClient(cancelCtx, "dev.miren.runtime/deployment")
+			if connectErr != nil {
+				return deploymentCancellationUnknown, fmt.Errorf("reconnecting to cancel deployment %s: %w", id, connectErr)
+			}
+			defer fresh.Close()
+			client = deployment_v1alpha.NewDeploymentClient(fresh)
+		}
+
+		result, cancelErr := client.CancelDeployment(cancelCtx, id, "")
+		if cancelErr != nil {
+			cancelErr = fmt.Errorf("cancelling deployment %s: %w", id, cancelErr)
+			return reconcileDeploymentCancellation(cancelCtx, id, newDepClientStatusGetter(client, ctx.Log), cancelErr)
+		}
+		if result.HasError() && result.Error() != "" {
+			cancelErr = fmt.Errorf("cancelling deployment %s: %s", id, result.Error())
+			return reconcileDeploymentCancellation(cancelCtx, id, newDepClientStatusGetter(client, ctx.Log), cancelErr)
+		}
+		if !result.HasSuccess() || !result.Success() {
+			cancelErr = fmt.Errorf("server did not confirm cancellation of deployment %s", id)
+			return reconcileDeploymentCancellation(cancelCtx, id, newDepClientStatusGetter(client, ctx.Log), cancelErr)
+		}
+		return deploymentCancellationConfirmed, nil
 	}
 
 	// The build status stream announces a normalized upstream image when the
@@ -820,12 +904,27 @@ func Deploy(ctx *Context, opts struct {
 
 			// Check if this was a context cancellation
 			if buildCtx.Err() != nil {
+				if serverOwnsDeployment {
+					outcome, cancelErr := requestDeploymentCancellation()
+					if cancelErr != nil {
+						ctx.Printf("\n\n❌ Deploy interrupted, but cancellation could not be confirmed.\n%s\n", cancelErr)
+						return fmt.Errorf("deploy interrupted without confirmed cancellation: %w", cancelErr)
+					}
+					if outcome == deploymentCancellationCompleted {
+						ctx.Printf("\n\n✅ Deploy completed before cancellation.\n")
+						return nil
+					}
+				}
 				ctx.Printf("\n\n❌ Deploy cancelled.\n")
 				// Don't update deployment status - it's already cancelled
 				if !wasExternallyCancelled() {
 					updateDeploymentOnError("Deploy cancelled by user")
 				}
 				return buildCtx.Err()
+			}
+			if serverOwnsDeployment && isDeploymentCancelled(err) {
+				ctx.Printf("\n\n❌ Deploy cancelled.\n")
+				return err
 			}
 
 			// Check if this was a server panic
@@ -921,6 +1020,17 @@ func Deploy(ctx *Context, opts struct {
 			// Check if this was a user interruption (via UI flag or context cancellation)
 			dm, isDeploy := buildFinalModel.(*deployInfo)
 			if (isDeploy && dm.interrupted) || deployCtx.Err() != nil {
+				if serverOwnsDeployment {
+					outcome, cancelErr := requestDeploymentCancellation()
+					if cancelErr != nil {
+						ctx.Printf("\n\n❌ Deploy interrupted, but cancellation could not be confirmed.\n%s\n", cancelErr)
+						return fmt.Errorf("deploy interrupted without confirmed cancellation: %w", cancelErr)
+					}
+					if outcome == deploymentCancellationCompleted {
+						ctx.Printf("\n\n✅ Deploy completed before cancellation.\n")
+						return nil
+					}
+				}
 				ctx.Printf("\n\n❌ Deploy cancelled.\n")
 				// Don't update deployment status if externally cancelled - it's already cancelled
 				if !wasExternallyCancelled() {
@@ -933,6 +1043,10 @@ func Deploy(ctx *Context, opts struct {
 					return buildCtx.Err()
 				}
 				return context.Canceled
+			}
+			if serverOwnsDeployment && isDeploymentCancelled(err) {
+				ctx.Printf("\n\n❌ Deploy cancelled.\n")
+				return err
 			}
 
 			// Check if this was a server panic

--- a/cli/commands/deploy_cancel_test.go
+++ b/cli/commands/deploy_cancel_test.go
@@ -2,11 +2,63 @@ package commands
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"miren.dev/runtime/pkg/cond"
 )
+
+func TestIsDeploymentCancelled(t *testing.T) {
+	err := fmt.Errorf("build failed: %w", cond.RemoteError("deployment", "cancelled", "deployment cancelled"))
+	if !isDeploymentCancelled(err) {
+		t.Fatal("expected the deployment cancellation condition to survive wrapping")
+	}
+	if isDeploymentCancelled(cond.RemoteError("deployment", "conflict", "already active")) {
+		t.Fatal("a different deployment condition must not look cancelled")
+	}
+}
+
+func TestReconcileDeploymentCancellation(t *testing.T) {
+	cancelErr := errors.New("cancellation rejected")
+
+	tests := []struct {
+		name        string
+		status      string
+		statusErr   error
+		wantOutcome deploymentCancellationOutcome
+		wantErr     bool
+	}{
+		{name: "cancelled confirms cancellation", status: "cancelled", wantOutcome: deploymentCancellationConfirmed},
+		{name: "succeeded reports completion", status: "succeeded", wantOutcome: deploymentCancellationCompleted},
+		{name: "legacy active reports completion", status: "active", wantOutcome: deploymentCancellationCompleted},
+		{name: "in progress preserves cancellation error", status: "in_progress", wantOutcome: deploymentCancellationUnknown, wantErr: true},
+		{name: "status read failure preserves cancellation error", statusErr: context.DeadlineExceeded, wantOutcome: deploymentCancellationUnknown, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getter := &mockStatusGetter{
+				statuses: []string{tt.status},
+				errors:   []error{tt.statusErr},
+			}
+
+			outcome, err := reconcileDeploymentCancellation(t.Context(), "dep-123", getter, cancelErr)
+			if outcome != tt.wantOutcome {
+				t.Fatalf("outcome = %v, want %v", outcome, tt.wantOutcome)
+			}
+			if tt.wantErr && !errors.Is(err, cancelErr) {
+				t.Fatalf("error = %v, want wrapped cancellation error", err)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
 
 // mockStatusGetter is a test mock for deploymentStatusGetter
 type mockStatusGetter struct {

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -425,6 +425,10 @@ func (c *Context) DisplayTable(headers []string, rows [][]string) {
 }
 
 func (c *Context) RPCClient(name string) (*rpc.NetworkClient, error) {
+	return c.rpcClient(c, name)
+}
+
+func (c *Context) rpcClient(rpcCtx context.Context, name string) (*rpc.NetworkClient, error) {
 	// Nothing is printed unless this takes long enough to look like a hang.
 	defer c.startConnectNotice().Stop()
 
@@ -453,7 +457,7 @@ func (c *Context) RPCClient(name string) (*rpc.NetworkClient, error) {
 	// believing you were looking at something else. An error about the cluster
 	// you named beats correct-looking data about a cluster you didn't.
 	if c.ClusterConfig != nil && c.ClientConfig != nil {
-		cs, err = c.ClusterConfig.State(c, c.ClientConfig, opts...)
+		cs, err = c.ClusterConfig.State(rpcCtx, c.ClientConfig, opts...)
 		if err != nil {
 			return nil, c.unusableClusterError(c.ClusterName, err)
 		}
@@ -475,7 +479,7 @@ func (c *Context) RPCClient(name string) (*rpc.NetworkClient, error) {
 			return nil, c.noActiveClusterError()
 		}
 
-		cs, err = c.ClientConfig.State(c, opts...)
+		cs, err = c.ClientConfig.State(rpcCtx, opts...)
 		if err == nil {
 			client, err := cs.Client(name)
 			if err != nil {
@@ -500,7 +504,7 @@ func (c *Context) RPCClient(name string) (*rpc.NetworkClient, error) {
 		c.Log.Debug("Client config could not provide RPC state", "error", err)
 	}
 
-	cs, err = rpc.NewState(c, append(opts, rpc.WithSkipVerify)...)
+	cs, err = rpc.NewState(rpcCtx, append(opts, rpc.WithSkipVerify)...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/detach.go
+++ b/pkg/rpc/detach.go
@@ -1,0 +1,34 @@
+package rpc
+
+import "context"
+
+type serverLifetimeContextKey struct{}
+
+// contextWithServerLifetime records the server process context on an RPC
+// handler context. A handler may then detach long-running work from the client
+// transport without also detaching it from server shutdown.
+func contextWithServerLifetime(ctx, lifetime context.Context) context.Context {
+	if lifetime == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, serverLifetimeContextKey{}, lifetime)
+}
+
+// Detach returns a context that preserves the caller's values but does not end
+// when its transport goes away. When called by an RPC handler, the returned
+// context remains tied to the server process lifetime. Outside RPC dispatch it
+// falls back to context.WithoutCancel, which keeps the helper useful in direct
+// unit tests.
+func Detach(ctx context.Context) (context.Context, context.CancelFunc) {
+	detached, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	lifetime, _ := ctx.Value(serverLifetimeContextKey{}).(context.Context)
+	if lifetime == nil {
+		return detached, cancel
+	}
+
+	stop := context.AfterFunc(lifetime, cancel)
+	return detached, func() {
+		stop()
+		cancel()
+	}
+}

--- a/pkg/rpc/detach_test.go
+++ b/pkg/rpc/detach_test.go
@@ -1,0 +1,38 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type detachValueKey struct{}
+
+func TestDetachIgnoresCallerCancellationAndPreservesValues(t *testing.T) {
+	request, cancelRequest := context.WithCancel(context.WithValue(context.Background(), detachValueKey{}, "kept"))
+	detached, cancelDetached := Detach(request)
+	defer cancelDetached()
+
+	cancelRequest()
+
+	assert.NoError(t, detached.Err())
+	assert.Equal(t, "kept", detached.Value(detachValueKey{}))
+}
+
+func TestDetachStopsWithServerLifetime(t *testing.T) {
+	lifetime, stopServer := context.WithCancel(context.Background())
+	request, cancelRequest := context.WithCancel(context.Background())
+	request = contextWithServerLifetime(request, lifetime)
+	detached, cancelDetached := Detach(request)
+	defer cancelDetached()
+
+	cancelRequest()
+	assert.NoError(t, detached.Err())
+
+	stopServer()
+	require.Eventually(t, func() bool { return detached.Err() != nil }, time.Second, time.Millisecond)
+	assert.ErrorIs(t, detached.Err(), context.Canceled)
+}

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -1182,6 +1182,7 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 // panic over the control stream. It is transport-neutral: both the HTTP
 // callstream handler and the message-transport router use it.
 func (s *Server) runCallStream(ctx context.Context, cs *controlStream, mm Method, call *NetworkCall) {
+	ctx = contextWithServerLifetime(ctx, s.state.top)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -1329,6 +1330,7 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 			defer cancel()
 		}
 
+		ctx = contextWithServerLifetime(ctx, s.state.top)
 		err := mm.Handler(ctx, call)
 		if err != nil {
 			w.Header().Add("rpc-status", "error")

--- a/pkg/rpc/server_session.go
+++ b/pkg/rpc/server_session.go
@@ -470,6 +470,7 @@ func (s *Server) msgCall(ctx context.Context, dec *cbor.Decoder, enc *cbor.Encod
 // invokeUnary runs a unary handler, mirroring handleCalls (no cond.Wrap; panic
 // recovery), and returns the outcome.
 func (s *Server) invokeUnary(ctx context.Context, mm Method, call *NetworkCall) (oc callOutcome) {
+	ctx = contextWithServerLifetime(ctx, s.state.top)
 	defer func() {
 		if r := recover(); r != nil {
 			s.state.log.Error("panic in RPC handler",

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -29,6 +29,8 @@ var ErrRecoveryScopeMismatch = errors.New("execution recovery scope mismatch")
 type executorCtxKey struct{}
 type executionIDCtxKey struct{}
 type actionNameCtxKey struct{}
+type controlContextCtxKey struct{}
+type dedicatedActionContextCtxKey struct{}
 
 func executorFromContext(ctx context.Context) (*Executor, bool) {
 	e, ok := ctx.Value(executorCtxKey{}).(*Executor)
@@ -43,6 +45,19 @@ func executionIDFromContext(ctx context.Context) (string, bool) {
 func actionNameFromContext(ctx context.Context) (string, bool) {
 	name, ok := ctx.Value(actionNameCtxKey{}).(string)
 	return name, ok
+}
+
+func controlContextFromContext(ctx context.Context) context.Context {
+	controlCtx, ok := ctx.Value(controlContextCtxKey{}).(context.Context)
+	if !ok {
+		return ctx
+	}
+	return controlCtx
+}
+
+func hasDedicatedActionContext(ctx context.Context) bool {
+	dedicated, _ := ctx.Value(dedicatedActionContextCtxKey{}).(bool)
+	return dedicated
 }
 
 // Storage persists saga execution state.
@@ -171,10 +186,11 @@ func (e *Executor) scopeForExisting(exec *Execution) (adopt bool, err error) {
 
 // StartBuilder provides a fluent API for starting saga executions.
 type StartBuilder struct {
-	executor *Executor
-	defName  string
-	inputs   map[string]any
-	id       string
+	executor  *Executor
+	defName   string
+	inputs    map[string]any
+	id        string
+	actionCtx context.Context
 }
 
 // Start begins building a saga execution.
@@ -206,13 +222,27 @@ func (sb *StartBuilder) WithID(id string) *StartBuilder {
 	return sb
 }
 
+// WithActionContext gives actions a cancellation boundary separate from the
+// executor's control context. Persistence and compensation continue on the
+// control context passed to Execute. The default is to use that same context
+// for both, preserving existing saga behavior.
+func (sb *StartBuilder) WithActionContext(ctx context.Context) *StartBuilder {
+	sb.actionCtx = ctx
+	return sb
+}
+
 // Execute runs the saga to completion or failure.
 func (sb *StartBuilder) Execute(ctx context.Context) error {
-	return sb.executor.execute(ctx, sb.defName, sb.inputs, sb.id)
+	return sb.executor.execute(ctx, sb.actionCtx, sb.defName, sb.inputs, sb.id)
 }
 
 // execute runs a saga with the given definition and inputs.
-func (e *Executor) execute(ctx context.Context, defName string, inputs map[string]any, id string) error {
+func (e *Executor) execute(ctx, actionCtx context.Context, defName string, inputs map[string]any, id string) error {
+	if actionCtx == nil {
+		actionCtx = ctx
+	} else {
+		actionCtx = context.WithValue(actionCtx, dedicatedActionContextCtxKey{}, true)
+	}
 	// Look up definition
 	def, ok := e.registry.Get(defName)
 	if !ok {
@@ -270,7 +300,7 @@ func (e *Executor) execute(ctx context.Context, defName string, inputs map[strin
 		}
 		e.log.Info("continuing existing execution",
 			"saga", defName, "execution", id, "status", existing.Status)
-		return e.resume(ctx, def, existing)
+		return e.resumeWithActionContext(ctx, actionCtx, def, existing)
 	}
 
 	// Create execution
@@ -293,11 +323,11 @@ func (e *Executor) execute(ctx context.Context, defName string, inputs map[strin
 		return fmt.Errorf("persisting initial state: %w", err)
 	}
 
-	return e.runExecution(ctx, def, exec)
+	return e.runExecution(ctx, actionCtx, def, exec)
 }
 
 // runExecution executes or resumes a saga.
-func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Execution) error {
+func (e *Executor) runExecution(ctx, actionCtx context.Context, def *Definition, exec *Execution) error {
 	log := e.log.With("saga", def.Name, "execution", exec.ID)
 
 	// Update status to running
@@ -311,6 +341,10 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 	ctx = injectDependencies(ctx, def.dependencies)
 	ctx = context.WithValue(ctx, executorCtxKey{}, e)
 	ctx = context.WithValue(ctx, executionIDCtxKey{}, exec.ID)
+	actionCtx = injectDependencies(actionCtx, def.dependencies)
+	actionCtx = context.WithValue(actionCtx, executorCtxKey{}, e)
+	actionCtx = context.WithValue(actionCtx, executionIDCtxKey{}, exec.ID)
+	actionCtx = context.WithValue(actionCtx, controlContextCtxKey{}, ctx)
 
 	// Build outputs map from already-executed actions
 	outputs := make(map[string]json.RawMessage)
@@ -359,13 +393,26 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 
 		log.Info("executing action", "action", actionName)
 
-		// Execute the action
-		actionCtx := context.WithValue(ctx, actionNameCtxKey{}, actionName)
-		output, err := node.Action.Execute(actionCtx, actionInputs)
+		// Execute the action. Cancellation of a dedicated action context is a
+		// normal saga failure, even if it lands between steps. Do not let an
+		// action that ignores its context mutate more state after cancellation.
+		currentActionCtx := context.WithValue(actionCtx, actionNameCtxKey{}, actionName)
+		var output any
+		var err error
+		if actionErr := currentActionCtx.Err(); actionErr != nil {
+			err = actionErr
+		} else {
+			output, err = node.Action.Execute(currentActionCtx, actionInputs)
+		}
 		now := time.Now()
 
 		if err != nil {
-			log.Error("action failed", "action", actionName, "error", err)
+			actionErr := currentActionCtx.Err()
+			if hasDedicatedActionContext(currentActionCtx) && actionErr != nil && errors.Is(err, actionErr) {
+				log.Info("action cancelled, starting compensation", "action", actionName, "error", err)
+			} else {
+				log.Error("action failed", "action", actionName, "error", err)
+			}
 
 			// Record the failure
 			exec.ExecutedActions[actionName] = &ActionResult{
@@ -455,12 +502,45 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 			return e.runUndo(ctx, def, exec)
 		}
 
+		// An action may ignore cancellation and still return success after mutating
+		// state. Its output must be durable before we compensate it. Only a
+		// dedicated action context takes this path; cancellation of the shared
+		// control context keeps the historical interruption-and-recovery behavior.
+		if hasDedicatedActionContext(currentActionCtx) {
+			if actionErr := currentActionCtx.Err(); actionErr != nil {
+				log.Info("action completed after cancellation, starting compensation", "action", actionName, "error", actionErr)
+				exec.Error = fmt.Sprintf("action %q completed after cancellation: %v", actionName, actionErr)
+				exec.Status = StatusUndoing
+				exec.UpdatedAt = time.Now()
+				if saveErr := e.storage.Save(ctx, exec); saveErr != nil {
+					log.Error("failed to persist undoing state", "error", saveErr)
+				}
+				return e.runUndo(ctx, def, exec)
+			}
+		}
+
 		// Add outputs to the map for subsequent actions
 		if err := extractOutputs(node, outputBytes, outputs); err != nil {
 			log.Warn("failed to extract outputs", "action", actionName, "error", err)
 		}
 
 		log.Info("action completed", "action", actionName)
+	}
+
+	// A resumed execution may skip every already-persisted action, so the
+	// per-action cancellation checkpoint above never runs. Do not let that path
+	// turn a cancelled deployment into a completed saga with live side effects.
+	if hasDedicatedActionContext(actionCtx) {
+		if actionErr := actionCtx.Err(); actionErr != nil {
+			log.Info("action context cancelled before completion, starting compensation", "error", actionErr)
+			exec.Error = fmt.Sprintf("action context cancelled before completion: %v", actionErr)
+			exec.Status = StatusUndoing
+			exec.UpdatedAt = time.Now()
+			if saveErr := e.storage.Save(ctx, exec); saveErr != nil {
+				log.Error("failed to persist undoing state", "error", saveErr)
+			}
+			return e.runUndo(ctx, def, exec)
+		}
 	}
 
 	// All actions completed successfully
@@ -669,6 +749,10 @@ func (e *Executor) Recover(ctx context.Context) error {
 // retrying that is a decision for whoever owns the operation, not something to
 // do implicitly under the same name.
 func (e *Executor) resume(ctx context.Context, def *Definition, exec *Execution) error {
+	return e.resumeWithActionContext(ctx, ctx, def, exec)
+}
+
+func (e *Executor) resumeWithActionContext(ctx, actionCtx context.Context, def *Definition, exec *Execution) error {
 	// A name that means one saga to the caller and another to the record is an
 	// id collision, and resuming across it would run this definition's actions
 	// against the other's recorded outputs. Naming executions after entities
@@ -695,7 +779,7 @@ func (e *Executor) resume(ctx context.Context, def *Definition, exec *Execution)
 				"saga", exec.DefinitionName, "error", exec.Error)
 			return e.runUndo(ctx, def, exec)
 		}
-		return e.runExecution(ctx, def, exec)
+		return e.runExecution(ctx, actionCtx, def, exec)
 	case StatusUndoing:
 		return e.runUndo(ctx, def, exec)
 	case StatusCompleted:

--- a/pkg/saga/nested.go
+++ b/pkg/saga/nested.go
@@ -88,13 +88,14 @@ func RunNested(ctx context.Context, sagaName string, opts ...NestedOption) (*Nes
 		actionName, _ := actionNameFromContext(ctx)
 		childID = deriveChildID(parentExecID, sagaName, actionName)
 	}
-	exec, err := parent.createChildExecution(ctx, def, cfg.inputs, childID, parentExecID)
+	controlCtx := controlContextFromContext(ctx)
+	exec, err := parent.createChildExecution(controlCtx, def, cfg.inputs, childID, parentExecID)
 	if err != nil {
 		return nil, fmt.Errorf("creating nested execution: %w", err)
 	}
 
 	// Run the child saga
-	if err := parent.runExecution(ctx, def, exec); err != nil {
+	if err := parent.runExecution(controlCtx, ctx, def, exec); err != nil {
 		return nil, err
 	}
 

--- a/pkg/saga/nested_test.go
+++ b/pkg/saga/nested_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -221,6 +222,80 @@ func TestRunNested_ChildFailurePropagates(t *testing.T) {
 	// Child step was called, and parent undo should not call UndoNested
 	// because ParentStep itself failed (so ParentStepOut is empty)
 	assert.Equal(t, 1, ctrl.childCalls)
+}
+
+func TestRunNested_ActionCancellationStillCompensatesChild(t *testing.T) {
+	registry := NewRegistry()
+	ctrl := &testController{}
+	started := make(chan struct{}, 1)
+	waitForCancellation := func(ctx context.Context, _ MultiplyIn) (MultiplyOut, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		return MultiplyOut{}, ctx.Err()
+	}
+
+	err := Define("cancel-child").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("wait", waitForCancellation).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	runChild := func(ctx context.Context, in AddNumbersIn) (AddNumbersOut, error) {
+		_, err := RunNested(ctx, "cancel-child",
+			WithNestedID("cancel-child-1"),
+			WithNestedInput("a", in.A),
+			WithNestedInput("b", in.B),
+			WithNestedInput("factor", 2),
+		)
+		return AddNumbersOut{}, err
+	}
+	undoParent := func(context.Context, AddNumbersIn, AddNumbersOut) error { return nil }
+	err = Define("cancel-parent").
+		Using(ctrl).
+		Action("nested", runChild).Undo(undoParent).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+	actionCtx, cancelAction := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.Start("cancel-parent").
+			Input("a", 2).
+			Input("b", 3).
+			WithActionContext(actionCtx).
+			WithID("cancel-parent-1").
+			Execute(context.Background())
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("nested child did not reach cancellable action")
+	}
+	cancelAction()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("nested child did not finish compensation")
+	}
+
+	child, err := storage.Get(context.Background(), "cancel-child-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, child.Status)
+	assert.NotNil(t, child.ExecutedActions["add"].UndoneAt)
+	assert.Len(t, ctrl.undoAddCalls, 1)
+
+	parent, err := storage.Get(context.Background(), "cancel-parent-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, parent.Status)
 }
 
 func TestRunNested_ChildUsesParentStorage(t *testing.T) {

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -246,6 +246,146 @@ func TestExecutor_FailureAndUndo(t *testing.T) {
 	assert.Equal(t, StatusFailed, exec.Status)
 }
 
+func TestExecutor_ActionCancellationStillCompensates(t *testing.T) {
+	registry := NewRegistry()
+	ctrl := &testController{}
+	started := make(chan struct{})
+	waitForCancellation := func(ctx context.Context, _ MultiplyIn) (MultiplyOut, error) {
+		close(started)
+		<-ctx.Done()
+		return MultiplyOut{}, ctx.Err()
+	}
+
+	err := Define("action-context-cancel").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("wait", waitForCancellation).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+	actionCtx, cancelAction := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.Start("action-context-cancel").
+			Input("a", 2).
+			Input("b", 3).
+			Input("factor", 4).
+			WithActionContext(actionCtx).
+			WithID("action-context-cancel-1").
+			Execute(context.Background())
+	}()
+
+	<-started
+	cancelAction()
+	require.Error(t, <-done)
+	assert.Len(t, ctrl.undoAddCalls, 1,
+		"the live control context must carry compensation after action cancellation")
+
+	exec, err := storage.Get(context.Background(), "action-context-cancel-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, exec.Status)
+}
+
+func TestExecutor_ActionCancellationAfterSuccessCompensates(t *testing.T) {
+	registry := NewRegistry()
+	ctrl := &testController{}
+	started := make(chan struct{}, 1)
+	completeAfterCancellation := func(ctx context.Context, in AddNumbersIn) (AddNumbersOut, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		ctrl.recordAdd(in)
+		return AddNumbersOut{Sum: in.A + in.B}, nil
+	}
+
+	err := Define("action-context-success-after-cancel").
+		Using(ctrl).
+		Action("add", completeAfterCancellation).Undo(UndoAddNumbers).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+	actionCtx, cancelAction := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.Start("action-context-success-after-cancel").
+			Input("a", 2).
+			Input("b", 3).
+			WithActionContext(actionCtx).
+			WithID("action-context-success-after-cancel-1").
+			Execute(context.Background())
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("action did not start")
+	}
+	cancelAction()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("successful action did not finish compensation")
+	}
+
+	assert.Len(t, ctrl.undoAddCalls, 1)
+	exec, err := storage.Get(context.Background(), "action-context-success-after-cancel-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, exec.Status)
+	assert.NotNil(t, exec.ExecutedActions["add"].UndoneAt)
+}
+
+func TestExecutor_ResumedExecutionChecksActionCancellationBeforeCompletion(t *testing.T) {
+	registry := NewRegistry()
+	ctrl := &testController{}
+	err := Define("resumed-action-context-cancel").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	now := time.Now()
+	require.NoError(t, storage.Save(context.Background(), &Execution{
+		ID:                "resumed-action-context-cancel-1",
+		DefinitionName:    "resumed-action-context-cancel",
+		DefinitionVersion: 1,
+		InitialInputs:     map[string]any{"a": 2, "b": 3},
+		Status:            StatusRunning,
+		ExecutedActions: map[string]*ActionResult{
+			"add": {
+				Output:     []byte(`{"Sum":5}`),
+				ExecutedAt: now,
+			},
+		},
+		ExecutionOrder: []string{"add"},
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}))
+
+	actionCtx, cancelAction := context.WithCancel(context.Background())
+	cancelAction()
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err = executor.Start("resumed-action-context-cancel").
+		WithActionContext(actionCtx).
+		WithID("resumed-action-context-cancel-1").
+		Execute(context.Background())
+	require.Error(t, err)
+
+	assert.Len(t, ctrl.undoAddCalls, 1)
+	exec, err := storage.Get(context.Background(), "resumed-action-context-cancel-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, exec.Status)
+	assert.NotNil(t, exec.ExecutedActions["add"].UndoneAt)
+}
+
 func TestExecutor_Recovery(t *testing.T) {
 	registry := NewRegistry()
 

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1345,6 +1345,12 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		return rpc.AppAccessError(ctx, name)
 	}
 
+	requestCtx := ctx
+	work := newDeploymentContext(ctx)
+	defer work.Close()
+	defer func() { retErr = work.result(retErr) }()
+	ctx = work.action
+
 	status := args.Status()
 
 	eph := ephemeralOptsFromArgs(args.HasEphemeralLabel(), args.EphemeralLabel(),
@@ -1384,7 +1390,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	// -- build.receive_tar span
 	ctx, recvSpan := buildTracer.Start(ctx, "build.receive_tar",
 		trace.WithAttributes(attribute.String("miren.app.name", name)))
-	r := stream.ToReader(ctx, td)
+	r := stream.ToReader(requestCtx, td)
 
 	_, err = tarx.TarFS(r, path)
 	if err != nil {
@@ -1513,6 +1519,12 @@ func (b *Builder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.Bu
 		return rpc.AppAccessError(ctx, name)
 	}
 
+	requestCtx := ctx
+	work := newDeploymentContext(ctx)
+	defer work.Close()
+	defer func() { retErr = work.result(retErr) }()
+	ctx = work.action
+
 	status := args.Status()
 
 	eph := ephemeralOptsFromArgs(args.HasEphemeralLabel(), args.EphemeralLabel(),
@@ -1539,7 +1551,7 @@ func (b *Builder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.Bu
 			_, _ = status.Send(ctx, so)
 		}
 
-		r := stream.ToReader(ctx, td)
+		r := stream.ToReader(requestCtx, td)
 		_, err := tarx.TarFS(r, sess.dir)
 		if err != nil {
 			b.sendErrorStatus(ctx, status, "Error extracting changed files: %v", err)

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -778,8 +778,11 @@ func beginDeployment(ctx context.Context, in beginDeploymentIn) (beginDeployment
 	}
 
 	id := string(rec.Deployment.ID)
-	b.trackDeployment(id, deps.statuses.SenderFor(in.StreamID)).
-		emit(string(deploylifecycle.PhasePreparing))
+	tracking := b.trackDeployment(id, deps.statuses.SenderFor(in.StreamID))
+	if work := deploymentContextFrom(ctx); work != nil {
+		work.attach(tracking)
+	}
+	tracking.emit(string(deploylifecycle.PhasePreparing))
 	return beginDeploymentOut{DeploymentID: id}, nil
 }
 

--- a/servers/build/build_saga_deploy_test.go
+++ b/servers/build/build_saga_deploy_test.go
@@ -2,9 +2,11 @@ package build
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +14,7 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
@@ -27,8 +30,7 @@ func newDeploySagaHarness(t *testing.T) *sagaTestHarness {
 }
 
 // newDeploySagaHarnessWith is newDeploySagaHarness with a substitute
-// set-active-version action, so a test can wedge behaviour into the window
-// between the version going live and the deployment record settling.
+// set-active-version action, so tests can control the activation window.
 func newDeploySagaHarnessWith(t *testing.T, setActive any) *sagaTestHarness {
 	t.Helper()
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -287,21 +289,15 @@ func TestBuildSaga_CancellationBeforeActivationFailsDeploy(t *testing.T) {
 	assert.Nil(t, blocking, "a failed settle must not strand the deploy lock")
 }
 
-// A client that disappears mid-build must not leave the app locked.
-//
-// A disconnect cancels the saga's context, and the executor's undo loop bails
-// on a cancelled context by design, so undoBeginDeployment never runs and the
-// deployment record would be left in_progress holding the deploy lock for its
-// full TTL. The saga entry point settles it directly for exactly this case,
-// mirroring the plain path's deferred failOnError.
-func TestBuildSaga_Tracked_ClientDisconnectDoesNotStrandLock(t *testing.T) {
+// A client that disappears after upload must not stop the server-owned build.
+func TestBuildSaga_Tracked_ClientDisconnectStillActivates(t *testing.T) {
 	ctx, disconnect := context.WithCancel(context.Background())
 
-	// Stand in for the client vanishing partway through: cancel the saga's
-	// context from inside an action and fail the way a cancelled call would.
+	// Stand in for the client vanishing partway through, while the server still
+	// has everything it needs to finish.
 	dropped := func(ctx context.Context, in setActiveVersionIn) (setActiveVersionOut, error) {
 		disconnect()
-		return setActiveVersionOut{}, context.Canceled
+		return setActiveVersion(ctx, in)
 	}
 
 	h := newDeploySagaHarnessWith(t, dropped)
@@ -310,26 +306,94 @@ func TestBuildSaga_Tracked_ClientDisconnectDoesNotStrandLock(t *testing.T) {
 	sb := &SagaBuilder{
 		inner:    h.builder,
 		executor: h.executor,
-		storage:  h.storage,
 		log:      slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
 	}
 
 	req := &build_v1alpha.DeployRequest{}
 	req.SetClusterId("prod")
 
-	err := sb.startBuild(ctx, "test-drop", "demo", "stream-drop", nil, nil, req)
-	require.Error(t, err, "a cancelled build must still fail the RPC")
+	work := newDeploymentContext(ctx)
+	defer work.Close()
+	err := sb.startBuild(work.control, work.action, "test-drop", "demo", "stream-drop", nil, nil, req)
+	require.NoError(t, err)
 
 	// Reads below use a live context; the saga's is deliberately dead.
 	records, err := h.builder.deploy.Store().List(context.Background(), deploylifecycle.Query{AppName: "demo"})
 	require.NoError(t, err)
 	require.Len(t, records, 1)
-	assert.Equal(t, deploylifecycle.StatusFailed, records[0].Status(),
-		"an abandoned deployment must settle rather than linger in_progress")
+	assert.Equal(t, deploylifecycle.StatusSucceeded, records[0].Status())
 
 	blocking, err := h.builder.deploy.Locks().Blocking(context.Background(), "demo")
 	require.NoError(t, err)
-	assert.Nil(t, blocking, "the next deploy of this app must not wait out the lock TTL")
+	assert.Nil(t, blocking)
+}
+
+// Cancelling the deployment record is the build's control plane. It stops the
+// current action, but the saga's server-owned context remains live long enough
+// to persist the failure and compensate everything it already created.
+func TestBuildSaga_Tracked_RecordCancellationCompensates(t *testing.T) {
+	ctx := context.Background()
+	activeStarted := make(chan struct{}, 1)
+	waitForCancellation := func(ctx context.Context, _ setActiveVersionIn) (setActiveVersionOut, error) {
+		select {
+		case activeStarted <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		return setActiveVersionOut{}, ctx.Err()
+	}
+
+	h := newDeploySagaHarnessWith(t, waitForCancellation)
+	h.streams.Register("stream-cancel", makeTar(t, dockerfileTarball(t)))
+	sb := &SagaBuilder{
+		inner:    h.builder,
+		executor: h.executor,
+		log:      slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+	req := &build_v1alpha.DeployRequest{}
+	req.SetClusterId("prod")
+	work := newDeploymentContext(ctx)
+	defer work.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sb.startBuild(work.control, work.action, "test-cancel", "demo", "stream-cancel", nil, nil, req)
+	}()
+	select {
+	case <-activeStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("build did not reach the cancellable action")
+	}
+
+	records, err := h.builder.deploy.Store().List(ctx, deploylifecycle.Query{AppName: "demo"})
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.NoError(t, h.builder.deploy.Cancel(ctx, string(records[0].Deployment.ID), "operator cancelled"))
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		remote, ok := errors.AsType[cond.ErrRemote](work.result(err))
+		require.True(t, ok)
+		assert.Equal(t, "deployment", remote.Category)
+		assert.Equal(t, "cancelled", remote.Code)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled build did not finish compensation")
+	}
+
+	exec, err := h.storage.Get(ctx, "test-cancel")
+	require.NoError(t, err)
+	assert.Equal(t, saga.StatusFailed, exec.Status)
+	assert.NotNil(t, exec.ExecutedActions[actionCreateVersion].UndoneAt)
+
+	records, err = h.builder.deploy.Store().List(ctx, deploylifecycle.Query{AppName: "demo"})
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, deploylifecycle.StatusCancelled, records[0].Status())
+
+	blocking, err := h.builder.deploy.Locks().Blocking(ctx, "demo")
+	require.NoError(t, err)
+	assert.Nil(t, blocking)
 }
 
 // The saga path must advance the record's phase, not park it at "preparing"

--- a/servers/build/deploy_tracking.go
+++ b/servers/build/deploy_tracking.go
@@ -8,6 +8,7 @@ import (
 
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/rpc/standard"
 	"miren.dev/runtime/pkg/rpc/stream"
@@ -19,6 +20,7 @@ import (
 // saga that predates server-owned attempts). Every method is then a no-op.
 type deployTracking struct {
 	tracker      *deploylifecycle.Tracker
+	eac          *entityserver_v1alpha.EntityAccessClient
 	deploymentID string
 	source       core_v1alpha.Source
 	status       StatusSender
@@ -40,6 +42,7 @@ func (b *Builder) trackDeployment(deploymentID string, status StatusSender) *dep
 	}
 	return &deployTracking{
 		tracker:      b.deploy,
+		eac:          b.EAS,
 		deploymentID: deploymentID,
 		status:       status,
 		log:          b.Log.With("deployment_id", deploymentID),
@@ -89,6 +92,9 @@ func (b *Builder) beginDeploy(
 
 	dt := b.trackDeployment(string(rec.Deployment.ID), NewRPCStatusSender(status, b.Log))
 	dt.source = deploylifecycle.SourceFromGitInfo(gitInfo)
+	if work := deploymentContextFrom(ctx); work != nil {
+		work.attach(dt)
+	}
 
 	// Announce the record and its opening phase so the client can display and
 	// cancel a deployment it did not create.

--- a/servers/build/deploy_tracking_test.go
+++ b/servers/build/deploy_tracking_test.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc/standard"
@@ -176,6 +178,25 @@ func TestFailOnErrorSettlesEvenWhenContextCancelled(t *testing.T) {
 	rec, err := b.deploy.Store().Get(context.Background(), dt.deploymentID)
 	require.NoError(t, err)
 	assert.Equal(t, deploylifecycle.StatusFailed, rec.Status())
+}
+
+func TestDeploymentContextCancelsWhenRecordIsCancelled(t *testing.T) {
+	b := newDeployTestBuilder(t)
+	work := newDeploymentContext(context.Background())
+	defer work.Close()
+
+	dt, err := b.beginDeploy(work.action, "web", deployRequest("prod"), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, b.deploy.Cancel(context.Background(), dt.deploymentID, "operator cancelled"))
+
+	require.Eventually(t, func() bool {
+		return errors.Is(context.Cause(work.action), errDeploymentCancelled)
+	}, 5*time.Second, 10*time.Millisecond)
+
+	remote, ok := errors.AsType[cond.ErrRemote](work.result(work.action.Err()))
+	require.True(t, ok)
+	assert.Equal(t, "deployment", remote.Category)
+	assert.Equal(t, "cancelled", remote.Code)
 }
 
 // When activation fails after the version is already live, the plain path must

--- a/servers/build/deployment_context.go
+++ b/servers/build/deployment_context.go
@@ -1,0 +1,123 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/deploylifecycle"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/indexwatch"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+var errDeploymentCancelled = errors.New("deployment cancelled")
+
+type deploymentContextKey struct{}
+
+// deploymentContext separates the server-owned lifetime of a build from the
+// context its actions use. CancelDeployment ends the action context while the
+// control context remains live for saga persistence and compensation.
+type deploymentContext struct {
+	control       context.Context
+	action        context.Context
+	cancelAction  context.CancelCauseFunc
+	cancelControl context.CancelFunc
+
+	mu       sync.Mutex
+	watchers []*indexwatch.Watcher
+	closed   bool
+}
+
+func newDeploymentContext(requestCtx context.Context) *deploymentContext {
+	control, cancelControl := rpc.Detach(requestCtx)
+	action, cancelAction := context.WithCancelCause(control)
+	d := &deploymentContext{
+		control:       control,
+		action:        action,
+		cancelAction:  cancelAction,
+		cancelControl: cancelControl,
+	}
+	d.action = context.WithValue(d.action, deploymentContextKey{}, d)
+	return d
+}
+
+func deploymentContextFrom(ctx context.Context) *deploymentContext {
+	d, _ := ctx.Value(deploymentContextKey{}).(*deploymentContext)
+	return d
+}
+
+func (d *deploymentContext) result(err error) error {
+	if errors.Is(context.Cause(d.action), errDeploymentCancelled) {
+		return cond.ErrRemote{Category: "deployment", Code: "cancelled", Message: "deployment cancelled"}
+	}
+	return err
+}
+
+func (d *deploymentContext) attach(t *deployTracking) {
+	if d == nil || t == nil || t.eac == nil {
+		return
+	}
+
+	w := indexwatch.New(t.eac, entity.Ref(entity.DBId, entity.Id(t.deploymentID)), indexwatch.Options{
+		Logger:     t.log,
+		BufferSize: 4,
+	})
+
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return
+	}
+	d.watchers = append(d.watchers, w)
+	d.mu.Unlock()
+
+	_ = w.Start(d.action)
+	go func() {
+		for {
+			select {
+			case <-d.action.Done():
+				return
+			case _, ok := <-w.Updates():
+				if !ok {
+					return
+				}
+
+				status, err := t.tracker.Store().Status(d.action, t.deploymentID)
+				if err != nil {
+					if d.action.Err() == nil {
+						t.log.Warn("failed to read deployment while watching cancellation", "error", err)
+					}
+					continue
+				}
+				if status == deploylifecycle.StatusCancelled {
+					t.log.Info("deployment cancellation received")
+					d.cancelAction(errDeploymentCancelled)
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (d *deploymentContext) Close() {
+	if d == nil {
+		return
+	}
+
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		return
+	}
+	d.closed = true
+	watchers := append([]*indexwatch.Watcher(nil), d.watchers...)
+	d.mu.Unlock()
+
+	d.cancelAction(nil)
+	for _, w := range watchers {
+		w.Stop()
+	}
+	d.cancelControl()
+}

--- a/servers/build/saga_builder.go
+++ b/servers/build/saga_builder.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -53,11 +52,6 @@ type SagaBuilder struct {
 	streams  *StreamRegistry
 	statuses *StatusRegistry
 	log      *slog.Logger
-
-	// storage is the same handle the executor holds. It is retained so a
-	// failed build can read its own execution back, which ExecutionOutputs
-	// cannot do — that helper requires a completed saga.
-	storage saga.Storage
 }
 
 // NewSagaBuilder constructs a SagaBuilder over an existing Builder. The
@@ -80,7 +74,6 @@ func NewSagaBuilder(inner *Builder, sagaStorage saga.Storage, log *slog.Logger) 
 		streams:  streams,
 		statuses: statuses,
 		log:      log.With("module", "saga-builder"),
-		storage:  sagaStorage,
 	}
 }
 
@@ -114,12 +107,15 @@ func (s *SagaBuilder) Recover(ctx context.Context) error {
 // Stream registration, status sender registration, and saga start all
 // key off the same generated stream ID so the saga's actions can find
 // the live reader and status sink by ID alone.
-func (s *SagaBuilder) BuildFromTar(ctx context.Context, state *build_v1alpha.BuilderBuildFromTar) error {
+func (s *SagaBuilder) BuildFromTar(ctx context.Context, state *build_v1alpha.BuilderBuildFromTar) (retErr error) {
 	args := state.Args()
 	name := args.Application()
 	if !rpc.AllowApp(ctx, name) {
 		return rpc.AppAccessError(ctx, name)
 	}
+	work := newDeploymentContext(ctx)
+	defer work.Close()
+	defer func() { retErr = work.result(retErr) }()
 
 	streamID := idgen.Gen("bt")
 	status := args.Status()
@@ -144,11 +140,11 @@ func (s *SagaBuilder) BuildFromTar(ctx context.Context, state *build_v1alpha.Bui
 	}
 
 	executionID := "build-from-tar-" + streamID
-	if err := s.startBuild(ctx, executionID, name, streamID, args.EnvVars(), ephemeralFromArgs(args), deployReq); err != nil {
+	if err := s.startBuild(work.control, work.action, executionID, name, streamID, args.EnvVars(), ephemeralFromArgs(args), deployReq); err != nil {
 		return err
 	}
 
-	return s.populateResults(ctx, executionID, name, state.Results(), ephemeralLabelFromArgs(args))
+	return s.populateResults(work.control, executionID, name, state.Results(), ephemeralLabelFromArgs(args))
 }
 
 // BuildFromPrepared mirrors BuildFromTar but starts from an upload
@@ -156,7 +152,7 @@ func (s *SagaBuilder) BuildFromTar(ctx context.Context, state *build_v1alpha.Bui
 // stays out of the saga (it's a pre-flight check, not a step we'd
 // want to retry on recovery), then MarkStaged tells the registry the
 // path is ready so the saga's receive-tar action returns it directly.
-func (s *SagaBuilder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.BuilderBuildFromPrepared) error {
+func (s *SagaBuilder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.BuilderBuildFromPrepared) (retErr error) {
 	args := state.Args()
 	sessionID := args.SessionId()
 
@@ -171,6 +167,9 @@ func (s *SagaBuilder) BuildFromPrepared(ctx context.Context, state *build_v1alph
 	if !rpc.AllowApp(ctx, name) {
 		return rpc.AppAccessError(ctx, name)
 	}
+	work := newDeploymentContext(ctx)
+	defer work.Close()
+	defer func() { retErr = work.result(retErr) }()
 
 	status := args.Status()
 	sender := NewRPCStatusSender(status, s.inner.Log)
@@ -209,11 +208,11 @@ func (s *SagaBuilder) BuildFromPrepared(ctx context.Context, state *build_v1alph
 	}
 
 	executionID := "build-from-prepared-" + sessionID
-	if err := s.startBuild(ctx, executionID, name, sessionID, args.EnvVars(), ephemeralFromArgs(args), deployReq); err != nil {
+	if err := s.startBuild(work.control, work.action, executionID, name, sessionID, args.EnvVars(), ephemeralFromArgs(args), deployReq); err != nil {
 		return err
 	}
 
-	return s.populateResults(ctx, executionID, name, state.Results(), ephemeralLabelFromArgs(args))
+	return s.populateResults(work.control, executionID, name, state.Results(), ephemeralLabelFromArgs(args))
 }
 
 // PrepareUpload is a session-management op, not a build, so it routes
@@ -229,7 +228,7 @@ func (s *SagaBuilder) AnalyzeApp(ctx context.Context, state *build_v1alpha.Build
 
 // startBuild fans out the initial inputs and runs the saga.
 func (s *SagaBuilder) startBuild(
-	ctx context.Context,
+	ctx, actionCtx context.Context,
 	executionID, appName, streamID string,
 	cliEnvVars []*build_v1alpha.EnvironmentVariable,
 	eph *ephemeralOpts,
@@ -238,6 +237,7 @@ func (s *SagaBuilder) startBuild(
 	sb := s.executor.Start(sagaBuildFromTar).
 		Input("app_name", appName).
 		Input("stream_id", streamID).
+		WithActionContext(actionCtx).
 		WithID(executionID)
 
 	if len(cliEnvVars) > 0 {
@@ -267,59 +267,9 @@ func (s *SagaBuilder) startBuild(
 	}
 
 	if err := sb.Execute(ctx); err != nil {
-		s.settleAbandonedDeployment(ctx, executionID, err)
 		return fmt.Errorf("build saga: %w", err)
 	}
 	return nil
-}
-
-// settleAbandonedDeployment settles the server-owned deployment record for a
-// saga that failed without compensating it.
-//
-// The case that needs this is a client disconnect. It cancels the saga's
-// context, and the executor's undo loop bails out on a cancelled context by
-// design, leaving the execution in Undoing for recovery to finish after a
-// restart. That is the right call for the build's own artifacts, but it means
-// undoBeginDeployment never runs, so the deployment record stays in_progress
-// and holds the app's deploy lock for the full TTL, blocking every later deploy
-// of that app. The plain build path settles from a defer for the same reason.
-//
-// Best effort throughout: the lock's TTL remains the final backstop, and a saga
-// that did compensate normally has already settled the record, which
-// FailIfUnsettled treats as a no-op.
-func (s *SagaBuilder) settleAbandonedDeployment(ctx context.Context, executionID string, cause error) {
-	// Detached: the whole point is to run after the client's context died.
-	settleCtx, cancel := settleContext(ctx)
-	defer cancel()
-
-	exec, err := s.storage.Get(settleCtx, executionID)
-	if err != nil {
-		s.log.Warn("could not load saga execution to settle its deployment",
-			"execution", executionID, "error", err)
-		return
-	}
-
-	result, ok := exec.ExecutedActions[actionBeginDeploy]
-	if !ok || result.Error != "" || len(result.Output) == 0 {
-		// Untracked build, or begin-deployment never completed, so there is no
-		// record of ours to settle.
-		return
-	}
-
-	var out beginDeploymentOut
-	if err := json.Unmarshal(result.Output, &out); err != nil {
-		s.log.Warn("could not decode begin-deployment output",
-			"execution", executionID, "error", err)
-		return
-	}
-	if out.DeploymentID == "" {
-		return
-	}
-
-	if err := s.inner.deploy.FailIfUnsettled(settleCtx, out.DeploymentID, cause.Error()); err != nil {
-		s.log.Error("failed to settle deployment after saga failure",
-			"deployment_id", out.DeploymentID, "error", err)
-	}
 }
 
 // populateResults fishes the saga's outputs back out of storage to


### PR DESCRIPTION
Deploy cancellation was accidentally coupled to the CLI's RPC connection. A dropped terminal stopped the build, while `miren deploy cancel` only worked because the initiating CLI kept polling the record and translated that state back into local context cancellation.

This makes the server-owned deployment record the control plane. Builds detach from the transport but remain tied to server shutdown; record cancellation stops action work while saga persistence and compensation finish. Ctrl-C writes that cancellation explicitly, and older servers keep the polling fallback.

Verified with the full serial test suite and a standalone smoke: one build survived its CLI being killed, while SIGINT cancelled the record, interrupted BuildKit, compensated, and released the lock.

Closes MIR-1506