### PR TITLE
Make sandbox DNS forwarding observable and resilient

### DIFF
--- a/controllers/sandbox/resolv_conf_test.go
+++ b/controllers/sandbox/resolv_conf_test.go
@@ -1,0 +1,42 @@
+package sandbox
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/network"
+)
+
+func TestWriteResolve(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolv.conf")
+	ep := &network.EndpointConfig{
+		Bridge: &network.BridgeConfig{
+			Addresses: []netip.Prefix{
+				netip.MustParsePrefix("10.8.95.1/24"),
+				netip.MustParsePrefix("fd00::1/64"),
+			},
+		},
+	}
+
+	err := (&SandboxController{}).writeResolve(path, ep)
+	require.NoError(t, err)
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "search app.miren\n"+
+		"options timeout:2 attempts:3\n"+
+		"nameserver 10.8.95.1\n"+
+		"nameserver fd00::1\n", string(contents))
+}
+
+func TestWriteResolveRequiresNameserver(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolv.conf")
+	ep := &network.EndpointConfig{Bridge: &network.BridgeConfig{}}
+
+	err := (&SandboxController{}).writeResolve(path, ep)
+
+	assert.EqualError(t, err, "no nameservers available in bridge config")
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -2085,6 +2085,7 @@ func (c *SandboxController) writeResolve(path string, ep *network.EndpointConfig
 
 	// Add search domain for app.miren
 	fmt.Fprintf(f, "search app.miren\n")
+	fmt.Fprintf(f, "options timeout:2 attempts:3\n")
 
 	for _, addr := range ep.Bridge.Addresses {
 		if !addr.Addr().IsValid() {

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -100,7 +100,7 @@ func TestSandboxControllerFrozen(t *testing.T) {
 		// refresh tick. No matching saga edit either: reconcileSandboxesOnBoot
 		// is only reached from Init, which both paths share, and the saga
 		// controller has no boot reconciliation of its own.
-		"sandbox.go":  "5a553e6a9c1594a5f75fbf4e753ee8c0eaffbfa80a779d12542d9c77e57ee798",
+		"sandbox.go":  "d38b8bc2e05cf5b3419d0bec46899415936f100a4e99e9e10b6b8d1b4404d7ec",
 		"volume.go":   "4105e65c8453fd7c3c7025da93aaffb0ee5c5416aa3ca1432c23fec850aedb15",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/network/services.go
+++ b/network/services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/netip"
 	"slices"
 	"sync"
@@ -63,7 +64,7 @@ func (sm *ServiceManager) SetupDNS(ctx context.Context, bc *BridgeConfig) error 
 
 	for _, addr := range bs.ips {
 		// Create and start DNS server with entity client and logger
-		server, err := dns.New(fmt.Sprintf("%s:53", addr.Addr().String()), sm.EAC, sm.Log)
+		server, err := dns.New(net.JoinHostPort(addr.Addr().String(), "53"), sm.EAC, sm.Log)
 		if err != nil {
 			return fmt.Errorf("creating DNS server for bridge %s: %w", bridgeName, err)
 		}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -10,9 +11,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/miekg/dns"
+	"golang.org/x/net/netutil"
 	"miren.dev/runtime/api/compute"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/indexwatch"
@@ -40,12 +43,92 @@ type sandboxMapping struct {
 	seq     uint64
 }
 
+const (
+	forwardTimeout     = 1500 * time.Millisecond
+	forwardLogInterval = time.Minute
+	// DNS-over-TCP connections are normally brief. This leaves ample room for
+	// bursts while bounding the goroutines held by buggy sandbox clients.
+	maxTCPConnections = 256
+)
+
+type exchanger interface {
+	ExchangeContext(context.Context, *dns.Msg, string) (*dns.Msg, time.Duration, error)
+}
+
+type forwardLogKey struct {
+	upstream string
+	network  string
+	reason   string
+}
+
+type forwardLogState struct {
+	last       time.Time
+	suppressed int64
+}
+
+// forwardLogDeduper keeps a broken resolver or tenant-controlled query loop from
+// flooding Warn while still periodically recording that the failure continues.
+// Its key space is bounded by the server's configured upstreams and the small set
+// of failure reasons below.
+type forwardLogDeduper struct {
+	mu       sync.Mutex
+	interval time.Duration
+	seen     map[forwardLogKey]*forwardLogState
+	now      func() time.Time
+}
+
+func newForwardLogDeduper() *forwardLogDeduper {
+	return &forwardLogDeduper{
+		interval: forwardLogInterval,
+		seen:     make(map[forwardLogKey]*forwardLogState),
+	}
+}
+
+func (d *forwardLogDeduper) record(key forwardLogKey) (bool, int64) {
+	if d == nil {
+		return true, 0
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now()
+	if d.now != nil {
+		now = d.now()
+	}
+	if state, ok := d.seen[key]; ok {
+		if now.Sub(state.last) < d.interval {
+			state.suppressed++
+			return false, 0
+		}
+		suppressed := state.suppressed
+		state.last = now
+		state.suppressed = 0
+		return true, suppressed
+	}
+
+	d.seen[key] = &forwardLogState{last: now}
+	return true, 0
+}
+
 type Server struct {
-	*dns.Server
-	client       *dns.Client
-	upstreams    []string
-	entityClient *entityserver_v1alpha.EntityAccessClient
-	log          *slog.Logger
+	addr          string
+	boundAddr     string
+	udpServer     *dns.Server
+	tcpServer     *dns.Server
+	udpClient     exchanger
+	tcpClient     exchanger
+	forwardBudget time.Duration
+	forwardLogs   *forwardLogDeduper
+	upstreams     []string
+	entityClient  *entityserver_v1alpha.EntityAccessClient
+	log           *slog.Logger
+	ready         chan struct{}
+	listenDone    chan struct{}
+	listenStarted atomic.Bool
+	stopRequested atomic.Bool
+	shutdownOnce  sync.Once
+	shutdownErr   error
 
 	mu              sync.RWMutex
 	ipToApp         map[string]string              // source IP → app name
@@ -74,15 +157,21 @@ func New(addr string, entityClient *entityserver_v1alpha.EntityAccessClient, log
 		return nil, fmt.Errorf("no nameservers found in /etc/resolv.conf")
 	}
 
+	return newServer(addr, upstreams, entityClient, log), nil
+}
+
+func newServer(addr string, upstreams []string, entityClient *entityserver_v1alpha.EntityAccessClient, log *slog.Logger) *Server {
 	s := &Server{
-		Server: &dns.Server{
-			Addr: addr,
-			Net:  "udp",
-		},
-		client:          &dns.Client{},
+		addr:            addr,
+		udpClient:       &dns.Client{Net: "udp", Timeout: forwardTimeout},
+		tcpClient:       &dns.Client{Net: "tcp", Timeout: forwardTimeout},
+		forwardBudget:   forwardTimeout,
+		forwardLogs:     newForwardLogDeduper(),
 		upstreams:       upstreams,
 		entityClient:    entityClient,
 		log:             log.With("module", "dns"),
+		ready:           make(chan struct{}),
+		listenDone:      make(chan struct{}),
 		ipToApp:         make(map[string]string),
 		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
@@ -90,8 +179,10 @@ func New(addr string, entityClient *entityserver_v1alpha.EntityAccessClient, log
 		sandboxes:       make(map[string]sandboxMapping),
 	}
 
-	s.Handler = dns.HandlerFunc(s.handleRequest)
-	return s, nil
+	handler := dns.HandlerFunc(s.handleRequest)
+	s.udpServer = &dns.Server{Handler: handler}
+	s.tcpServer = &dns.Server{Handler: handler}
+	return s
 }
 
 func (s *Server) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
@@ -138,34 +229,7 @@ func (s *Server) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
-	// Not an app.miren query, forward to upstream
-	var response *dns.Msg
-	var err error
-
-	for _, upstream := range s.upstreams {
-		// Ensure upstream address has port 53
-		upstream = net.JoinHostPort(upstream, "53")
-		response, _, err = s.client.Exchange(r, upstream)
-		if err == nil && response != nil {
-			break
-		}
-	}
-
-	if err != nil || response == nil {
-		// If all upstreams failed, return SERVFAIL
-		response = new(dns.Msg)
-		response.SetReply(r)
-		response.Rcode = dns.RcodeServerFailure
-		w.WriteMsg(response)
-		return
-	}
-
-	// Ensure the response has the correct id and is marked as a response
-	response.Id = r.Id
-	response.RecursionAvailable = true
-	response.Response = true
-
-	w.WriteMsg(response)
+	s.forwardToUpstream(w, r)
 }
 
 func (s *Server) handleServiceListQuery(w dns.ResponseWriter, r *dns.Msg) {
@@ -330,29 +394,177 @@ func (s *Server) handlePTRQuery(w dns.ResponseWriter, r *dns.Msg, qname string) 
 }
 
 func (s *Server) forwardToUpstream(w dns.ResponseWriter, r *dns.Msg) {
-	var response *dns.Msg
-	var err error
+	budget := s.forwardBudget
+	if budget <= 0 {
+		budget = forwardTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
 
-	for _, upstream := range s.upstreams {
-		upstream = net.JoinHostPort(upstream, "53")
-		response, _, err = s.client.Exchange(r, upstream)
-		if err == nil && response != nil {
+	var truncatedFallback *dns.Msg
+	deadline, _ := ctx.Deadline()
+	for i, upstream := range s.upstreams {
+		if ctx.Err() != nil {
 			break
 		}
-	}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		upstreamsLeft := len(s.upstreams) - i
+		upstreamCtx, upstreamCancel := context.WithTimeout(ctx, remaining/time.Duration(upstreamsLeft))
 
-	if err != nil || response == nil {
-		response = new(dns.Msg)
-		response.SetReply(r)
-		response.Rcode = dns.RcodeServerFailure
-		w.WriteMsg(response)
+		endpoint := net.JoinHostPort(upstream, "53")
+		response, ok := s.exchange(upstreamCtx, r, w, s.udpClient, endpoint, "udp")
+		if !ok {
+			upstreamCancel()
+			continue
+		}
+
+		if response.Truncated {
+			if truncatedFallback == nil {
+				truncatedFallback = response
+			}
+			s.log.Debug("DNS upstream response truncated; retrying over TCP",
+				s.queryAttrs(r, w, endpoint, "tcp")...)
+			response, ok = s.exchange(upstreamCtx, r, w, s.tcpClient, endpoint, "tcp")
+			if !ok {
+				upstreamCancel()
+				continue
+			}
+		}
+
+		upstreamCancel()
+		s.writeForwardedResponse(w, r, response)
 		return
 	}
 
-	response.Id = r.Id
+	if truncatedFallback != nil && responseWriterNetwork(w) == "udp" {
+		s.writeForwardedResponse(w, r, truncatedFallback)
+		return
+	}
+
+	qname, qtype := queryNameAndType(r)
+	s.logForwardWarning("DNS forwarding failed; returning SERVFAIL",
+		forwardLogKey{reason: "exhausted"},
+		"qname", qname,
+		"qtype", qtype,
+		"client_ip", responseWriterIP(w),
+		"upstreams", s.upstreams,
+	)
+	response := new(dns.Msg)
+	response.SetReply(r)
+	response.Rcode = dns.RcodeServerFailure
+	w.WriteMsg(response)
+}
+
+func (s *Server) writeForwardedResponse(w dns.ResponseWriter, request, response *dns.Msg) {
+	response.Id = request.Id
 	response.RecursionAvailable = true
 	response.Response = true
+	if responseWriterNetwork(w) == "udp" {
+		size := dns.MinMsgSize
+		if opt := request.IsEdns0(); opt != nil {
+			size = int(opt.UDPSize())
+		}
+		response.Truncate(size)
+	}
 	w.WriteMsg(response)
+}
+
+func (s *Server) exchange(ctx context.Context, r *dns.Msg, w dns.ResponseWriter, client exchanger, upstream, network string) (*dns.Msg, bool) {
+	response, _, err := client.ExchangeContext(ctx, r, upstream)
+	if err != nil {
+		s.logForwardWarning("DNS upstream query failed",
+			forwardLogKey{upstream: upstream, network: network, reason: "exchange"},
+			append(s.queryAttrs(r, w, upstream, network), "error", err)...)
+		return nil, false
+	}
+	if response == nil {
+		s.logForwardWarning("DNS upstream query returned no response",
+			forwardLogKey{upstream: upstream, network: network, reason: "empty"},
+			s.queryAttrs(r, w, upstream, network)...)
+		return nil, false
+	}
+	// SERVFAIL from one upstream may be a resolver failure rather than an
+	// authoritative answer, so try the next one. When every resolver agrees,
+	// this trades some latency for protection against a broken upstream.
+	if response.Rcode == dns.RcodeServerFailure {
+		s.logForwardWarning("DNS upstream returned SERVFAIL",
+			forwardLogKey{upstream: upstream, network: network, reason: "servfail"},
+			s.queryAttrs(r, w, upstream, network)...)
+		return nil, false
+	}
+
+	return response, true
+}
+
+func (s *Server) logForwardWarning(message string, key forwardLogKey, attrs ...any) {
+	shouldLog, suppressed := s.forwardLogs.record(key)
+	if !shouldLog {
+		return
+	}
+	if suppressed > 0 {
+		attrs = append(attrs, "suppressed", suppressed)
+	}
+	s.log.Warn(message, attrs...)
+}
+
+func (s *Server) queryAttrs(r *dns.Msg, w dns.ResponseWriter, upstream, network string) []any {
+	qname, qtype := queryNameAndType(r)
+	return []any{
+		"qname", qname,
+		"qtype", qtype,
+		"client_ip", responseWriterIP(w),
+		"upstream", upstream,
+		"network", network,
+	}
+}
+
+func queryNameAndType(r *dns.Msg) (string, string) {
+	if r == nil || len(r.Question) == 0 {
+		return "", ""
+	}
+	question := r.Question[0]
+	qtype, ok := dns.TypeToString[question.Qtype]
+	if !ok {
+		qtype = fmt.Sprintf("TYPE%d", question.Qtype)
+	}
+	return strings.ToLower(question.Name), qtype
+}
+
+func responseWriterIP(w dns.ResponseWriter) string {
+	if w == nil || w.RemoteAddr() == nil {
+		return ""
+	}
+	switch addr := w.RemoteAddr().(type) {
+	case *net.UDPAddr:
+		return addr.IP.String()
+	case *net.TCPAddr:
+		return addr.IP.String()
+	default:
+		host, _, err := net.SplitHostPort(w.RemoteAddr().String())
+		if err == nil {
+			return host
+		}
+		return w.RemoteAddr().String()
+	}
+}
+
+func responseWriterNetwork(w dns.ResponseWriter) string {
+	if w == nil {
+		return "unknown"
+	}
+	if addr := w.RemoteAddr(); addr != nil {
+		network := addr.Network()
+		if strings.HasPrefix(network, "udp") {
+			return "udp"
+		}
+		if strings.HasPrefix(network, "tcp") {
+			return "tcp"
+		}
+	}
+	return "unknown"
 }
 
 func (s *Server) handleAppMirenQuery(w dns.ResponseWriter, r *dns.Msg, qname string) {
@@ -614,6 +826,8 @@ func (s *Server) handleSandboxUpdate(ctx context.Context, sb *compute_v1alpha.Sa
 func NewTestServer() *Server {
 	return &Server{
 		log:             slog.Default(),
+		ready:           make(chan struct{}),
+		listenDone:      make(chan struct{}),
 		ipToApp:         make(map[string]string),
 		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
@@ -937,11 +1151,72 @@ func (s *Server) RemoveSandboxMapping(sandboxID string) {
 
 // ListenAndServe starts the DNS server
 func (s *Server) ListenAndServe() error {
-	return s.Server.ListenAndServe()
+	if !s.listenStarted.CompareAndSwap(false, true) {
+		return errors.New("dns server already started")
+	}
+	defer close(s.listenDone)
+	if s.stopRequested.Load() {
+		return nil
+	}
+
+	tcpListener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return fmt.Errorf("listening for TCP DNS: %w", err)
+	}
+	tcpListener = netutil.LimitListener(tcpListener, maxTCPConnections)
+
+	// Binding TCP first lets an address ending in :0 pick one port that both
+	// transports share. Production addresses name port 53 explicitly, but the
+	// shared ephemeral port keeps the same invariant in tests.
+	boundAddr := tcpListener.Addr().String()
+	udpConn, err := net.ListenPacket("udp", boundAddr)
+	if err != nil {
+		tcpListener.Close()
+		return fmt.Errorf("listening for UDP DNS: %w", err)
+	}
+	s.boundAddr = boundAddr
+
+	started := make(chan struct{}, 2)
+	s.udpServer.PacketConn = udpConn
+	s.udpServer.NotifyStartedFunc = func() { started <- struct{}{} }
+	s.tcpServer.Listener = tcpListener
+	s.tcpServer.NotifyStartedFunc = func() { started <- struct{}{} }
+
+	errs := make(chan error, 2)
+	go func() { errs <- s.udpServer.ActivateAndServe() }()
+	go func() { errs <- s.tcpServer.ActivateAndServe() }()
+
+	for range 2 {
+		select {
+		case <-started:
+		case serveErr := <-errs:
+			udpConn.Close()
+			tcpListener.Close()
+			return serveErr
+		}
+	}
+	close(s.ready)
+	if s.stopRequested.Load() {
+		s.shutdownListeners()
+	}
+
+	firstErr := <-errs
+	shutdownErr := s.shutdownListeners()
+	secondErr := <-errs
+	return errors.Join(firstErr, secondErr, shutdownErr)
+}
+
+func (s *Server) shutdownListeners() error {
+	s.shutdownOnce.Do(func() {
+		s.shutdownErr = errors.Join(s.udpServer.Shutdown(), s.tcpServer.Shutdown())
+	})
+	return s.shutdownErr
 }
 
 // Shutdown gracefully shuts down the server
 func (s *Server) Shutdown() error {
+	s.stopRequested.Store(true)
+
 	// Cancel the watch context to stop the watcher goroutine
 	if s.watchCancel != nil {
 		s.watchCancel()
@@ -954,6 +1229,16 @@ func (s *Server) Shutdown() error {
 	// Wait for the watcher goroutine to finish
 	s.watchWg.Wait()
 
-	// Shutdown the DNS server
-	return s.Server.Shutdown()
+	if s.udpServer == nil || s.tcpServer == nil {
+		return nil
+	}
+	if !s.listenStarted.Load() {
+		return nil
+	}
+	select {
+	case <-s.ready:
+		return s.shutdownListeners()
+	case <-s.listenDone:
+		return nil
+	}
 }

--- a/pkg/dns/forward_test.go
+++ b/pkg/dns/forward_test.go
@@ -1,0 +1,352 @@
+package dns
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	mdns "github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/slogfmt"
+)
+
+type exchangeResult struct {
+	msg *mdns.Msg
+	err error
+}
+
+type fakeExchanger struct {
+	results []exchangeResult
+	calls   []string
+}
+
+func (f *fakeExchanger) ExchangeContext(_ context.Context, _ *mdns.Msg, upstream string) (*mdns.Msg, time.Duration, error) {
+	f.calls = append(f.calls, upstream)
+	if len(f.results) == 0 {
+		return nil, 0, errors.New("unexpected exchange")
+	}
+	result := f.results[0]
+	f.results = f.results[1:]
+	return result.msg, 0, result.err
+}
+
+type blockingExchanger struct {
+	calls int
+}
+
+func (f *blockingExchanger) ExchangeContext(ctx context.Context, _ *mdns.Msg, _ string) (*mdns.Msg, time.Duration, error) {
+	f.calls++
+	<-ctx.Done()
+	return nil, 0, ctx.Err()
+}
+
+type captureResponseWriter struct {
+	remote  net.Addr
+	message *mdns.Msg
+}
+
+func (w *captureResponseWriter) LocalAddr() net.Addr          { return &net.UDPAddr{} }
+func (w *captureResponseWriter) RemoteAddr() net.Addr         { return w.remote }
+func (w *captureResponseWriter) WriteMsg(msg *mdns.Msg) error { w.message = msg; return nil }
+func (w *captureResponseWriter) Write([]byte) (int, error)    { return 0, nil }
+func (w *captureResponseWriter) Close() error                 { return nil }
+func (w *captureResponseWriter) TsigStatus() error            { return nil }
+func (w *captureResponseWriter) TsigTimersOnly(bool)          {}
+func (w *captureResponseWriter) Hijack()                      {}
+
+func testForwardServer(t *testing.T, upstreams []string, udp, tcp exchanger) (*Server, *bytes.Buffer) {
+	t.Helper()
+	var logs bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s := newServer("127.0.0.1:0", upstreams, nil, log)
+	s.udpClient = udp
+	s.tcpClient = tcp
+	return s, &logs
+}
+
+func query(name string) *mdns.Msg {
+	msg := new(mdns.Msg)
+	msg.SetQuestion(name, mdns.TypeA)
+	return msg
+}
+
+func successfulResponse(request *mdns.Msg) *mdns.Msg {
+	response := new(mdns.Msg)
+	response.SetReply(request)
+	return response
+}
+
+func oversizedResponse(request *mdns.Msg, size int) *mdns.Msg {
+	response := successfulResponse(request)
+	for response.Len() <= size {
+		response.Answer = append(response.Answer, &mdns.TXT{
+			Hdr: mdns.RR_Header{Name: request.Question[0].Name, Rrtype: mdns.TypeTXT, Class: mdns.ClassINET},
+			Txt: []string{strings.Repeat("x", 200)},
+		})
+	}
+	return response
+}
+
+func TestNewServerSetsExplicitUpstreamTimeouts(t *testing.T) {
+	s := newServer("127.0.0.1:0", []string{"192.0.2.1"}, nil, slog.Default())
+
+	udp, ok := s.udpClient.(*mdns.Client)
+	require.True(t, ok)
+	tcp, ok := s.tcpClient.(*mdns.Client)
+	require.True(t, ok)
+	assert.Equal(t, forwardTimeout, udp.Timeout)
+	assert.Equal(t, "udp", udp.Net)
+	assert.Equal(t, forwardTimeout, tcp.Timeout)
+	assert.Equal(t, "tcp", tcp.Net)
+	assert.Equal(t, forwardTimeout, s.forwardBudget)
+	assert.NotNil(t, s.forwardLogs)
+}
+
+func TestServerListensOnUDPAndTCP(t *testing.T) {
+	log := slog.New(slogfmt.NewTestHandler(t, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s := newServer("127.0.0.1:0", []string{"192.0.2.1"}, nil, log)
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.ListenAndServe() }()
+
+	select {
+	case <-s.ready:
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("DNS listeners did not start")
+	}
+
+	for _, network := range []string{"udp", "tcp"} {
+		t.Run(network, func(t *testing.T) {
+			client := &mdns.Client{Net: network, Timeout: time.Second}
+			msg := new(mdns.Msg)
+			msg.SetQuestion("web.app.miren.", mdns.TypeAAAA)
+			response, _, err := client.Exchange(msg, s.boundAddr)
+			require.NoError(t, err)
+			assert.Equal(t, mdns.RcodeSuccess, response.Rcode)
+		})
+	}
+
+	require.NoError(t, s.Shutdown())
+	require.NoError(t, <-errCh)
+}
+
+func TestShutdownRequestedBeforeListenStopsBothListeners(t *testing.T) {
+	log := slog.New(slogfmt.NewTestHandler(t, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s := newServer("127.0.0.1:0", []string{"192.0.2.1"}, nil, log)
+	require.NoError(t, s.Shutdown())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.ListenAndServe() }()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("DNS listeners did not honor the pending shutdown")
+	}
+	assert.Empty(t, s.boundAddr, "a server stopped before startup must not bind")
+}
+
+func TestListenAndServeRejectsSecondCall(t *testing.T) {
+	log := slog.New(slogfmt.NewTestHandler(t, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s := newServer("127.0.0.1:0", []string{"192.0.2.1"}, nil, log)
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.ListenAndServe() }()
+
+	select {
+	case <-s.ready:
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("DNS listeners did not start")
+	}
+
+	assert.EqualError(t, s.ListenAndServe(), "dns server already started")
+	require.NoError(t, s.Shutdown())
+	require.NoError(t, <-errCh)
+}
+
+func TestForwardRetruncatesTCPResponseForUDPClient(t *testing.T) {
+	request := query("example.com.")
+	truncated := successfulResponse(request)
+	truncated.Truncated = true
+	tcpResponse := oversizedResponse(request, mdns.MinMsgSize)
+	require.Greater(t, tcpResponse.Len(), mdns.MinMsgSize)
+
+	udp := &fakeExchanger{results: []exchangeResult{{msg: truncated}}}
+	tcp := &fakeExchanger{results: []exchangeResult{{msg: tcpResponse}}}
+	s, logs := testForwardServer(t, []string{"192.0.2.1"}, udp, tcp)
+	w := &captureResponseWriter{remote: &net.UDPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	s.forwardToUpstream(w, request)
+
+	require.Same(t, tcpResponse, w.message)
+	assert.True(t, w.message.Truncated)
+	assert.LessOrEqual(t, w.message.Len(), mdns.MinMsgSize)
+	assert.Equal(t, []string{"192.0.2.1:53"}, udp.calls)
+	assert.Equal(t, []string{"192.0.2.1:53"}, tcp.calls)
+	assert.Contains(t, logs.String(), "retrying over TCP")
+}
+
+func TestForwardKeepsFullTCPResponseForTCPClient(t *testing.T) {
+	request := query("example.com.")
+	truncated := successfulResponse(request)
+	truncated.Truncated = true
+	tcpResponse := oversizedResponse(request, mdns.MinMsgSize)
+	fullSize := tcpResponse.Len()
+
+	udp := &fakeExchanger{results: []exchangeResult{{msg: truncated}}}
+	tcp := &fakeExchanger{results: []exchangeResult{{msg: tcpResponse}}}
+	s, _ := testForwardServer(t, []string{"192.0.2.1"}, udp, tcp)
+	w := &captureResponseWriter{remote: &net.TCPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	s.forwardToUpstream(w, request)
+
+	require.Same(t, tcpResponse, w.message)
+	assert.False(t, w.message.Truncated)
+	assert.Equal(t, fullSize, w.message.Len())
+}
+
+func TestForwardHonorsEDNSUDPSize(t *testing.T) {
+	request := query("example.com.")
+	request.SetEdns0(1232, false)
+	truncated := successfulResponse(request)
+	truncated.Truncated = true
+	tcpResponse := oversizedResponse(request, 1232)
+
+	udp := &fakeExchanger{results: []exchangeResult{{msg: truncated}}}
+	tcp := &fakeExchanger{results: []exchangeResult{{msg: tcpResponse}}}
+	s, _ := testForwardServer(t, []string{"192.0.2.1"}, udp, tcp)
+	w := &captureResponseWriter{remote: &net.UDPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	s.forwardToUpstream(w, request)
+
+	assert.True(t, w.message.Truncated)
+	assert.LessOrEqual(t, w.message.Len(), 1232)
+}
+
+func TestForwardTriesNextUpstreamAfterTCPRetryFails(t *testing.T) {
+	request := query("example.com.")
+	truncated := successfulResponse(request)
+	truncated.Truncated = true
+	secondResponse := successfulResponse(request)
+
+	udp := &fakeExchanger{results: []exchangeResult{{msg: truncated}, {msg: secondResponse}}}
+	tcp := &fakeExchanger{results: []exchangeResult{{err: errors.New("TCP unavailable")}}}
+	s, logs := testForwardServer(t, []string{"192.0.2.1", "192.0.2.2"}, udp, tcp)
+	w := &captureResponseWriter{remote: &net.TCPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	s.forwardToUpstream(w, request)
+
+	require.Same(t, secondResponse, w.message)
+	assert.Equal(t, []string{"192.0.2.1:53", "192.0.2.2:53"}, udp.calls)
+	assert.Equal(t, []string{"192.0.2.1:53"}, tcp.calls)
+	assert.Contains(t, logs.String(), "network=tcp")
+	assert.Contains(t, logs.String(), "TCP unavailable")
+}
+
+func TestForwardReturnsTruncatedFallbackWhenTCPRetriesFail(t *testing.T) {
+	request := query("example.com.")
+	truncated := successfulResponse(request)
+	truncated.Truncated = true
+
+	udp := &fakeExchanger{results: []exchangeResult{
+		{msg: truncated},
+		{err: errors.New("second resolver unavailable")},
+	}}
+	tcp := &fakeExchanger{results: []exchangeResult{{err: errors.New("TCP unavailable")}}}
+	s, logs := testForwardServer(t, []string{"192.0.2.1", "192.0.2.2"}, udp, tcp)
+	w := &captureResponseWriter{remote: &net.UDPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	s.forwardToUpstream(w, request)
+
+	require.Same(t, truncated, w.message)
+	assert.True(t, w.message.Truncated)
+	assert.NotEqual(t, mdns.RcodeServerFailure, w.message.Rcode)
+	assert.NotContains(t, logs.String(), "DNS forwarding failed; returning SERVFAIL")
+}
+
+func TestForwardTriesNextUpstreamAfterSERVFAIL(t *testing.T) {
+	request := query("example.com.")
+	servfail := successfulResponse(request)
+	servfail.Rcode = mdns.RcodeServerFailure
+	success := successfulResponse(request)
+
+	udp := &fakeExchanger{results: []exchangeResult{{msg: servfail}, {msg: success}}}
+	s, logs := testForwardServer(t, []string{"192.0.2.1", "192.0.2.2"}, udp, &fakeExchanger{})
+	w := &captureResponseWriter{remote: &net.UDPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	s.forwardToUpstream(w, request)
+
+	require.Same(t, success, w.message)
+	assert.Equal(t, []string{"192.0.2.1:53", "192.0.2.2:53"}, udp.calls)
+	assert.Contains(t, logs.String(), "DNS upstream returned SERVFAIL")
+	assert.Contains(t, logs.String(), "qname=example.com.")
+	assert.Contains(t, logs.String(), "client_ip=10.8.95.12")
+}
+
+func TestForwardLogsAndReturnsSERVFAILWhenAllUpstreamsFail(t *testing.T) {
+	request := query("example.com.")
+	udp := &fakeExchanger{results: []exchangeResult{
+		{err: errors.New("first resolver timed out")},
+		{err: errors.New("second resolver timed out")},
+	}}
+	s, logs := testForwardServer(t, []string{"192.0.2.1", "192.0.2.2"}, udp, &fakeExchanger{})
+	w := &captureResponseWriter{remote: &net.UDPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	s.forwardToUpstream(w, request)
+
+	require.NotNil(t, w.message)
+	assert.Equal(t, mdns.RcodeServerFailure, w.message.Rcode)
+	assert.Contains(t, logs.String(), "first resolver timed out")
+	assert.Contains(t, logs.String(), "second resolver timed out")
+	assert.Contains(t, logs.String(), "DNS forwarding failed; returning SERVFAIL")
+	assert.Contains(t, logs.String(), "qtype=A")
+	assert.Contains(t, logs.String(), "client_ip=10.8.95.12")
+	assert.NotContains(t, logs.String(), "level=ERROR")
+}
+
+func TestForwardSlicesOneBudgetAcrossUpstreams(t *testing.T) {
+	blocking := &blockingExchanger{}
+	s, _ := testForwardServer(t, []string{"192.0.2.1", "192.0.2.2"}, blocking, &fakeExchanger{})
+	s.forwardBudget = 100 * time.Millisecond
+	w := &captureResponseWriter{remote: &net.UDPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	started := time.Now()
+	s.forwardToUpstream(w, query("example.com."))
+
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	assert.Equal(t, 2, blocking.calls, "a blackholed primary must not starve the secondary")
+	require.NotNil(t, w.message)
+	assert.Equal(t, mdns.RcodeServerFailure, w.message.Rcode)
+}
+
+func TestForwardFailureLogsAreDeduplicated(t *testing.T) {
+	udp := &fakeExchanger{results: []exchangeResult{
+		{err: errors.New("resolver timed out")},
+		{err: errors.New("resolver timed out")},
+		{err: errors.New("resolver timed out")},
+	}}
+	s, logs := testForwardServer(t, []string{"192.0.2.1"}, udp, &fakeExchanger{})
+	now := time.Date(2026, time.September, 1, 12, 0, 0, 0, time.UTC)
+	s.forwardLogs.now = func() time.Time { return now }
+	w := &captureResponseWriter{remote: &net.UDPAddr{IP: net.ParseIP("10.8.95.12"), Port: 53000}}
+
+	s.forwardToUpstream(w, query("first.example."))
+	s.forwardToUpstream(w, query("second.example."))
+	assert.Equal(t, 1, strings.Count(logs.String(), "DNS upstream query failed"))
+	assert.Equal(t, 1, strings.Count(logs.String(), "DNS forwarding failed; returning SERVFAIL"))
+
+	now = now.Add(forwardLogInterval)
+	s.forwardToUpstream(w, query("third.example."))
+	assert.Equal(t, 2, strings.Count(logs.String(), "DNS upstream query failed"))
+	assert.Equal(t, 2, strings.Count(logs.String(), "DNS forwarding failed; returning SERVFAIL"))
+	assert.Contains(t, logs.String(), "suppressed=1")
+}


### PR DESCRIPTION
Sandbox DNS failures currently disappear into a silent SERVFAIL, while glibc can spend ten seconds waiting before the app sees an error. This gives sandbox resolvers a bounded retry policy and gives operators actionable, rate-limited Warn records with the query, client, transport, and upstream that failed.

The bridge resolver now serves both UDP and TCP on IPv4 and IPv6. Truncated upstream replies retry over TCP, then get sized for the client's transport. If upstream TCP is unavailable, UDP clients retain the original truncated reply and can retry against the bridge's TCP listener. The upstream walk remains serial, but one 1.5-second budget bounds the whole request rather than each attempt.

Closes MIR-1704
Closes MIR-1702