### PR TITLE
Apply Bring Your Own Image capabilities across the docs

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -107,7 +107,7 @@ miren deploy --analyze
 			Body: "miren deploy -e DATABASE_URL=postgres://localhost/mydb",
 		}),
 		WithExample(mflags.Example{
-			Name: "Deploy a previously built version",
+			Name: "Deploy an existing version",
 			Body: "miren deploy --version v3",
 		}),
 	))
@@ -1306,23 +1306,23 @@ Warning: These commands are intended for advanced users and developers. They may
 // generated command docs (docs/docs/command/*.md) and clarify which operations
 // roll out automatically versus require a rebuild.
 
-const deployDescription = `Deploy uploads your source, builds a new container image on the server, and activates the resulting version — replacing the previously running one. This is the only command that rebuilds your image.
+const deployDescription = `Deploy uploads your project files and configuration, selects the app's primary image, and activates the resulting version. A Dockerfile selected by ` + "`" + `[build].dockerfile` + "`" + ` or discovered as ` + "`" + `Dockerfile.miren` + "`" + ` is built first. Without one, a configured web image is resolved directly; otherwise Miren builds an image from automatically detected source. When source needs rebuilding, this is the command that does it.
 
-To activate a previously built version without rebuilding, pass ` + "`" + `--version` + "`" + `:
+To activate an existing version without selecting or building another image, pass ` + "`" + `--version` + "`" + `:
 ` + "```" + `bash
 miren deploy --version myapp-vCVkjR6u7744AsMebwMjGU
 ` + "```" + `
-This reuses the existing image and rolls it out immediately — useful for rolling forward to a known-good version without waiting for a build. Find version IDs with ` + "`" + `miren app history` + "`" + `.
+This reuses the existing image and rolls it out immediately. It is useful for rolling forward to a known-good version without waiting for an image to resolve or build. Find version IDs with ` + "`" + `miren app history` + "`" + `.
 
 :::note[Config changes deploy on their own]
 Changing environment variables (` + "`" + `miren env set` + "`" + ` / ` + "`" + `miren env delete` + "`" + `) or addons (` + "`" + `miren addon create` + "`" + ` / ` + "`" + `miren addon destroy` + "`" + `) already creates and rolls out a new version. You only need ` + "`" + `miren deploy` + "`" + ` when your code or ` + "`" + `app.toml` + "`" + ` has changed.
 :::`
 
-const rollbackDescription = `Rollback re-activates a previous version by reusing its already-built image — no rebuild happens. It presents a picker of recent successful deployments and rolls out the one you choose immediately. The currently active version is excluded since rolling back to it would be a no-op.
+const rollbackDescription = `Rollback re-activates a previous version by reusing its already-resolved image. No image selection or build happens. It presents a picker of recent successful deployments and rolls out the one you choose immediately. The currently active version is excluded since rolling back to it would be a no-op.
 
 Rollback creates a new deployment record; it does not erase history.`
 
-const appRestartDescription = `Restart stops your app's running sandboxes and lets the pool manager re-create them from the *current* active version. It does not create a new version, change any configuration, or rebuild your image — the app comes back on exactly the spec it was already running.
+const appRestartDescription = `Restart stops your app's running sandboxes and lets the pool manager re-create them from the *current* active version. It does not create a new version, change any configuration, or select or build another image. The app comes back on exactly the spec it was already running.
 
 Use restart to:
 - Clear stuck or wedged process state

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -83,7 +83,7 @@ func reconcileDeploymentCancellation(
 func Deploy(ctx *Context, opts struct {
 	AppCentric
 
-	Version       string   `short:"V" long:"version" description:"Deploy an existing version (skip build)"`
+	Version       string   `short:"V" long:"version" description:"Deploy an existing version (reuse its resolved image; skip image selection and build)"`
 	Analyze       bool     `long:"analyze" description:"Analyze the app without building (show detected stack, services, etc.)"`
 	Explain       bool     `short:"x" long:"explain" description:"Explain the build process"`
 	ExplainFormat string   `long:"explain-format" description:"Explain format" choice:"auto" choice:"plain" choice:"tty" choice:"rawjson" default:"auto"` //nolint

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -8,7 +8,7 @@ import CliCommand from '@site/src/components/CliCommand';
 
 # App Configuration
 
-Miren uses a **convention over configuration** approach. Most apps deploy with zero configuration—Miren detects your language, builds your image, and runs it with sensible defaults. When you need to customize, you add a `.miren/app.toml` file.
+Miren uses a **convention over configuration** approach. Most apps need little configuration: Miren can detect your language and build an image, or run a configured image with its own startup defaults. When you need to customize, you add a `.miren/app.toml` file.
 
 ## Minimum working example
 
@@ -21,7 +21,7 @@ name = "myapp"
 command = "npm start"
 ```
 
-Deploy with `miren deploy` and Miren builds the image and runs `web` with that command. Everything else on this page is additive — environment variables, more services, scaling, disks.
+Deploy with `miren deploy` and Miren builds the image and runs `web` with that command. Everything else on this page is additive: environment variables, more services, scaling, disks.
 
 :::tip[Have an agent inspect your app]
 Install the [Miren agent skills](/agent-skills) and ask your AI coding agent to
@@ -123,14 +123,13 @@ To deploy an existing image as the app, set `image` on the `web` service. Miren 
 ```toml
 [services.web]
 image = "ghcr.io/example/myapp:latest"
-args = ["serve", "--port", "8080"]
-port = 8080
 ```
 
 The optional `args` array replaces the image's `CMD` while preserving its
 `ENTRYPOINT`. Miren passes the array directly, without shell expansion. Leave both
 `args` and `command` unset to use the image's defaults unchanged; use `command` for
-the existing full `/bin/sh -c` override.
+the existing full `/bin/sh -c` override. Miren also inherits a single TCP port from
+the image's `EXPOSE` metadata. Set `port` when the image exposes no ports or several.
 
 See [Services](/services) for patterns like running databases alongside your app.
 

--- a/docs/docs/app-toml.md
+++ b/docs/docs/app-toml.md
@@ -205,12 +205,12 @@ args = ["postgres", "-c", "shared_buffers=256MB"]
 |-------|------|-------------|---------|
 | `command` | string | Shell command that replaces the image startup command (`/bin/sh -c`) | — |
 | `args` | string[] | Exec-form arguments that replace the image `CMD` while preserving its `ENTRYPOINT` | — |
-| `port` | int | Port the service listens on (single-port shorthand) | Built image's single TCP `EXPOSE` port, else `3000` (web only) |
+| `port` | int | Port the service listens on (single-port shorthand) | For `web` inheriting the primary image: its single exposed TCP port, otherwise `3000` |
 | `port_name` | string | Named port identifier (single-port shorthand) | Service name |
 | `port_type` | string | `"http"` or `"tcp"` (single-port shorthand) | `"http"` |
 | `ports` | [[port]](#ports) | Multi-port configuration array | — |
 | `port_timeout` | duration | Time to wait for the service to bind its port at startup (e.g. `"60s"`, `"2m"`) | `"15s"` |
-| `image` | string | Container image to use. On `services.web`, this selects the app's primary image unless `[build].dockerfile` is set or `Dockerfile.miren` exists | App's built image |
+| `image` | string | Container image to use. On `services.web`, this selects the app's primary image unless `[build].dockerfile` is set or `Dockerfile.miren` exists | App version's primary image |
 | `env` | [[env]](#env) | Service-specific environment variables (same schema as global `[[env]]`) | — |
 | `concurrency` | [concurrency](#concurrency) | Scaling configuration | See defaults below |
 | `metrics` | [metrics](#service-metrics) | Prometheus-compatible metrics endpoint scraped by the runtime | Disabled |

--- a/docs/docs/command/app-restart.md
+++ b/docs/docs/command/app-restart.md
@@ -8,7 +8,7 @@ description: "Restart an application"
 
 Restart an application
 
-Restart stops your app's running sandboxes and lets the pool manager re-create them from the *current* active version. It does not create a new version, change any configuration, or rebuild your image — the app comes back on exactly the spec it was already running.
+Restart stops your app's running sandboxes and lets the pool manager re-create them from the *current* active version. It does not create a new version, change any configuration, or select or build another image. The app comes back on exactly the spec it was already running.
 
 Use restart to:
 - Clear stuck or wedged process state

--- a/docs/docs/command/deploy.md
+++ b/docs/docs/command/deploy.md
@@ -8,13 +8,13 @@ description: "Deploy an application"
 
 Deploy an application
 
-Deploy uploads your source, builds a new container image on the server, and activates the resulting version — replacing the previously running one. This is the only command that rebuilds your image.
+Deploy uploads your project files and configuration, selects the app's primary image, and activates the resulting version. A Dockerfile selected by `[build].dockerfile` or discovered as `Dockerfile.miren` is built first. Without one, a configured web image is resolved directly; otherwise Miren builds an image from automatically detected source. When source needs rebuilding, this is the command that does it.
 
-To activate a previously built version without rebuilding, pass `--version`:
+To activate an existing version without selecting or building another image, pass `--version`:
 ```bash
 miren deploy --version myapp-vCVkjR6u7744AsMebwMjGU
 ```
-This reuses the existing image and rolls it out immediately — useful for rolling forward to a known-good version without waiting for a build. Find version IDs with `miren app history`.
+This reuses the existing image and rolls it out immediately. It is useful for rolling forward to a known-good version without waiting for an image to resolve or build. Find version IDs with `miren app history`.
 
 :::note[Config changes deploy on their own]
 Changing environment variables (`miren env set` / `miren env delete`) or addons (`miren addon create` / `miren addon destroy`) already creates and rolls out a new version. You only need `miren deploy` when your code or `app.toml` has changed.
@@ -37,7 +37,7 @@ miren deploy [flags]
 - `--sensitive, -s` — Set sensitive environment variable (masked in output)
 - `--summary-json` — Write a JSON summary of the deploy result (deploy id, version, and route URLs) to this path
 - `--ttl` — TTL for ephemeral version (e.g. 48h) (default: `24h`)
-- `--version, -V` — Deploy an existing version (skip build)
+- `--version, -V` — Deploy an existing version (reuse its resolved image; skip image selection and build)
 
 ## Config Options
 
@@ -78,7 +78,7 @@ miren deploy --analyze
 miren deploy -e DATABASE_URL=postgres://localhost/mydb
 ```
 
-**Deploy a previously built version:**
+**Deploy an existing version:**
 
 ```bash
 miren deploy --version v3

--- a/docs/docs/command/rollback.md
+++ b/docs/docs/command/rollback.md
@@ -8,7 +8,7 @@ description: "Roll back to a previous version"
 
 Roll back to a previous version
 
-Rollback re-activates a previous version by reusing its already-built image — no rebuild happens. It presents a picker of recent successful deployments and rolls out the one you choose immediately. The currently active version is excluded since rolling back to it would be a no-op.
+Rollback re-activates a previous version by reusing its already-resolved image. No image selection or build happens. It presents a picker of recent successful deployments and rolls out the one you choose immediately. The currently active version is excluded since rolling back to it would be a no-op.
 
 Rollback creates a new deployment record; it does not erase history.
 

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -20,14 +20,14 @@ miren deploy
 ```
 </CliCommand>
 
-That's the whole thing — Miren detects your language, builds the image on the server, and activates the new version. If the project isn't set up yet, the CLI offers to run `miren init` first; if the app doesn't exist on the server, it's created automatically on first deploy.
+That's the whole thing. Miren first honors a Dockerfile selected by `[build].dockerfile` or discovered as `Dockerfile.miren`. Without one, it uses a configured image directly or detects your language and builds one on the server, then activates the new version. If the project isn't set up yet, the CLI offers to run `miren init` first; if the app doesn't exist on the server, it's created automatically on first deploy.
 
 ## How Deployment Works
 
 When you run `miren deploy`, Miren:
 
 1. **Uploads your files** — sends your project files and app configuration to the server (after your first deploy, only changed files are transferred)
-2. **Selects or builds an image** — uses a configured web image directly, or inspects your source to build an image from a detected [language or framework](/guides) or your Dockerfile
+2. **Selects or builds an image** — builds a configured or discovered Dockerfile first; otherwise uses a configured web image directly or inspects your source for a detected [language or framework](/guides)
 3. **Activates the new version** — rolls out the new version, replacing the previous one
 
 Each deployment is a tracked object with its own ID, a status, and the git commit it came from. A successful deployment produces a new version (identified by a version ID); a failed one produces no version but stays in history as a record of the attempt. You can inspect, roll back, or redeploy any previous version at any time.
@@ -85,7 +85,7 @@ Source: dockerfile
 Source: image ghcr.io/example/myapp:latest
 ```
 
-The same source appears in `miren app status` after deployment, so it remains visible after the build finishes.
+The same source appears in `miren app status` after deployment, so it remains visible after the deploy finishes.
 
 If a build fails, Miren displays the build errors and the deployment is marked as failed in history (visible via `miren app history`).
 
@@ -100,10 +100,9 @@ name = "myapp"
 
 [services.web]
 image = "ghcr.io/example/myapp:latest"
-port = 8080
 ```
 
-Miren normalizes the reference and launches that image directly. It does not run BuildKit, push a derived image, or create a build artifact. When `command` is unset, the container uses the image's default entrypoint and command.
+Miren normalizes the reference and launches that image directly. It does not run BuildKit, push a derived image, or create a build artifact. The container keeps the image's working directory, entrypoint, and command. If the image exposes exactly one TCP port, Miren uses it for the web service and injects the same value as `PORT`. Set `port` explicitly when the image exposes no ports or several.
 
 :::note[Image selection]
 A Dockerfile selected by `[build].dockerfile` or discovered as `Dockerfile.miren` takes precedence over `services.web.image`. Without one, the web image takes precedence over automatic source detection, even if the project directory also contains recognizable source files. Images on other services do not suppress source detection. If detection finds no buildable source, Miren uses a lone service image as the fallback; with several service images, set `services.web.image` to choose the primary one.
@@ -131,7 +130,7 @@ miren deploy -s SECRET_KEY
 
 ## Redeploying an Existing Version
 
-Skip the build entirely and redeploy a previously built version:
+Skip image selection and building entirely by redeploying an existing version:
 
 <CliCommand context="client">
 ```miren
@@ -139,7 +138,7 @@ miren deploy --version myapp-vCVkjR6u7744AsMebwMjGU
 ```
 </CliCommand>
 
-Useful for rolling forward to a known-good version without waiting for a new build.
+Useful for rolling forward to a known-good version without waiting for a new image to resolve or build.
 
 Find version IDs with `miren app history` (see [Deployment History](#deployment-history) below).
 

--- a/docs/docs/distributed-runners.md
+++ b/docs/docs/distributed-runners.md
@@ -60,7 +60,7 @@ When an app runs several instances, the scheduler spreads them across nodes rath
 
 ### Images
 
-Runners pull the images they need from the registry on the coordinator. There's no separate registry to run or configure, and no manual step to push a build out to your runners. When you deploy, the coordinator builds the image once, and each runner that needs to start a sandbox pulls it on demand.
+Runners pull the images they need from the registry on the coordinator. There's no separate registry to run or configure, and no manual step to distribute an image to your runners. When you deploy, the coordinator resolves a configured image or builds one from source, and each runner that needs to start a sandbox pulls the selected image on demand.
 
 ## Adding a runner
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -166,7 +166,7 @@ That's it! You have an app running on Miren.
 
 Now that you've got something deployed, here's where to go depending on what you need.
 
-**Deploy your own app.** Miren auto-detects Python, Node, Bun, Go, Ruby, and Rust projects. Run `miren init` in your project to create a [`.miren/app.toml`](/app-configuration) config, then `miren deploy`. You can always provide a `Dockerfile` if you need full control over the build. For a step-by-step walkthrough for your language, see the [Language Guides](/guides).
+**Deploy your own app.** Miren auto-detects Python, Node, Bun, Go, Ruby, and Rust projects. Run `miren init` in your project to create a [`.miren/app.toml`](/app-configuration) config, then `miren deploy`. If your app already has a runnable container image, [configure it directly](/deployment#deploying-an-existing-image). Use a `Dockerfile` when the deployment still needs to add source, packages, or build steps. For a step-by-step source-build walkthrough, see the [Language Guides](/guides).
 
 :::tip[Set up your own app with an agent]
 Install the [Miren agent skills](/agent-skills) and ask your AI coding agent to

--- a/docs/docs/guides/bash.md
+++ b/docs/docs/guides/bash.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this shell script on Miren" after installing
 front-end, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Add a `Dockerfile.miren` to your project root. Miren builds from it instead of
 guessing the stack — see [Using Dockerfile.miren](/guides#using-dockerfilemiren).
@@ -42,11 +42,8 @@ printf 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\n
 ## The socket front-end
 
 The script doesn't bind a port — `socat` does. Miren injects `PORT`, and `socat`'s
-`TCP-LISTEN` binds all interfaces; `fork` runs the script once per connection:
-
-```procfile
-web: socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:/app/hello.sh
-```
+`TCP-LISTEN` binds all interfaces; `fork` runs the script once per connection. The
+Dockerfile's `CMD` starts that socket front-end.
 
 This same `socat` pattern serves any program that writes an HTTP response to stdout —
 see the [COBOL guide](/guides/cobol) for another example.
@@ -70,6 +67,7 @@ WORKDIR /app
 COPY hello.sh .
 RUN chmod +x hello.sh
 EXPOSE 8080
+CMD ["sh", "-c", "exec socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:/app/hello.sh"]
 ```
 
 ### .dockerignore
@@ -79,6 +77,9 @@ EXPOSE 8080
 ```
 
 ## Deploy
+
+Miren uses the image's `CMD` and infers the web port from `EXPOSE 8080`, so you don't
+need a `Procfile` or service command.
 
 Create `.miren/app.toml` naming your app and deploy from your project root:
 
@@ -96,7 +97,7 @@ miren deploy
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Serving:** the script prints a full HTTP response; `socat` owns the socket
-- **Service is required:** `Procfile` `web: socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:/app/hello.sh`
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `socat TCP-LISTEN:$PORT` binds `0.0.0.0`
 - **Pattern:** works for any executable that writes an HTTP response to stdout
 

--- a/docs/docs/guides/c.md
+++ b/docs/docs/guides/c.md
@@ -20,7 +20,7 @@ Ask your AI coding agent to "set up this C app on Miren" after installing the
 binds `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect C, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -109,15 +109,12 @@ trixie) and run on an older base, the binary crashes at startup with
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /usr/local/bin/app
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "c-bench"
@@ -148,7 +145,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren`
 - **Library:** GNU libmicrohttpd from Debian (`libmicrohttpd-dev` build, `libmicrohttpd12` runtime)
 - **Build:** `gcc -O2 -o app server.c -lmicrohttpd`; keep build + runtime on the same Debian release
-- **Service is required:** define a `Procfile` (`web: /usr/local/bin/app`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `getenv("PORT")`; `MHD_start_daemon` binds `0.0.0.0`
 - **Env vars:** `miren env set -e/-s`; read with `getenv`
 

--- a/docs/docs/guides/clojure.md
+++ b/docs/docs/guides/clojure.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Clojure app on Miren" after installing 
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Clojure, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -35,7 +35,7 @@ support, [request it](https://linear.miren.garden/suggest).
 Miren injects `PORT` and routes traffic to it, so read `PORT` and bind `0.0.0.0`:
 
 ```clojure
-;; src/app.clj — deps.edn searches "src" and the Procfile runs the `app` namespace
+;; src/app.clj — deps.edn searches "src" and the image CMD runs the `app` namespace
 (ns app
   (:require [ring.adapter.jetty :as jetty]))
 
@@ -71,6 +71,7 @@ RUN clojure -P
 COPY . /app
 
 EXPOSE 8080
+CMD ["clojure", "-M", "-m", "app"]
 ```
 
 ### .dockerignore
@@ -80,16 +81,12 @@ EXPOSE 8080
 .cpcache
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile` that runs the main
-namespace:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: clojure -M -m app
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "clojure-bench"
@@ -132,7 +129,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Base image:** `clojure:temurin-21-tools-deps`; `clojure -P` caches deps in the build
-- **Service is required:** define a `Procfile` (`web: clojure -M -m app`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `(System/getenv "PORT")`; `run-jetty handler {:host "0.0.0.0"}`
 - **Env vars:** `miren env set -e/-s`; read with `(System/getenv "KEY")`
 

--- a/docs/docs/guides/cobol.md
+++ b/docs/docs/guides/cobol.md
@@ -19,7 +19,7 @@ Ask your AI coding agent to "set up this COBOL program on Miren" after installin
 front-end, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Add a `Dockerfile.miren` to your project root. Miren builds from it instead of
 guessing the stack — see [Using Dockerfile.miren](/guides#using-dockerfilemiren).
@@ -56,11 +56,8 @@ the body — to standard output. `X"0D0A"` is CRLF:
 
 The program itself doesn't listen on a port — `socat` does. For each connection, `socat`
 runs the program and pipes its stdout back to the client. Miren injects `PORT`, and
-`socat`'s `TCP-LISTEN` binds all interfaces:
-
-```procfile
-web: socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:/app/hello
-```
+`socat`'s `TCP-LISTEN` binds all interfaces. The Dockerfile's `CMD` starts that socket
+front-end.
 
 This `socat` pattern works for any language that can print an HTTP response to stdout.
 
@@ -89,6 +86,7 @@ COPY hello.cob .
 RUN cobc -x -o /app/hello hello.cob
 
 EXPOSE 8080
+CMD ["sh", "-c", "exec socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:/app/hello"]
 ```
 
 ### .dockerignore
@@ -98,6 +96,9 @@ EXPOSE 8080
 ```
 
 ## Deploy
+
+Miren uses the image's `CMD` and infers the web port from `EXPOSE 8080`, so you don't
+need a `Procfile` or service command.
 
 Create `.miren/app.toml` naming your app and deploy from your project root:
 
@@ -116,7 +117,7 @@ miren deploy
 - **Detection:** none — requires `Dockerfile.miren`
 - **Build:** `cobc -x -o /app/hello hello.cob` on `debian:12-slim` with `gnucobol`
 - **Serving:** the program prints a full HTTP response; `socat` handles the socket
-- **Service is required:** `Procfile` `web: socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:/app/hello`
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `socat TCP-LISTEN:$PORT` binds `0.0.0.0`
 - **Pattern:** the same `socat` front-end works for any language that writes an HTTP response to stdout
 

--- a/docs/docs/guides/commonlisp.md
+++ b/docs/docs/guides/commonlisp.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Common Lisp app on Miren" after install
 to `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Add a `Dockerfile.miren` to your project root. Miren builds from it instead of
 guessing the stack — see [Using Dockerfile.miren](/guides#using-dockerfilemiren).
@@ -74,6 +74,7 @@ RUN apt-get update -y && apt-get install -y curl && rm -rf /var/lib/apt/lists/* 
 WORKDIR /app
 COPY . /app
 EXPOSE 8080
+CMD ["sbcl", "--disable-debugger", "--load", "/app/app.lisp"]
 ```
 
 ### .dockerignore
@@ -82,15 +83,12 @@ EXPOSE 8080
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Run the script with SBCL:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: sbcl --disable-debugger --load /app/app.lisp
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "commonlisp-bench"
@@ -130,7 +128,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Base image:** `clfoundation/sbcl:latest`; install Quicklisp + preload Hunchentoot in the build
-- **Service is required:** `Procfile` `web: sbcl --disable-debugger --load /app/app.lisp` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Keep-alive:** end the script with `(loop (sleep 3600))` so the process stays running
 - **Port:** `(uiop:getenv "PORT")`; `easy-acceptor :address "0.0.0.0"`
 - **Env vars:** `miren env set -e/-s`; read with `(uiop:getenv "KEY")`

--- a/docs/docs/guides/cpp.md
+++ b/docs/docs/guides/cpp.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this C++ app on Miren" after installing the
 binds `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect C++, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -85,15 +85,12 @@ with `-static-libstdc++ -static-libgcc`.
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /usr/local/bin/app
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "cpp-bench"
@@ -124,7 +121,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren`
 - **Build:** fetch `httplib.h`; `g++ -O2 -std=c++17 -pthread -o app main.cpp` on `gcc:14`
 - **Runtime glibc/libstdc++:** use `debian:trixie-slim` (matches `gcc:14`) — older bases crash on `GLIBC_2.38`/`GLIBCXX_3.4.32`
-- **Service is required:** define a `Procfile` (`web: /usr/local/bin/app`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `std::getenv("PORT")`; `svr.listen("0.0.0.0", port)`
 - **Env vars:** `miren env set -e/-s`; read with `std::getenv`
 

--- a/docs/docs/guides/crystal.md
+++ b/docs/docs/guides/crystal.md
@@ -19,7 +19,7 @@ server binds `0.0.0.0:$PORT`, wires up environment variables, and deploys — us
 page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Crystal yet, so add a `Dockerfile.miren` to your project
 root. Miren builds from it instead of guessing the stack — see
@@ -100,15 +100,12 @@ bin
 lib
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /usr/local/bin/app
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "crystal-bench"
@@ -152,7 +149,7 @@ injects `DATABASE_URL` for you. See
 - **Detection:** none — requires `Dockerfile.miren` (static binary)
 - **Build:** `shards build --release --static --no-debug` on `crystallang/crystal:*-alpine`
 - **Runtime:** copy `bin/<target>` to a minimal Alpine image
-- **Service is required:** define a `Procfile` (`web: /usr/local/bin/app`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** read `ENV["PORT"]`; bind `0.0.0.0`
 - **Env vars:** `miren env set -e/-s`, or `[[env]]` in `app.toml`; read with `ENV["KEY"]`
 - **Database:** optional `[addons.miren-postgresql]` injects `DATABASE_URL`

--- a/docs/docs/guides/dart.md
+++ b/docs/docs/guides/dart.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Dart app on Miren" after installing the
 binds `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Dart, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -83,15 +83,12 @@ snapshots run with `dartaotruntime`, not for `compile exe`.)
 .dart_tool
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /app/server
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "dart-bench"
@@ -132,7 +129,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren` (compiled exe)
 - **Build:** `dart compile exe bin/server.dart -o /app/server` on `dart:stable`
 - **Runtime:** `debian:12-slim` (glibc) — the compiled exe won't run on `scratch`
-- **Service is required:** define a `Procfile` (`web: /app/server`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `Platform.environment['PORT']`; bind `0.0.0.0` via `shelf_io.serve`
 - **Env vars:** `miren env set -e/-s`; read with `Platform.environment`
 

--- a/docs/docs/guides/deno.md
+++ b/docs/docs/guides/deno.md
@@ -19,7 +19,7 @@ server binds `0.0.0.0:$PORT`, sets the runtime permissions, and deploys — usin
 page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren's JavaScript detection covers Node and Bun (see
 [JavaScript on Miren](/guides/javascript)); Deno needs a `Dockerfile.miren`. Miren builds
@@ -75,16 +75,12 @@ fast. Deno runs with no permissions by default, so grant exactly what your app n
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile` with the full
-`deno run` command (including permissions):
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: deno run --allow-net --allow-env main.ts
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "deno-bench"
@@ -126,7 +122,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren` (Node/Bun are detected, Deno is not)
 - **Base image:** `denoland/deno:<version>`; `deno cache main.ts` warms deps
-- **Service is required:** define a `Procfile` (`web: deno run --allow-net --allow-env main.ts`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Permissions:** grant `--allow-net` + `--allow-env` at minimum; add others as needed
 - **Port:** read `Deno.env.get("PORT")`; bind `0.0.0.0` via `Deno.serve`
 - **Env vars:** `miren env set -e/-s`, or `[[env]]` in `app.toml`; read with `Deno.env.get`

--- a/docs/docs/guides/dotnet.md
+++ b/docs/docs/guides/dotnet.md
@@ -19,7 +19,7 @@ Ask your AI coding agent to "set up this .NET app on Miren" after installing the
 reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect .NET, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -79,15 +79,12 @@ bin
 obj
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: dotnet /app/dotnet-bench.dll
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "dotnet-bench"
@@ -128,7 +125,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Build:** `dotnet publish -c Release -o /out` on the SDK image; run on `dotnet/aspnet`
-- **Service is required:** define a `Procfile` (`web: dotnet /app/<assembly>.dll`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `app.Run($"http://0.0.0.0:{port}")` (reading `PORT` in code; `ASPNETCORE_URLS` is not shell-expanded)
 - **Env vars:** `miren env set -e/-s`; `__` maps to nested config keys
 - **Database:** optional `[addons.miren-postgresql]` injects `DATABASE_URL`

--- a/docs/docs/guides/elixir.md
+++ b/docs/docs/guides/elixir.md
@@ -20,7 +20,7 @@ Ask your AI coding agent to "set up this Phoenix app on Miren" after installing 
 secrets, and deploy — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect the BEAM yet, so add a `Dockerfile.miren` to your
 project root. Miren builds from it instead of guessing the stack — see
@@ -143,16 +143,12 @@ node_modules
 mise.toml
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile` next to your
-`Dockerfile.miren` that starts the release (replace `my_app` with your OTP app name):
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /app/bin/my_app start
-```
-
-Then create `.miren/app.toml` naming your app and declaring the database addon
+Create `.miren/app.toml` naming your app and declaring the database addon
 (covered in the next section):
 
 ```toml
@@ -191,7 +187,7 @@ one, and the instance crashes. Configure the addon and secrets first.
 The simplest way to get `DATABASE_URL` is a managed Postgres [addon](/addons) — Miren
 provisions it and injects the connection string (plus `PG*` variables) as environment
 variables automatically. Declare it in `.miren/app.toml` (as shown in
-[Set up the app](#set-up-the-app)):
+[Deploy](#deploy)):
 
 ```toml
 [addons.miren-postgresql]
@@ -249,7 +245,7 @@ resolves all instance IPs, which activates the scaffolded `DNSCluster`.
 - **Release:** `mix phx.gen.release`; `mix compile` **before** `mix assets.deploy`; `COPY rel rel`
 - **Runtime image:** `debian-slim` is fine — `mix release` bundles ERTS, so the runner needs no Erlang install
 - **Runtime env:** `PHX_SERVER=true` in the Dockerfile; endpoint binds `0.0.0.0:$PORT` via `runtime.exs`
-- **Service is required:** define a `Procfile` (`web: /app/bin/<app> start`) or `[services.web]` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Secrets first:** set `SECRET_KEY_BASE` + `PHX_HOST` before the app serves traffic, or the instance crashloops
 - **Database:** `[addons.miren-postgresql]` injects `DATABASE_URL` (and `PG*`) automatically
 - **Migrations:** `miren app run -a <app> -- /app/bin/migrate`

--- a/docs/docs/guides/erlang.md
+++ b/docs/docs/guides/erlang.md
@@ -19,7 +19,7 @@ Ask your AI coding agent to "set up this Erlang app on Miren" after installing t
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Erlang, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -106,15 +106,12 @@ CMD ["/app/bin/erlang_bench", "foreground"]
 _build
 ```
 
-## Set up the app
+## Deploy
 
-Run the release in the foreground:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /app/bin/erlang_bench foreground
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "erlang-bench"
@@ -155,7 +152,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren` (rebar3 release)
 - **Build:** `rebar3 release` on `erlang:27`; `include_erts, true` makes it self-contained
 - **Runtime libs:** `libncurses6 libssl3` on `debian-slim`
-- **Service is required:** `Procfile` `web: /app/bin/<release> foreground` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `os:getenv("PORT", "8080")`; `cowboy:start_clear(_, [{port, Port}], _)`
 - **Env vars:** `miren env set -e/-s`; read with `os:getenv`
 

--- a/docs/docs/guides/fsharp.md
+++ b/docs/docs/guides/fsharp.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this F# app on Miren" after installing the
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect .NET, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -94,15 +94,12 @@ bin
 obj
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: dotnet /app/fsharp-bench.dll
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "fsharp-bench"
@@ -142,7 +139,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren` (same toolchain as [C#](/guides/dotnet))
 - **Build:** `dotnet publish -c Release -o /out` on the SDK image; run on `dotnet/aspnet`
 - **fsproj:** use `Microsoft.NET.Sdk.Web`; list `<Compile Include>` files in dependency order
-- **Service is required:** `Procfile` `web: dotnet /app/<assembly>.dll` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `app.Run(sprintf "http://0.0.0.0:%s" port)` (reading `PORT` in code; `ASPNETCORE_URLS` is not shell-expanded)
 - **Env vars:** `miren env set -e/-s`; `__` maps to nested config keys
 

--- a/docs/docs/guides/gleam.md
+++ b/docs/docs/guides/gleam.md
@@ -19,7 +19,7 @@ server binds `0.0.0.0:$PORT`, wire up environment variables, and deploy — usin
 page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect the BEAM yet, so add a `Dockerfile.miren` to your
 project root. Miren builds from it instead of guessing the stack — see
@@ -142,20 +142,16 @@ Keep build artifacts out of the image context:
 build
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile` next to your
-`Dockerfile.miren`:
-
-```procfile
-web: /app/entrypoint.sh run
-```
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
 The command is the release entrypoint the shipment generated. Use the absolute path
 (`/app/entrypoint.sh`, matching the Dockerfile's `WORKDIR /app`); the script resolves
 its own release directory, so it works regardless of the working directory.
 
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "gleam-bench"
@@ -200,7 +196,7 @@ injects `DATABASE_URL` for you. See
 - **Detection:** none — requires `Dockerfile.miren` (Erlang shipment)
 - **Build:** `gleam export erlang-shipment` → `build/erlang-shipment/` with `entrypoint.sh`
 - **Runtime image:** Erlang major version **must match** the builder's OTP (the pinned v1.15.0 image ships OTP 28 → `erlang:28-alpine`)
-- **Service is required:** define a `Procfile` (`web: /app/entrypoint.sh run`) or `[services.web]` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** read `PORT` via `envoy.get("PORT")`; bind `mist`/`wisp` to `0.0.0.0`
 - **mist API:** v6 ends the builder with `mist.start`; older versions use `mist.start_http`
 - **Env vars:** `miren env set -e/-s`, or `[[env]]` in `app.toml`; read with `envoy.get/1`

--- a/docs/docs/guides/go.md
+++ b/docs/docs/guides/go.md
@@ -17,7 +17,7 @@ Ask your AI coding agent to "set up this Go app on Miren" after installing the
 command, wires up environment variables, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 No. Miren detects Go from `go.mod` and compiles the binary for you. The Go version
 comes from the `go` directive in your `go.mod` (falling back to 1.23). Provide a

--- a/docs/docs/guides/haskell.md
+++ b/docs/docs/guides/haskell.md
@@ -19,7 +19,7 @@ binds `0.0.0.0:$PORT`, wires up environment variables, and deploys — using thi
 its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Haskell, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -116,15 +116,12 @@ faster.
 dist-newstyle
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /usr/local/bin/app
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "haskell-bench"
@@ -166,7 +163,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Build:** `cabal build` on the `haskell` image; copy `$(cabal list-bin <exe>)` to a slim image
 - **Threaded runtime:** add `ghc-options: -threaded` — Warp/Scotty crashes on first request without it
 - **Runtime libs:** `libgmp10 zlib1g` on `debian-slim`
-- **Service is required:** define a `Procfile` (`web: /usr/local/bin/app`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** read `lookupEnv "PORT"`; Scotty/Warp binds all interfaces
 - **Env vars:** `miren env set -e/-s`; read with `lookupEnv`
 

--- a/docs/docs/guides/index.md
+++ b/docs/docs/guides/index.md
@@ -8,7 +8,7 @@ keywords: [guides, languages, python, javascript, node, bun, go, ruby, rust, eli
 
 These guides take you from a project on your laptop to a running app on Miren, one
 language at a time. Each one covers the same three things: **how to set up the app**,
-**how to set environment variables**, and **whether you need a Dockerfile**.
+**how to set environment variables**, and **whether its source build needs a Dockerfile**.
 
 :::tip[Let your agent do this]
 If you use an AI coding agent (Claude Code, Codex, Amp, and others), you don't have to
@@ -92,6 +92,19 @@ like Miren to detect and build another language first-class — no Dockerfile ne
 [tell us what to build next](https://linear.miren.garden/suggest).
 :::
 
+## Already have a runnable image?
+
+These language guides assume Miren starts with your source code. If you already publish a
+runnable container image, skip both language detection and `Dockerfile.miren`: set
+`services.web.image` and Miren launches the image directly.
+
+Keep the image's defaults when they already start the right process. Add `args` when its
+`ENTRYPOINT` is right but the deployment needs different arguments. Use `command` when you
+need to replace the whole process with a shell command. Build a derived image only when the
+deployment adds files or packages, or when the upstream image's startup contract is
+incomplete. See [Deploying an existing image](/deployment#deploying-an-existing-image) for
+the complete example.
+
 ## Using Dockerfile.miren {#using-dockerfilemiren}
 
 For applications that require custom build steps or don't fit the automatic detection,
@@ -123,11 +136,12 @@ EXPOSE 3000
 CMD ["node", "dist/index.js"]
 ```
 
-### Build priority
+### Deployment source priority
 
 1. `build.dockerfile` setting in `app.toml` (if specified)
 2. `Dockerfile.miren` in project root
-3. Automatic language detection
+3. `services.web.image` in `app.toml`
+4. Automatic language detection
 
 ### Build arguments
 

--- a/docs/docs/guides/java.md
+++ b/docs/docs/guides/java.md
@@ -20,7 +20,7 @@ Ask your AI coding agent to "set up this Spring Boot app on Miren" after install
 reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect the JVM, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -78,15 +78,12 @@ name, or adjust the `COPY` to match your artifact.
 target
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: java -jar /app/app.jar
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "java-bench"
@@ -125,7 +122,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Build:** `mvn -DskipTests package` (or Gradle); run the jar on a JRE image
-- **Service is required:** define a `Procfile` (`web: java -jar /app/app.jar`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** Spring `server.port=${PORT:8080}` + `server.address=0.0.0.0`; other frameworks read `PORT` and bind `0.0.0.0`
 - **Env vars:** `miren env set -e/-s`; Spring maps `SPRING_*` env vars to properties
 - **Database:** optional `[addons.miren-postgresql]` injects `DATABASE_URL`

--- a/docs/docs/guides/javascript.md
+++ b/docs/docs/guides/javascript.md
@@ -19,7 +19,7 @@ Ask your AI coding agent to "set up this app on Miren" after installing the
 wires up environment variables, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 No. Miren detects your project and builds the image automatically. Provide a
 `Dockerfile.miren` only for custom build steps — see

--- a/docs/docs/guides/jruby.md
+++ b/docs/docs/guides/jruby.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this app on JRuby on Miren" after installing
 the server, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes — to run on JRuby specifically. (Miren's auto-detection would pick MRI Ruby.) Add a
 `Dockerfile.miren` built on the `jruby` image. See
@@ -72,8 +72,8 @@ require './app'
 run App
 ```
 
-Miren injects `PORT` and routes to it; you bind it via the Puma command in the Procfile
-below (`0.0.0.0` on `$PORT`).
+Miren injects `PORT` and routes to it; the Dockerfile's Puma `CMD` below binds
+`0.0.0.0` on that port.
 
 ## The Dockerfile
 
@@ -86,6 +86,7 @@ COPY Gemfile ./
 RUN bundle install
 COPY . /app
 EXPOSE 8080
+CMD ["sh", "-c", "exec bundle exec puma -b tcp://0.0.0.0:$PORT"]
 ```
 
 ### .dockerignore
@@ -94,13 +95,10 @@ EXPOSE 8080
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Run Puma bound to the injected port:
-
-```procfile
-web: bundle exec puma -b tcp://0.0.0.0:$PORT
-```
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
 JRuby's JVM startup plus Bundler and Puma can take longer than the default 15-second
 port-wait, so raise `port_timeout`. Keeping one instance always warm (fixed scaling) also
@@ -149,7 +147,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** MRI Ruby is auto-detected from a `Gemfile`; use `Dockerfile.miren` to pin JRuby
 - **Base image:** `jruby:9.4`; `bundle install` at build time
-- **Service is required:** `Procfile` `web: bundle exec puma -b tcp://0.0.0.0:$PORT` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Slow boot:** raise `port_timeout` (e.g. `"120s"`) past the 15s default, and pin `num_instances = 1` to stay warm
 - **Port:** Puma `-b tcp://0.0.0.0:$PORT`
 - **Env vars:** `miren env set -e/-s`; read with `ENV['KEY']`

--- a/docs/docs/guides/julia.md
+++ b/docs/docs/guides/julia.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Julia app on Miren" after installing th
 binds `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Julia, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -58,6 +58,7 @@ RUN julia -e 'using Pkg; Pkg.add("HTTP"); using HTTP'
 COPY . /app
 
 EXPOSE 8080
+CMD ["julia", "/app/app.jl"]
 ```
 
 :::info[Cold-start compile]
@@ -72,15 +73,12 @@ heavier apps, consider `PackageCompiler.jl` to bake a sysimage.
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: julia /app/app.jl
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "julia-bench"
@@ -120,7 +118,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Base image:** `julia:1.10`; `Pkg.add` + `using` in the build to precompile
-- **Service is required:** define a `Procfile` (`web: julia /app/app.jl`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `get(ENV, "PORT", "8080")`; `HTTP.serve("0.0.0.0", port)`
 - **Cold start:** JIT compiles on first request; precompile in build or use `PackageCompiler.jl`
 - **Env vars:** `miren env set -e/-s`; read with `ENV["KEY"]`

--- a/docs/docs/guides/klong.md
+++ b/docs/docs/guides/klong.md
@@ -20,7 +20,7 @@ Ask your AI coding agent to "set up this Klong app on Miren" after installing th
 front-end, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Add a `Dockerfile.miren` to your project root. Miren builds from it instead of
 guessing the stack — see [Using Dockerfile.miren](/guides#using-dockerfilemiren).
@@ -54,11 +54,8 @@ output. In file mode only your `.d` bytes are written.
 ## The socket front-end
 
 The program doesn't bind a port — `socat` does. Miren injects `PORT`, and `socat`'s
-`TCP-LISTEN` binds all interfaces; `fork` runs Klong once per connection:
-
-```procfile
-web: socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:'kgpy /app/hello.kg'
-```
+`TCP-LISTEN` binds all interfaces; `fork` runs Klong once per connection. The Dockerfile's
+`CMD` starts that socket front-end.
 
 :::note[Behind Miren's ingress]
 Miren's HTTP ingress terminates TLS and handles the public HTTP layer in front of your
@@ -80,6 +77,7 @@ RUN pip install --no-cache-dir klongpy colorama \
 WORKDIR /app
 COPY hello.kg /app/
 EXPOSE 8080
+CMD ["sh", "-c", "exec socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:'kgpy /app/hello.kg'"]
 ```
 
 ### .dockerignore
@@ -89,6 +87,9 @@ EXPOSE 8080
 ```
 
 ## Deploy
+
+Miren uses the image's `CMD` and infers the web port from `EXPOSE 8080`, so you don't
+need a `Procfile` or service command.
 
 Create `.miren/app.toml` naming your app and deploy from your project root:
 
@@ -108,7 +109,7 @@ miren deploy
 - **Runtime:** KlongPy (`pip install klongpy colorama`) on `python:3.12-slim`
 - **Serving:** the Klong program `.d`-prints a full HTTP response; `socat` owns the socket
 - **Run from a file:** `kgpy hello.kg` (file mode) — `-e`/pipe modes echo the result too
-- **Service is required:** `Procfile` `web: socat TCP-LISTEN:$PORT,reuseaddr,fork EXEC:'kgpy /app/hello.kg'`
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `socat TCP-LISTEN:$PORT` binds `0.0.0.0`
 
 ## Next steps

--- a/docs/docs/guides/kotlin.md
+++ b/docs/docs/guides/kotlin.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Ktor app on Miren" after installing the
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect the JVM, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -97,15 +97,12 @@ build
 .gradle
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: java -jar /app/app.jar
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "kotlin-bench"
@@ -145,7 +142,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Build:** `gradle shadowJar` (fat jar) on `gradle:8.10-jdk21`; run on a JRE image
-- **Service is required:** define a `Procfile` (`web: java -jar /app/app.jar`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `System.getenv("PORT")`; `embeddedServer(Netty, port, host = "0.0.0.0")`
 - **Env vars:** `miren env set -e/-s`; read with `System.getenv`
 

--- a/docs/docs/guides/lua.md
+++ b/docs/docs/guides/lua.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Lua app on Miren" after installing the
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Lua, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -74,6 +74,7 @@ WORKDIR /app
 RUN luarocks --lua-version=5.4 install http
 COPY . /app
 EXPOSE 8080
+CMD ["lua5.4", "/app/app.lua"]
 ```
 
 :::note[Pin the Lua version for LuaRocks]
@@ -88,15 +89,12 @@ same interpreter you run with.
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: lua5.4 /app/app.lua
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "lua-bench"
@@ -126,7 +124,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Library:** lua-http via `luarocks --lua-version=5.4 install http` (needs `gcc make m4 libssl-dev`)
-- **Service is required:** define a `Procfile` (`web: lua5.4 /app/app.lua`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `os.getenv("PORT")`; `server.listen { host = "0.0.0.0", port = port }`
 - **Env vars:** `miren env set -e/-s`; read with `os.getenv`
 - **Heavier option:** OpenResty (nginx + Lua) for a production Lua web stack

--- a/docs/docs/guides/nim.md
+++ b/docs/docs/guides/nim.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Nim app on Miren" after installing the
 binds `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Nim, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -99,15 +99,12 @@ image) and installs `libpcre3` for Jester's routing.
 app
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /usr/local/bin/app
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "nim-bench"
@@ -149,7 +146,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Build:** `nimble install -dy && nim c -d:release --mm:refc -o:app app.nim`
 - **`--mm:refc` required:** Jester/httpbeast segfaults on startup with Nim 2.0's default ORC GC
 - **Runtime libs:** `libpcre3 openssl` on `debian-slim` (glibc base)
-- **Service is required:** define a `Procfile` (`web: /usr/local/bin/app`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `getEnv("PORT", "8080")`; Jester `settings: bindAddr = "0.0.0.0"`
 - **Env vars:** `miren env set -e/-s`; read with `getEnv`
 

--- a/docs/docs/guides/objc.md
+++ b/docs/docs/guides/objc.md
@@ -20,7 +20,7 @@ Ask your AI coding agent to "set up this Objective-C app on Miren" after install
 and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Add a `Dockerfile.miren` to your project root. Miren builds from it instead of
 guessing the stack — see [Using Dockerfile.miren](/guides#using-dockerfilemiren).
@@ -64,11 +64,7 @@ int main(int argc, const char *argv[]) {
 
 SOPE's HTTP adaptor takes its listen address from the `WOPort` default, which you pass
 on the command line. Miren injects `PORT`, so start the app with
-`-WOPort 0.0.0.0:$PORT`:
-
-```procfile
-web: sh -c '. /usr/share/GNUstep/Makefiles/GNUstep.sh && exec /app/obj/app -WOPort 0.0.0.0:$PORT'
-```
+`-WOPort 0.0.0.0:$PORT`. The Dockerfile's `CMD` below supplies that command.
 
 :::warning[Give WOPort an explicit `0.0.0.0`]
 `-WOPort 8080` alone makes the adaptor bind the wildcard address (`*:8080`), which fails
@@ -93,6 +89,7 @@ WORKDIR /app
 COPY main.m GNUmakefile ./
 RUN . /usr/share/GNUstep/Makefiles/GNUstep.sh && make
 EXPOSE 8080
+CMD ["sh", "-c", ". /usr/share/GNUstep/Makefiles/GNUstep.sh && exec /app/obj/app -WOPort 0.0.0.0:$PORT"]
 ```
 
 The `GNUmakefile` builds a plain tool linked against the SOPE libraries (SOPE's own
@@ -118,6 +115,9 @@ The compiled binary lands at `obj/app`.
 
 ## Deploy
 
+Miren uses the image's `CMD` and infers the web port from `EXPOSE 8080`, so you don't
+need a `Procfile` or service command.
+
 Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
@@ -137,7 +137,7 @@ miren deploy
 - **Build:** GNUstep makefiles as a plain tool linking `-lNGObjWeb …` (install `make`); binary at `obj/app`
 - **Port:** `-WOPort 0.0.0.0:$PORT` — the explicit `0.0.0.0` avoids a wildcard bind failure
 - **Runtime:** source `GNUstep.sh` before exec so the app finds its frameworks
-- **Service is required:** the `web:` Procfile line — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 
 ## Next steps
 

--- a/docs/docs/guides/ocaml.md
+++ b/docs/docs/guides/ocaml.md
@@ -19,7 +19,7 @@ binds `0.0.0.0:$PORT`, wires up environment variables, and deploys — using thi
 its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect OCaml, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -115,15 +115,12 @@ A minimal `dune-project` and `dune`:
 _build
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /usr/local/bin/app
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "ocaml-bench"
@@ -164,7 +161,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren` (native binary)
 - **Build:** `opam install --no-depexts dream dune`, `dune build --profile release ./main.exe`
 - **System deps:** use `USER root` for `apt-get` (`sudo` fails in the build sandbox); runtime needs `libev4 libgmp10 libssl3`
-- **Service is required:** define a `Procfile` (`web: /usr/local/bin/app`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** read `Sys.getenv_opt "PORT"`; Dream needs `~interface:"0.0.0.0"`
 - **Env vars:** `miren env set -e/-s`; read with `Sys.getenv_opt`
 

--- a/docs/docs/guides/perl.md
+++ b/docs/docs/guides/perl.md
@@ -19,7 +19,7 @@ Ask your AI coding agent to "set up this Perl app on Miren" after installing the
 at `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Perl, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -58,6 +58,7 @@ RUN cpanm --notest Mojolicious
 COPY . /app
 
 EXPOSE 8080
+CMD ["sh", "-c", "exec perl /app/app.pl daemon -l \"http://*:$PORT\""]
 ```
 
 For an app with a `cpanfile`, install from it instead: `RUN cpanm --notest --installdeps .`
@@ -68,16 +69,12 @@ For an app with a `cpanfile`, install from it instead: `RUN cpanm --notest --ins
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile` that starts the
-Mojolicious daemon on the injected port:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: perl /app/app.pl daemon -l "http://*:$PORT"
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "perl-bench"
@@ -89,8 +86,17 @@ miren deploy
 ```
 </CliCommand>
 
-For a PSGI app (Dancer2, Catalyst), run it under a Plack server instead:
-`web: plackup -s Starman --host 0.0.0.0 --port $PORT app.psgi`.
+For a PSGI app (Dancer2, Catalyst), install Plack and Starman in the Dockerfile:
+
+```dockerfile
+RUN cpanm --notest Plack Starman
+```
+
+Then replace the Dockerfile's `CMD` with one that starts the PSGI app:
+
+```dockerfile
+CMD ["sh", "-c", "exec plackup -s Starman --host 0.0.0.0 --port \"$PORT\" /app/app.psgi"]
+```
 
 ## Environment variables
 
@@ -120,7 +126,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Base image:** `perl:5.40`; `cpanm --notest Mojolicious` (or `--installdeps .` with a `cpanfile`)
-- **Service is required:** `Procfile` `web: perl /app/app.pl daemon -l "http://*:$PORT"` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** Mojolicious `daemon -l http://*:$PORT`; PSGI apps use `plackup --host 0.0.0.0 --port $PORT`
 - **Env vars:** `miren env set -e/-s`; read with `$ENV{KEY}`
 

--- a/docs/docs/guides/php.md
+++ b/docs/docs/guides/php.md
@@ -20,7 +20,7 @@ at `0.0.0.0:$PORT`, wires up environment variables, and deploys — using this p
 reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect PHP, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -44,6 +44,7 @@ WORKDIR /app
 COPY . /app
 
 EXPOSE 8080
+CMD ["sh", "-c", "exec frankenphp php-server --listen 0.0.0.0:$PORT --root /app/public"]
 ```
 
 For a Laravel or Composer app, install dependencies during the build:
@@ -65,6 +66,7 @@ COPY . /app
 RUN composer dump-autoload --optimize --no-interaction
 
 EXPOSE 8080
+CMD ["sh", "-c", "exec frankenphp php-server --listen 0.0.0.0:$PORT --root /app/public"]
 ```
 
 (`install-php-extensions` ships with the FrankenPHP image.)
@@ -76,20 +78,19 @@ EXPOSE 8080
 vendor
 ```
 
-## Set up the app
+## Deploy
 
-FrankenPHP's `php-server` command
-takes the listen address and document root; point it at Miren's injected `$PORT` and
-`0.0.0.0` in a `Procfile`:
+The Dockerfile's `CMD` starts the app, so you don't need a `Procfile` or service command.
+The FrankenPHP base image exposes several HTTP, HTTPS, and admin ports; select this app's
+HTTP port explicitly.
 
-```procfile
-web: frankenphp php-server --listen 0.0.0.0:$PORT --root /app/public
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "php-bench"
+
+[services.web]
+port = 8080
 ```
 
 <CliCommand context="client">
@@ -130,7 +131,7 @@ injects `DATABASE_URL` for you. See
 - **Detection:** none — requires `Dockerfile.miren`
 - **Base image:** `dunglas/frankenphp:1-php8.3`; use `install-php-extensions` for pdo_pgsql, etc.
 - **Composer:** `composer install --no-dev --optimize-autoloader` during the build
-- **Service is required:** `Procfile` `web: frankenphp php-server --listen 0.0.0.0:$PORT --root /app/public` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** FrankenPHP `--listen 0.0.0.0:$PORT`
 - **Env vars:** `miren env set -e/-s`; read with `getenv()` / Laravel `env()`
 - **Database:** optional `[addons.miren-postgresql]` injects `DATABASE_URL`

--- a/docs/docs/guides/python.md
+++ b/docs/docs/guides/python.md
@@ -19,7 +19,7 @@ proposes a start command, wires up environment variables, and deploys — using 
 page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 No. Miren detects Python from a `requirements.txt`, `Pipfile`, `pyproject.toml`, or
 `uv.lock` and builds the image automatically. The default Python version is **3.11**;

--- a/docs/docs/guides/r.md
+++ b/docs/docs/guides/r.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this R API on Miren" after installing the
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect R, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -65,6 +65,8 @@ WORKDIR /app
 COPY . /app
 
 EXPOSE 8080
+ENTRYPOINT ["Rscript"]
+CMD ["/app/entrypoint.R"]
 ```
 
 If you need extra packages, install them in the build:
@@ -76,15 +78,12 @@ If you need extra packages, install them in the build:
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `ENTRYPOINT` and `CMD` start the app. Miren uses them as the web
+service's startup default, so you don't need a `Procfile` or service command.
 
-```procfile
-web: Rscript /app/entrypoint.R
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "r-bench"
@@ -124,7 +123,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Base image:** `rstudio/plumber:latest` (R + Plumber preinstalled)
-- **Service is required:** define a `Procfile` (`web: Rscript /app/entrypoint.R`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `ENTRYPOINT` and `CMD`; no `Procfile` or service command needed
 - **Port:** `Sys.getenv("PORT")`; `pr_run(host = "0.0.0.0", port = port)`
 - **Env vars:** `miren env set -e/-s`; read with `Sys.getenv`
 

--- a/docs/docs/guides/raku.md
+++ b/docs/docs/guides/raku.md
@@ -17,7 +17,7 @@ Ask your AI coding agent to "set up this Raku app on Miren" after installing the
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Raku, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -66,6 +66,7 @@ WORKDIR /app
 RUN zef install --/test Cro::HTTP
 COPY . /app
 EXPOSE 8080
+CMD ["raku", "/app/app.raku"]
 ```
 
 :::warning[Cro needs the OpenSSL headers]
@@ -80,15 +81,12 @@ symlink Cro's native bindings look for.
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: raku /app/app.raku
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "raku-bench"
@@ -119,7 +117,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren`
 - **Base image:** `rakudo-star:latest` (Rakudo + zef); `zef install --/test Cro::HTTP`
 - **OpenSSL:** install `libssl-dev` before `zef install` or Cro::TLS fails to build
-- **Service is required:** define a `Procfile` (`web: raku /app/app.raku`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Keep-alive:** end with `sleep;` so the process stays up after `$service.start`
 - **Port:** `%*ENV<PORT>`; `Cro::HTTP::Server.new(:host('0.0.0.0'), :port(...))`
 - **Env vars:** `miren env set -e/-s`; read with `%*ENV<KEY>`

--- a/docs/docs/guides/ruby.md
+++ b/docs/docs/guides/ruby.md
@@ -19,7 +19,7 @@ Ask your AI coding agent to "set up this Rails app on Miren" after installing th
 using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 No. Miren detects Ruby from your `Gemfile` and builds the image automatically. The
 default Ruby version is **3.4**; override it in [`.miren/app.toml`](/app-configuration)

--- a/docs/docs/guides/rust.md
+++ b/docs/docs/guides/rust.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Rust app on Miren" after installing the
 reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 No. Miren detects Rust from `Cargo.toml` and runs `cargo build --release` for you. The
 default is the **latest Rust 1.x**. Provide a `Dockerfile.miren` only for custom build

--- a/docs/docs/guides/scala.md
+++ b/docs/docs/guides/scala.md
@@ -19,7 +19,7 @@ Ask your AI coding agent to "set up this Scala app on Miren" after installing th
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Scala, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -79,15 +79,12 @@ CMD ["java", "-jar", "app.jar"]
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: java -jar /app/app.jar
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "scala-bench"
@@ -127,7 +124,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** none — requires `Dockerfile.miren`
 - **Build:** `scala-cli --power package app.scala -o app.jar --assembly`; run on a JRE image
-- **Service is required:** define a `Procfile` (`web: java -jar /app/app.jar`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `sys.env.getOrElse("PORT", "8080").toInt`; Cask `override def host = "0.0.0.0"`
 - **Env vars:** `miren env set -e/-s`; read with `sys.env.get`
 

--- a/docs/docs/guides/static.md
+++ b/docs/docs/guides/static.md
@@ -19,7 +19,7 @@ Ask your AI coding agent to "set up this Vite app on Miren" after installing the
 configures the SPA fallback, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Add a `Dockerfile.miren` to your project root. Miren builds from it instead of
 guessing the stack — see [Using Dockerfile.miren](/guides#using-dockerfilemiren).
@@ -57,6 +57,7 @@ COPY site /site
 COPY Caddyfile /etc/caddy/Caddyfile
 
 EXPOSE 8080
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
 ```
 
 For a built SPA (Vite, Astro, Create React App), add a build stage and copy the output
@@ -76,6 +77,7 @@ FROM caddy:2-alpine
 COPY --from=builder /app/dist /site
 COPY Caddyfile /etc/caddy/Caddyfile
 EXPOSE 8080
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
 ```
 
 Point the `COPY --from=builder` at your framework's output directory (`dist` for Vite,
@@ -89,19 +91,19 @@ node_modules
 dist
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile` that runs Caddy
-with your Caddyfile:
+The Dockerfile's `CMD` starts the app, so you don't need a `Procfile` or service command.
+The Caddy base image exposes several HTTP, HTTPS, and admin ports; select this app's HTTP
+port explicitly.
 
-```procfile
-web: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "static-bench"
+
+[services.web]
+port = 8080
 ```
 
 <CliCommand context="client">
@@ -125,7 +127,7 @@ configuration.
 - **Detection:** none — requires `Dockerfile.miren`
 - **Serve:** `caddy:2-alpine` with a `Caddyfile` using `:{$PORT:8080}` and `try_files {path} /index.html`
 - **SPA build:** add a `node:20-alpine` build stage, copy the output dir into `/site`
-- **Service is required:** `Procfile` `web: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** Caddy binds `:{$PORT}` from the environment
 - **Runtime env:** not visible to the browser; use build-time `VITE_*` vars or a runtime config API
 

--- a/docs/docs/guides/swift.md
+++ b/docs/docs/guides/swift.md
@@ -18,7 +18,7 @@ Ask your AI coding agent to "set up this Vapor app on Miren" after installing th
 `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Swift, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -105,16 +105,12 @@ are faster.
 .build
 ```
 
-## Set up the app
+## Deploy
 
-The executable target `App` compiles
-to `/app/App`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /app/App
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "swift-bench"
@@ -155,7 +151,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren`
 - **Build:** `swift build -c release --static-swift-stdlib` on `swift:5.10-jammy` (slow — BoringSSL)
 - **Runtime:** `ubuntu:jammy` + `ca-certificates libcurl4`; binary at `.build/release/<target>`
-- **Service is required:** define a `Procfile` (`web: /app/App`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** `Environment.get("PORT")`; set `app.http.server.configuration.hostname = "0.0.0.0"`
 - **Env vars:** `miren env set -e/-s`; read with `Environment.get`
 

--- a/docs/docs/guides/truffleruby.md
+++ b/docs/docs/guides/truffleruby.md
@@ -19,7 +19,7 @@ the [Miren agent skills](/agent-skills). It adds the `Dockerfile.miren`, wires u
 and the server, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes — to run on TruffleRuby specifically. (Miren's auto-detection would pick MRI Ruby.)
 Add a `Dockerfile.miren` built on the GraalVM TruffleRuby image. See
@@ -73,8 +73,8 @@ require './app'
 run App
 ```
 
-Miren injects `PORT` and routes to it; you bind it via the Puma command in the Procfile
-below (`0.0.0.0` on `$PORT`).
+Miren injects `PORT` and routes to it; the Dockerfile's Puma `CMD` below binds
+`0.0.0.0` on that port.
 
 ## The Dockerfile
 
@@ -88,6 +88,7 @@ COPY Gemfile ./
 RUN bundle install
 COPY . /app
 EXPOSE 8080
+CMD ["sh", "-c", "exec bundle exec puma -b tcp://0.0.0.0:$PORT"]
 ```
 
 ### .dockerignore
@@ -96,13 +97,10 @@ EXPOSE 8080
 .git
 ```
 
-## Set up the app
+## Deploy
 
-Run Puma bound to the injected port:
-
-```procfile
-web: bundle exec puma -b tcp://0.0.0.0:$PORT
-```
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
 TruffleRuby warms up slowly (GraalVM startup plus gem loading), so raise `port_timeout`
 past the 15-second default, and keep one instance always running instead of autoscaling
@@ -151,7 +149,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 
 - **Detection:** MRI Ruby is auto-detected from a `Gemfile`; use `Dockerfile.miren` to pin TruffleRuby
 - **Base image:** `ghcr.io/graalvm/truffleruby-community:latest`; `bundle install` at build time
-- **Service is required:** `Procfile` `web: bundle exec puma -b tcp://0.0.0.0:$PORT` — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Slow boot:** raise `port_timeout` (e.g. `"120s"`) past the 15s default, and pin `num_instances = 1` to stay warm
 - **Port:** Puma `-b tcp://0.0.0.0:$PORT`
 - **Env vars:** `miren env set -e/-s`; read with `ENV['KEY']`

--- a/docs/docs/guides/zig.md
+++ b/docs/docs/guides/zig.md
@@ -17,7 +17,7 @@ Ask your AI coding agent to "set up this Zig app on Miren" after installing the
 server binds `0.0.0.0:$PORT`, and deploys — using this page as its reference.
 :::
 
-## Do you need a Dockerfile?
+## Does this source build need a Dockerfile?
 
 Yes. Miren doesn't auto-detect Zig, so add a `Dockerfile.miren` to your project root.
 Miren builds from it instead of guessing the stack — see
@@ -124,15 +124,12 @@ zig-out
 .zig-cache
 ```
 
-## Set up the app
+## Deploy
 
-Add a `Procfile`:
+The Dockerfile's `CMD` starts the app. Miren uses it as the web service's startup default,
+so you don't need a `Procfile` or service command.
 
-```procfile
-web: /usr/local/bin/app
-```
-
-Then create `.miren/app.toml` naming your app and deploy from your project root:
+Create `.miren/app.toml` naming your app and deploy from your project root:
 
 ```toml
 name = "zig-bench"
@@ -173,7 +170,7 @@ See [App Configuration — Environment Variables](/app-configuration#environment
 - **Detection:** none — requires `Dockerfile.miren` (static binary)
 - **Build:** download Zig tarball, `zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-musl`
 - **Runtime:** copy `zig-out/bin/<name>` to a minimal Alpine image
-- **Service is required:** define a `Procfile` (`web: /usr/local/bin/app`) — the image `CMD` is not used
+- **Startup:** inherited from the Dockerfile `CMD`; no `Procfile` or service command needed
 - **Port:** read `std.posix.getenv("PORT")`; bind `0.0.0.0`
 - **Std API churn:** pin a Zig version; `std.net`/`std.http` change between releases
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -17,7 +17,7 @@ Miren is a container platform for small teams. You install it on a Linux server,
 
 Miren has two sides. The **server** runs on your Linux machine and manages containers, networking, and storage. The **client** is the `miren` CLI on your laptop (or CI runner), which talks to the server over a secure connection.
 
-You deploy apps by running `miren deploy` from your project directory. Miren detects your language (Python, Node, Bun, Go, Ruby, Rust, or a Dockerfile), builds a container image, and runs it. Your first app gets a route automatically. Scaling is automatic by default, adjusting instance counts based on traffic.
+You deploy apps by running `miren deploy` from your project directory. Miren can run a configured container image directly, or detect your language (Python, Node, Bun, Go, Ruby, Rust, or a Dockerfile) and build one from your source. Your first app gets a route automatically. Scaling is automatic by default, adjusting instance counts based on traffic.
 
 If your server is on a home network or behind a firewall, [Miren Anywhere](/miren-cloud/miren-anywhere) still puts your apps on the internet, routing their traffic through Miren Cloud so you don't need port forwarding or a public IP of your own.
 

--- a/docs/docs/recipes/amp-runner.md
+++ b/docs/docs/recipes/amp-runner.md
@@ -72,9 +72,10 @@ The commands below target it explicitly with `-C amp`. Omit `-C` to use your def
 
 ## The Dockerfile
 
-Amp ships as a CLI, not a container image, so build a thin image that installs it with the
-official installer (a standalone binary — no Node required). Include the tools the agent will
-reach for when it runs shell commands (`git`, `ripgrep`, `curl`):
+Keep a Dockerfile here because Amp ships as a CLI, not a container image. This is a real
+application image: it pins and installs Amp, adds the shell tools the agent needs, and copies
+the runner lifecycle script. The official installer produces a standalone binary, so Node
+isn't required.
 
 ```dockerfile
 FROM debian:bookworm-slim

--- a/docs/docs/recipes/headscale.md
+++ b/docs/docs/recipes/headscale.md
@@ -57,7 +57,8 @@ miren whoami
 
 ## The Dockerfile
 
-You only need to add your config file and tell the image what to run:
+Keep a small Dockerfile here. This is a derived image, not a wrapper: the deployment needs
+to add `config.yaml`, and the upstream image supplies an `ENTRYPOINT` but no `CMD`.
 
 ```dockerfile
 FROM docker.io/headscale/headscale:0.29.3
@@ -68,8 +69,10 @@ COPY config.yaml /etc/headscale/config.yaml
 CMD ["serve"]
 ```
 
-That's the whole build. The upstream image already carries the CA bundle headscale needs to
-fetch the DERP map, so there's nothing to install.
+That's the whole build. Miren still inherits the upstream entrypoint and working directory;
+the Dockerfile adds the deployment artifact and completes the image's startup contract. The
+upstream image already carries the CA bundle headscale needs to fetch the DERP map, so
+there's nothing to install.
 
 :::warning[Don't set a `command` for this app]
 The headscale image ships without a shell, and a service that sets `command` needs one.

--- a/docs/docs/recipes/hermes-agent.md
+++ b/docs/docs/recipes/hermes-agent.md
@@ -103,11 +103,11 @@ key = "OPENAI_API_KEY"
 sensitive = true
 ```
 
-The image's `ENTRYPOINT` is s6-overlay:
-`["/init", "/opt/hermes/docker/main-wrapper.sh"]`. `/init` seeds `/opt/data` on first
-boot and drops privileges; `main-wrapper.sh` maps `gateway run` to `hermes gateway run`.
-The `args` field replaces only the image's default `CMD`, so that entrypoint stays intact
-and receives `gateway` and `run` as separate arguments.
+The image's `ENTRYPOINT` is `/opt/hermes/docker/entrypoint-dispatch.sh`. When it runs as
+PID 1, the dispatcher starts s6-overlay and passes the arguments through to Hermes' main
+wrapper. The `args` field supplies `gateway` and `run` as separate arguments without
+replacing that startup path. The image doesn't expose a port, so the recipe declares the
+dashboard's port explicitly.
 
 :::warning[Name the HTTP service `web`]
 Miren's HTTP ingress routes a hostname to the app's `web` service by default, so the
@@ -215,7 +215,7 @@ Healthy signs in the logs: `s6-rc: service main-hermes successfully started`,
 
 ## Roadblock checklist
 
-1. Set `args = ["gateway", "run"]` so Miren preserves the image's s6 `ENTRYPOINT` and replaces only its default `CMD`.
+1. Set `args = ["gateway", "run"]` so Miren preserves the image's dispatcher `ENTRYPOINT` and supplies the gateway subcommand.
 2. Name the HTTP service `web` (or pass `--service <name>` to `miren route set`).
 3. Bind services to `0.0.0.0`, not `127.0.0.1`.
 4. `port_timeout = "180s"` for the slow s6 first boot.

--- a/docs/docs/recipes/openhands-agent-server.md
+++ b/docs/docs/recipes/openhands-agent-server.md
@@ -35,7 +35,7 @@ the browser) and connect it to this server.
 3. A client (Agent Canvas or the SDK) creates a conversation, passing the LLM model + key and
    the agent's tools. The agent runs **in this container**, reading/writing its workspace on
    the mounted disk.
-4. Conversations, the agent workspace, and bash-event history persist under `/data`.
+4. Conversations, the agent workspace, and bash-event history persist under `/workspace`.
 
 ## Prerequisites
 
@@ -57,21 +57,12 @@ miren whoami -C openhands
 
 The commands below target it with `-C openhands`. Omit `-C` to use your default cluster.
 
-## The Dockerfile
+## Use the upstream image
 
-The agent server ships as a prebuilt image; wrap it and clear the entrypoint so Miren runs the
-service command from `app.toml`:
-
-```dockerfile
-FROM ghcr.io/openhands/agent-server:main-python
-ENTRYPOINT []
-```
-
-:::tip[Pin a version]
-`main-python` tracks the latest `main` build of the Python agent-server variant. For
-reproducible deploys, pin one of the commit-tagged images (e.g.
-`ghcr.io/openhands/agent-server:<sha>-python`) instead and bump it deliberately.
-:::
+OpenHands publishes a ready-to-run Python agent-server image. Miren can use its working
+directory, entrypoint, and server defaults directly, so this recipe doesn't need a Dockerfile
+or a shell command. The versioned tag keeps deploys reproducible. Bump it deliberately when
+you want a newer OpenHands release.
 
 ## The app.toml
 
@@ -80,11 +71,9 @@ This file lives at `.miren/app.toml`.
 ```toml
 name = "openhands-agent-server"
 
-[build]
-dockerfile = "Dockerfile"
-
 [services.web]
-command = "exec /usr/local/bin/openhands-agent-server --host 0.0.0.0 --port 8000"
+image = "ghcr.io/openhands/agent-server:1.44.1-python"
+# The image exposes the API and noVNC ports, so select the API port explicitly.
 port = 8000
 port_type = "http"
 port_timeout = "300s"
@@ -97,19 +86,7 @@ num_instances = 1
 [[services.web.disks]]
 name = "workspace"
 provider = "local"
-mount_path = "/data"
-
-# The server's default state paths are RELATIVE to its working directory and fail to create;
-# point them at absolute paths on the writable disk.
-[[env]]
-key = "OH_CONVERSATIONS_PATH"
-value = "/data/conversations"
-[[env]]
-key = "OH_WORKSPACE_PATH"
-value = "/data/project"
-[[env]]
-key = "OH_BASH_EVENTS_DIR"
-value = "/data/bash_events"
+mount_path = "/workspace"
 
 # CORS origin for a browser-based Agent Canvas client (set to your frontend's URL).
 [[env]]
@@ -126,35 +103,26 @@ required = true
 sensitive = true
 ```
 
-:::warning[Set absolute workspace paths]
-The server's `conversations_path` / `workspace_path` / `bash_events_dir` default to paths
-**relative to the process working directory** (`workspace/…`), which it can't create at
-startup — the server exits with `PermissionError: 'workspace'`. Set `OH_CONVERSATIONS_PATH`,
-`OH_WORKSPACE_PATH`, and `OH_BASH_EVENTS_DIR` to absolute paths on the mounted disk.
-:::
+The server defaults to port 8000. Setting `OH_SESSION_API_KEYS_0` enables authentication and
+also makes it listen on `0.0.0.0`, so no command-line override is needed.
 
 :::warning[Use a `local` disk, and let it run as the image's user]
-Mount the workspace with `provider = "local"`. Don't add a `USER root` to the Dockerfile — the
-image runs as its own `openhands` user, and a writable disk is made writable for the run user
-automatically; forcing root opts out of that.
+Mount the image's `/workspace` directory with `provider = "local"`. The server's default
+conversation, project, and bash-event paths all live below that directory. The image runs as
+its own `openhands` user, and Miren makes the disk writable for that user automatically.
 :::
 
 :::warning[The agent runs arbitrary shell in this container]
-A client can make the agent execute shell commands as the container user against `/data`. Use
-a dedicated, revocable session key, treat the workspace as untrusted, and keep the server
-reachable only over its authenticated API.
+A client can make the agent execute shell commands against `/workspace`. The pinned image
+grants the `openhands` user passwordless `sudo`, so those commands can become root inside the
+container. Treat the container as the isolation boundary and the workspace as untrusted. Use
+a dedicated, revocable session key and keep the server reachable only over its authenticated
+API.
 :::
 
 Unlike a typical app, the agent server takes no `LLM_API_KEY` of its own — the client passes the
 model and key when it creates a conversation, and `OH_SECRET_KEY` encrypts those secrets where
 the server persists them.
-
-Add a `.dockerignore` so local secrets stay out of the build context:
-
-```text
-.env
-.miren
-```
 
 ## Deploy
 
@@ -227,9 +195,9 @@ You can also drive the server directly with the OpenHands SDK, which sends the s
 
 ## Roadblock checklist
 
-1. The agent server runs on **port 8000**, not 3000 — set `port = 8000`.
-2. Set `OH_CONVERSATIONS_PATH` / `OH_WORKSPACE_PATH` / `OH_BASH_EVENTS_DIR` to absolute paths, or the server exits with `PermissionError: 'workspace'`.
-3. Use a `provider = "local"` disk; don't force `USER root` (it opts out of the disk being made writable for the run user).
+1. The image exposes both **8000** (API) and **8002** (noVNC), so select `port = 8000` explicitly.
+2. Mount the disk at `/workspace` so the image's default state paths land on it.
+3. Use a `provider = "local"` disk and keep the image's `openhands` user.
 4. Clients authenticate with the `X-Session-API-Key` header; set `OH_SESSION_API_KEYS_0` and `OH_SECRET_KEY`.
 5. For a browser frontend, set `OH_ALLOW_CORS_ORIGINS_0` to its origin.
 6. The client — not the server — supplies the LLM model and key.

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -24,7 +24,7 @@ command = "npm start"
 command = "npm run worker"
 ```
 
-Deploy, and both processes run from your app's built image — `web` receives HTTP traffic, `worker` runs alongside it, and each scales independently.
+Deploy, and both processes run from your app version's primary image. `web` receives HTTP traffic, `worker` runs alongside it, and each scales independently.
 
 ## What is a Service?
 
@@ -102,7 +102,7 @@ command = "npm start"
 command = "npm run worker"
 ```
 
-Both services use your app's built image. The `web` service runs your HTTP server, while `worker` runs a background processor.
+Both services use your app version's primary image. The `web` service runs your HTTP server, while `worker` runs a background processor.
 
 #### Example: Rails with Sidekiq
 
@@ -145,9 +145,12 @@ name = "myapp"
 
 [services.web]
 image = "ghcr.io/example/myapp:latest"
-args = ["serve", "--port", "8080"]
-port = 8080
 ```
+
+With no other service fields, Miren keeps the image's working directory, `ENTRYPOINT`,
+and `CMD`. A single exposed TCP port becomes the web port automatically. Set `port`
+when the image exposes no ports or several, and use `args` or `command` only when its
+startup defaults need to change.
 
 :::note[Image selection]
 Without a Dockerfile, `services.web.image` selects the app's primary image and Miren launches it directly. This explicit image wins over automatic source detection. A `[build].dockerfile` setting or a discovered `Dockerfile.miren` still wins over both.
@@ -179,7 +182,7 @@ mode = "fixed"
 num_instances = 1
 ```
 
-When you specify an `image` on a sidecar service, Miren pulls that container image instead of using your app's built image. This lets you run standard database images alongside your application code.
+When you specify an `image` on a sidecar service, Miren pulls that container image instead of using your app version's primary image. This lets you run standard database images alongside your application code.
 
 #### Example: Full Stack with PostgreSQL and Redis
 
@@ -230,8 +233,8 @@ Each service can configure:
 |--------|-------------|---------|
 | `command` | Shell command that replaces the image startup command (`/bin/sh -c`) | (none) |
 | `args` | Exec-form arguments that replace image `CMD` while preserving `ENTRYPOINT`; mutually exclusive with `command` | (none) |
-| `image` | Container image to use | App's built image |
-| `port` | Port the service listens on (single-port shorthand) | Built image's single TCP `EXPOSE` port, else 3000 (web only) |
+| `image` | Container image to use | App version's primary image |
+| `port` | Port the service listens on (single-port shorthand) | For `web` inheriting the primary image: its single exposed TCP port, otherwise 3000 |
 | `ports` | Port configuration array (multi-port, see [Traffic Routing](/traffic-routing)) | (none) |
 | `port_timeout` | Time to wait for the service to bind its port at startup (e.g. `"60s"`, `"2m"`) | `15s` |
 | `env` | Service-specific environment variables | (none) |
@@ -323,7 +326,8 @@ miren route add myapp.example.com --app myapp
 ```
 </CliCommand>
 
-The web service defaults to the built image's single TCP `EXPOSE` port when one is set, or 3000 otherwise. Override it if your app listens elsewhere:
+When `web` does not inherit a single exposed TCP port from the primary image, it
+defaults to port 3000. Override it if your app listens elsewhere:
 
 ```toml
 [services.web]

--- a/docs/docs/tasks.md
+++ b/docs/docs/tasks.md
@@ -135,7 +135,7 @@ command = "bin/reindex"
 
 `web = false` says so out loud. Without it, Miren would synthesize a web service from your image's entrypoint and keep it running forever — so declaring tasks with no services and no `web` setting is a build error rather than a guess.
 
-Deploying such an app builds the image and provisions addons; that's all. Nothing runs, and nothing is billed for compute, between invocations. `miren app list` reports it as `ready` — deployed and available to invoke, as opposed to `idle`, which means an app that scaled itself to zero.
+Deploying such an app selects or builds its image, provisions addons, and runs any deploy-triggered tasks. No long-running service starts, so nothing runs or is billed for compute between task invocations. `miren app list` reports it as `ready` — deployed and available to invoke, as opposed to `idle`, which means an app that scaled itself to zero.
 
 ## Migrating from `[services.console]`
 

--- a/docs/docs/terminology.md
+++ b/docs/docs/terminology.md
@@ -50,7 +50,7 @@ The [route](#route) automatically assigned to an app when it is first deployed. 
 
 ## Deployment
 
-An attempt to build and release a specific [version](#version) of your app. Running `miren deploy` starts a deployment, which gets its own ID. A successful deployment produces a new [version](#version); a failed deployment produces no version but remains as a record of what was attempted and why it failed. A [rollback](#rollback) is a deployment that re-releases an existing version without building a new one.
+An attempt to select or build an image and release a specific [version](#version) of your app. Running `miren deploy` starts a deployment, which gets its own ID. A successful deployment produces a new [version](#version); a failed deployment produces no version but remains as a record of what was attempted and why it failed. A [rollback](#rollback) is a deployment that re-releases an existing version without selecting or building another image.
 
 A deployment and the version it produces are distinct objects: the deployment is the action, and the version is the resulting artifact.
 
@@ -116,7 +116,7 @@ Maps a hostname to an application. Routes determine how HTTP traffic reaches you
 
 ## Rollback
 
-A type of [deployment](#deployment) that re-releases a previously built [version](#version) instead of building a new one. Because the container image already exists, a rollback skips the [build](#build) step and re-releases the target version as-is.
+A type of [deployment](#deployment) that re-releases an existing [version](#version). Because the container image is already resolved, a rollback skips image selection and building, then releases the target version as-is.
 
 ## Route Protection
 
@@ -148,7 +148,7 @@ Time to live — the expiration timer for an [ephemeral version](#ephemeral-vers
 
 ## Version
 
-A unique identifier for a specific build of your app (e.g., `myapp-vCVkjR6u7744AsMebwMjGU`). Each successful [deployment](#deployment) creates a new version, which tracks the container image, git commit, and configuration. Previous versions can be rolled back to without rebuilding — see [rollback](#rollback).
+A unique identifier for a runnable release of your app (e.g., `myapp-vCVkjR6u7744AsMebwMjGU`). Each successful [deployment](#deployment) creates a new version, which tracks the container image, git commit, and configuration. Previous versions can be rolled back to without selecting or building another image. See [rollback](#rollback).
 
 ## WAF
 


### PR DESCRIPTION
The Bring Your Own Image work gave Miren the ability to preserve an image’s startup contract and resolve its runtime metadata. Much of the documentation still reflected the previous behavior, routing runnable images through Dockerfiles, service commands, and Procfiles that are no longer required.

This sweeps the recipes, language guides, and core documentation to apply those capabilities consistently. OpenHands now runs directly from its upstream image, the Hermes explanation matches its actual metadata, and the retained Headscale and Amp Dockerfiles explain the files or packages they genuinely add.

Source-build tutorials still use Dockerfiles when they compile code or add application files, but those images now carry their own `CMD` instead of repeating it in a Procfile. Direct-image examples inherit the image’s working directory, entrypoint, command, and single exposed TCP port, adding overrides only where the image metadata leaves a gap. Verified with the docs build and local OpenHands and Hermes smoke deploys on current `main`.

Closes MIR-1686
