### PR TITLE
Make component cleanup survive canceled startup

### DIFF
--- a/components/appmetrics/appmetrics.go
+++ b/components/appmetrics/appmetrics.go
@@ -4,6 +4,7 @@ package appmetrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -141,7 +142,10 @@ func (c *Component) Start(ctx context.Context, config Config) error {
 		// The destination and mounted config are part of the container spec. A
 		// server restart must recreate it so an operator's config change cannot
 		// leave an old destination running indefinitely.
-		c.CleanupExistingContainer(ctx, existing)
+		if cleanupErr := c.CleanupExistingContainer(ctx, existing); cleanupErr != nil {
+			c.stopBackground()
+			return fmt.Errorf("cleaning up existing vmagent container: %w", cleanupErr)
+		}
 	}
 
 	container, err := c.createContainer(ctx, image, dataPath, config.RemoteWriteURL, config.HTTPPort)
@@ -153,23 +157,31 @@ func (c *Component) Start(ctx context.Context, config Config) error {
 
 	task, err := c.createTask(ctx, container)
 	if err != nil {
-		c.CleanupExistingContainer(ctx, container)
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
 		c.stopBackground()
-		return fmt.Errorf("creating vmagent task: %w", err)
+		return errors.Join(fmt.Errorf("creating vmagent task: %w", err), cleanupErr)
 	}
 	if err := task.Start(ctx); err != nil {
-		task.Delete(ctx)
-		c.CleanupExistingContainer(ctx, container)
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
 		c.stopBackground()
-		return fmt.Errorf("starting vmagent task: %w", err)
+		return errors.Join(fmt.Errorf("starting vmagent task: %w", err), cleanupErr)
 	}
 	c.SetTask(task)
 	if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 		c.stopBackground()
-		c.StopTask(ctx, task)
-		c.CleanupExistingContainer(ctx, container)
-		c.SetRunning(false)
-		return err
+		// CleanupExistingContainer reloads and stops the running task itself;
+		// calling StopTask first would run the same task cleanup twice.
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
+		return errors.Join(err, cleanupErr)
 	}
 
 	c.wg.Add(1)

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -5,6 +5,7 @@ package base
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -201,7 +202,7 @@ func (b *BaseComponent) Stop(ctx context.Context) error {
 // stopInternal performs the stop operation. Caller must hold opMu.
 func (b *BaseComponent) stopInternal(ctx context.Context) error {
 	b.stateMu.Lock()
-	if !b.running {
+	if !b.running && b.task == nil && b.container == nil && b.stopMonitor == nil {
 		b.stateMu.Unlock()
 		return nil
 	}
@@ -229,35 +230,59 @@ func (b *BaseComponent) stopInternal(ctx context.Context) error {
 	container := b.container
 	b.stateMu.Unlock()
 
-	ctx = namespaces.WithNamespace(ctx, b.Namespace)
+	// Cleanup must outlive the Start or Stop context that triggered it. Each
+	// containerd operation below has its own deadline, so removing cancellation
+	// here cannot make shutdown wait forever.
+	ctx = namespaces.WithNamespace(context.WithoutCancel(ctx), b.Namespace)
 
+	var taskErr, containerErr error
 	if task != nil {
-		b.stopTask(ctx, task)
-		b.stateMu.Lock()
-		b.task = nil
-		b.stateMu.Unlock()
+		taskErr = b.stopTask(ctx, task)
+		if taskErr == nil {
+			b.stateMu.Lock()
+			b.task = nil
+			b.stateMu.Unlock()
+		}
 	}
 
 	if container != nil {
-		b.deleteContainerWithRetry(ctx, container)
-		b.stateMu.Lock()
-		b.container = nil
-		b.stateMu.Unlock()
+		containerErr = b.deleteContainerWithRetry(ctx, container)
+		if containerErr == nil {
+			b.stateMu.Lock()
+			// A deleted container cannot retain a task. Treat successful container
+			// deletion as authoritative if task cleanup reported a transient error.
+			b.task = nil
+			b.container = nil
+			b.stateMu.Unlock()
+			taskErr = nil
+		}
 	}
 
 	b.stateMu.Lock()
-	b.running = false
+	b.running = taskErr != nil || containerErr != nil
 	b.stateMu.Unlock()
 
-	b.Log.Info(b.ComponentName + " server stopped")
+	if taskErr == nil && containerErr == nil {
+		b.Log.Info(b.ComponentName + " server stopped")
+	}
 
-	return nil
+	return errors.Join(taskErr, containerErr)
 }
 
 // stopTask gracefully stops a task with SIGTERM, escalating to SIGKILL if needed.
-func (b *BaseComponent) stopTask(ctx context.Context, task containerd.Task) {
-	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+func (b *BaseComponent) stopTask(ctx context.Context, task containerd.Task) error {
+	// Some callers arrive here directly with a live cancellable context. This is
+	// intentionally harmless when stopInternal already detached it for us.
+	shutdownBase := namespaces.WithNamespace(context.WithoutCancel(ctx), b.Namespace)
+	shutdownCtx, cancel := context.WithTimeout(shutdownBase, 30*time.Second)
 	defer cancel()
+
+	// Register the wait before signalling. Otherwise a fast exit can race with
+	// Wait and leave cleanup blocked until the shutdown deadline.
+	status, waitErr := task.Wait(shutdownCtx)
+	if waitErr != nil {
+		b.Log.Warn("failed to wait for "+b.ComponentName+" task, proceeding to delete", "error", waitErr)
+	}
 
 	if err := task.Kill(shutdownCtx, unix.SIGTERM); err != nil {
 		// The init process may already be gone — e.g. the previous server died
@@ -267,31 +292,28 @@ func (b *BaseComponent) stopTask(ctx context.Context, task containerd.Task) {
 		// removed and the next plain→TLS recreate wedges on "snapshot already
 		// exists". See MIR-1463.
 		b.Log.Warn("failed to send SIGTERM to "+b.ComponentName+" task, proceeding to delete", "error", err)
-	} else {
-		status, err := task.Wait(shutdownCtx)
-		if err == nil {
-			select {
-			case es := <-status:
-				b.Log.Info(b.ComponentName+" task exited", "code", es.ExitCode())
+	} else if waitErr == nil {
+		select {
+		case es := <-status:
+			b.Log.Info(b.ComponentName+" task exited", "code", es.ExitCode())
 
-			case <-shutdownCtx.Done():
-				b.Log.Warn(b.ComponentName + " task did not exit gracefully, sending SIGKILL")
-				killCtx, killCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), b.Namespace), 10*time.Second)
-				defer killCancel()
+		case <-shutdownCtx.Done():
+			b.Log.Warn(b.ComponentName + " task did not exit gracefully, sending SIGKILL")
+			killCtx, killCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), b.Namespace), 10*time.Second)
+			defer killCancel()
 
-				if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
-					b.Log.Error("failed to send SIGKILL to "+b.ComponentName+" task", "error", err)
+			if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
+				b.Log.Error("failed to send SIGKILL to "+b.ComponentName+" task", "error", err)
+			} else {
+				statusCh, waitErr := task.Wait(killCtx)
+				if waitErr != nil {
+					b.Log.Error(b.ComponentName+" task wait channel after SIGKILL failed", "error", waitErr)
 				} else {
-					statusCh, waitErr := task.Wait(killCtx)
-					if waitErr != nil {
-						b.Log.Error(b.ComponentName+" task wait channel after SIGKILL failed", "error", waitErr)
-					} else {
-						select {
-						case <-statusCh:
-							// Task exited
-						case <-killCtx.Done():
-							b.Log.Warn(b.ComponentName + " task did not exit after SIGKILL within timeout")
-						}
+					select {
+					case <-statusCh:
+						// Task exited
+					case <-killCtx.Done():
+						b.Log.Warn(b.ComponentName + " task did not exit after SIGKILL within timeout")
 					}
 				}
 			}
@@ -306,12 +328,15 @@ func (b *BaseComponent) stopTask(ctx context.Context, task containerd.Task) {
 	// A not-found task is already gone — treat that as success.
 	if _, err := task.Delete(deleteCtx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
 		b.Log.Error("failed to delete "+b.ComponentName+" task", "error", err)
+		return fmt.Errorf("delete %s task: %w", b.ComponentName, err)
 	}
+
+	return nil
 }
 
 // StopTask is the exported version of stopTask for use by components.
-func (b *BaseComponent) StopTask(ctx context.Context, task containerd.Task) {
-	b.stopTask(ctx, task)
+func (b *BaseComponent) StopTask(ctx context.Context, task containerd.Task) error {
+	return b.stopTask(ctx, task)
 }
 
 // deleteContainerAndSnapshot deletes the container and makes sure its snapshot is
@@ -354,10 +379,11 @@ func (b *BaseComponent) deleteContainerAndSnapshot(container containerd.Containe
 }
 
 // deleteContainerWithRetry deletes the container (and its snapshot) with retry logic.
-func (b *BaseComponent) deleteContainerWithRetry(ctx context.Context, container containerd.Container) {
+func (b *BaseComponent) deleteContainerWithRetry(ctx context.Context, container containerd.Container) error {
 	const maxRetries = 3
 	const retryDelay = 2 * time.Second
 
+	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		// The delete itself runs on a detached context so it always finishes; ctx
 		// only governs whether we keep retrying, so a shutdown stops the backoff
@@ -365,8 +391,9 @@ func (b *BaseComponent) deleteContainerWithRetry(ctx context.Context, container 
 		err := b.deleteContainerAndSnapshot(container)
 		if err == nil {
 			b.Log.Info(b.ComponentName + " container deleted successfully")
-			return
+			return nil
 		}
+		lastErr = err
 		b.Log.Error("failed to delete "+b.ComponentName+" container", "error", err, "attempt", attempt, "max_retries", maxRetries)
 
 		if attempt < maxRetries {
@@ -374,35 +401,52 @@ func (b *BaseComponent) deleteContainerWithRetry(ctx context.Context, container 
 			case <-time.After(retryDelay):
 			case <-ctx.Done():
 				b.Log.Warn(b.ComponentName+" container delete retries cancelled", "error", ctx.Err())
-				return
+				return errors.Join(lastErr, ctx.Err())
 			}
 		}
 	}
 
 	b.Log.Error("failed to delete " + b.ComponentName + " container after all retries, potential snapshot leak")
+	return fmt.Errorf("delete %s container after %d attempts: %w", b.ComponentName, maxRetries, lastErr)
 }
 
 // DeleteContainerWithRetry is the exported version for use by components.
-func (b *BaseComponent) DeleteContainerWithRetry(ctx context.Context) {
+func (b *BaseComponent) DeleteContainerWithRetry(ctx context.Context) error {
 	b.stateMu.Lock()
 	container := b.container
 	b.stateMu.Unlock()
 	if container != nil {
-		b.deleteContainerWithRetry(ctx, container)
+		return b.deleteContainerWithRetry(ctx, container)
 	}
+	return nil
 }
 
 // CleanupExistingContainer stops the task and deletes a container during restart scenarios.
 // It shares the same task-delete and snapshot-cleanup path as the graceful Stop flow, so
 // a task left registered by an unclean shutdown still gets force-deleted and its snapshot
 // removed rather than stranding both and wedging the recreate (MIR-1463).
-func (b *BaseComponent) CleanupExistingContainer(ctx context.Context, container containerd.Container) {
-	task, err := container.Task(ctx, nil)
+func (b *BaseComponent) CleanupExistingContainer(ctx context.Context, container containerd.Container) error {
+	// Startup commonly reaches this path because ctx was cancelled. Detach the
+	// cleanup work from that lifecycle while preserving values such as tracing.
+	cleanupCtx := namespaces.WithNamespace(context.WithoutCancel(ctx), b.Namespace)
+	taskCtx, cancel := context.WithTimeout(cleanupCtx, 10*time.Second)
+	task, err := container.Task(taskCtx, nil)
+	cancel()
+
+	var taskErr error
 	if err == nil {
-		b.stopTask(ctx, task)
+		taskErr = b.stopTask(cleanupCtx, task)
+	} else if !errdefs.IsNotFound(err) {
+		taskErr = fmt.Errorf("load %s task for cleanup: %w", b.ComponentName, err)
 	}
 
-	b.deleteContainerWithRetry(ctx, container)
+	containerErr := b.deleteContainerWithRetry(cleanupCtx, container)
+	if containerErr == nil {
+		// Removing the container proves no task remains, even if loading or
+		// deleting its task returned a transient error on the way there.
+		return nil
+	}
+	return errors.Join(taskErr, containerErr)
 }
 
 // WaitForReady waits until the component is ready by checking TCP connectivity.

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -6,6 +6,7 @@ package etcd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -268,7 +269,9 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 				}(),
 				"current_config_version", currentConfigVersion,
 				"tuning_changed", prevState != nil && prevState.TuningSignature != tuningSignature)
-			e.CleanupExistingContainer(ctx, existingContainer)
+			if cleanupErr := e.CleanupExistingContainer(ctx, existingContainer); cleanupErr != nil {
+				return fmt.Errorf("cleaning up outdated etcd container: %w", cleanupErr)
+			}
 		} else {
 			e.Log.Info("found existing etcd container, attempting restart", "container_id", existingContainer.ID())
 			err = e.restartExistingContainer(ctx, existingContainer, config)
@@ -278,8 +281,14 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 			}
 			// If restart failed (e.g., port mismatch), try deleting the container and creating fresh
 			e.Log.Warn("restart of existing container failed, recreating", "error", err)
-			e.CleanupExistingContainer(ctx, existingContainer)
+			cleanupErr := e.CleanupExistingContainer(ctx, existingContainer)
+			if cleanupErr != nil {
+				return errors.Join(err, fmt.Errorf("cleaning up failed etcd restart: %w", cleanupErr))
+			}
 			e.ClearRuntimeState()
+			if ctx.Err() != nil {
+				return err
+			}
 		}
 	}
 
@@ -302,15 +311,22 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	// Start container with structured logging for JSON output
 	task, err := e.createTask(ctx, container)
 	if err != nil {
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return fmt.Errorf("failed to create etcd task: %w", err)
+		startErr := fmt.Errorf("failed to create etcd task: %w", err)
+		cleanupErr := e.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			e.ClearRuntimeState()
+		}
+		return errors.Join(startErr, cleanupErr)
 	}
 
 	err = task.Start(ctx)
 	if err != nil {
-		task.Delete(ctx)
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return fmt.Errorf("failed to start etcd task: %w", err)
+		startErr := fmt.Errorf("failed to start etcd task: %w", err)
+		cleanupErr := e.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			e.ClearRuntimeState()
+		}
+		return errors.Join(startErr, cleanupErr)
 	}
 
 	e.SetTask(task)
@@ -318,9 +334,12 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 
 	// Wait for etcd to answer its API before returning.
 	if err := e.waitForHealthy(ctx); err != nil {
-		e.CleanupExistingContainer(ctx, container)
-		e.ClearRuntimeState()
-		return fmt.Errorf("etcd failed readiness check: %w", err)
+		readinessErr := fmt.Errorf("etcd failed readiness check: %w", err)
+		cleanupErr := e.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			e.ClearRuntimeState()
+		}
+		return errors.Join(readinessErr, cleanupErr)
 	}
 
 	// Start monitoring for unexpected exits

--- a/components/etcd/integration_test.go
+++ b/components/etcd/integration_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -528,6 +530,104 @@ func TestEtcdRecreateAfterUncleanShutdown(t *testing.T) {
 	assert.Equal(t, "recreate-value", string(resp.Kvs[0].Value), "value should round-trip after recreate")
 
 	t.Log("Recreate after unclean shutdown succeeded!")
+}
+
+// TestEtcdCanceledRestartCleansUpRunningTask is the regression test for MIR-1710.
+//
+// The boot graph can cancel component startup while an existing etcd task is
+// still in its readiness check. Cleanup used to reuse that cancelled context,
+// fail to load and stop the task, fail to delete its running container, then
+// clear the component's resource handles. The subsequent graph Stop therefore
+// had nothing left to clean up and the next boot adopted the orphaned task.
+func TestEtcdCanceledRestartCleansUpRunningTask(t *testing.T) {
+	testDeps, cleanup := testutils.NewTestDeps()
+	defer cleanup()
+
+	cc := testDeps.CC
+	tmpDir := t.TempDir()
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	testNamespace := fmt.Sprintf("miren-etcd-cancel-test-%d", time.Now().UnixNano())
+	ctx := namespaces.WithNamespace(context.Background(), testNamespace)
+	defer cleanupContainer(t, cc, testNamespace)
+
+	image, err := cc.Pull(ctx, imagerefs.Etcd, containerd.WithPullUnpack)
+	if err != nil && strings.Contains(err.Error(), "permission denied") {
+		t.Skip("permission denied error, skipping test")
+	}
+	require.NoError(t, err, "failed to pull etcd image")
+
+	seedClientPort := testutils.GetFreePort(t)
+	seedPeerPort := testutils.GetFreePort(t)
+	seedName := "seed-etcd"
+	container, err := cc.NewContainer(ctx, "miren-etcd",
+		containerd.WithImage(image),
+		containerd.WithNewSnapshot("miren-etcd-snapshot", image),
+		containerd.WithNewSpec(
+			oci.WithImageConfig(image),
+			oci.WithHostNamespace(specs.NetworkNamespace),
+			oci.WithProcessArgs(
+				"/usr/local/bin/etcd",
+				"--name="+seedName,
+				"--data-dir=/tmp/seed-etcd",
+				fmt.Sprintf("--listen-client-urls=http://127.0.0.1:%d", seedClientPort),
+				fmt.Sprintf("--advertise-client-urls=http://127.0.0.1:%d", seedClientPort),
+				fmt.Sprintf("--listen-peer-urls=http://127.0.0.1:%d", seedPeerPort),
+				fmt.Sprintf("--initial-advertise-peer-urls=http://127.0.0.1:%d", seedPeerPort),
+				fmt.Sprintf("--initial-cluster=%s=http://127.0.0.1:%d", seedName, seedPeerPort),
+			),
+		),
+	)
+	require.NoError(t, err, "failed to seed existing etcd container")
+
+	task, err := container.NewTask(ctx, cio.NullIO)
+	require.NoError(t, err, "failed to create seed task")
+	_, err = task.Wait(ctx)
+	require.NoError(t, err, "failed to wait on seed task")
+	require.NoError(t, task.Start(ctx), "failed to start seed task")
+	require.Eventually(t, func() bool {
+		status, statusErr := task.Status(ctx)
+		return statusErr == nil && status.Status == containerd.Running
+	}, 10*time.Second, 100*time.Millisecond, "seed etcd task did not start")
+
+	component := etcd.NewEtcdComponent(log, cc, testNamespace, tmpDir)
+	clientPort := testutils.GetFreePort(t)
+	for clientPort == seedClientPort {
+		clientPort = testutils.GetFreePort(t)
+	}
+	config := etcd.EtcdConfig{
+		Name:           "cancel-test-etcd",
+		ClientPort:     clientPort,
+		HTTPClientPort: testutils.GetFreePort(t),
+		PeerPort:       testutils.GetFreePort(t),
+		InitialToken:   "cancel-test-cluster",
+		ClusterState:   "new",
+	}
+
+	startCtx, cancelStart := context.WithCancel(context.Background())
+	defer cancelStart()
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- component.Start(startCtx, config)
+	}()
+
+	// restartExistingContainer marks the adopted task running immediately before
+	// entering the readiness loop. Cancel at that exact point.
+	require.Eventually(t, component.IsRunning, 30*time.Second, 100*time.Millisecond,
+		"component never adopted the existing etcd task")
+	cancelStart()
+
+	select {
+	case startErr := <-startDone:
+		require.ErrorIs(t, startErr, context.Canceled)
+	case <-time.After(90 * time.Second):
+		t.Fatal("cancelled etcd start did not return")
+	}
+
+	require.False(t, component.IsRunning(), "component should clear state after successful cleanup")
+	_, err = cc.LoadContainer(ctx, "miren-etcd")
+	require.True(t, errdefs.IsNotFound(err), "cancelled startup must not leave the etcd container behind: %v", err)
 }
 
 func cleanupContainer(t *testing.T, cc *containerd.Client, namespace string) {

--- a/components/victorialogs/victorialogs.go
+++ b/components/victorialogs/victorialogs.go
@@ -4,6 +4,7 @@ package victorialogs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -107,7 +108,14 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 		}
 		// If restart failed (e.g., port mismatch), try deleting the container and creating fresh
 		c.Log.Warn("restart of existing container failed, recreating", "error", err)
-		c.CleanupExistingContainer(ctx, existingContainer)
+		cleanupErr := c.CleanupExistingContainer(ctx, existingContainer)
+		if cleanupErr != nil {
+			return errors.Join(err, fmt.Errorf("cleaning up failed victorialogs restart: %w", cleanupErr))
+		}
+		c.ClearRuntimeState()
+		if ctx.Err() != nil {
+			return err
+		}
 	}
 
 	c.Log.Info("starting victorialogs with host networking", "http_port", config.HTTPPort)
@@ -123,22 +131,31 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 	// Start container with structured logging
 	task, err := c.createTask(ctx, container)
 	if err != nil {
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return fmt.Errorf("failed to create victorialogs task: %w", err)
+		startErr := fmt.Errorf("failed to create victorialogs task: %w", err)
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
+		return errors.Join(startErr, cleanupErr)
 	}
 
 	err = task.Start(ctx)
 	if err != nil {
-		task.Delete(ctx)
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return fmt.Errorf("failed to start victorialogs task: %w", err)
+		startErr := fmt.Errorf("failed to start victorialogs task: %w", err)
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
+		return errors.Join(startErr, cleanupErr)
 	}
 
 	// Wait for VictoriaLogs to be ready
 	if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
-		task.Delete(ctx)
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return err
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
+		return errors.Join(err, cleanupErr)
 	}
 
 	c.SetTask(task)

--- a/components/victoriametrics/victoriametrics.go
+++ b/components/victoriametrics/victoriametrics.go
@@ -4,6 +4,7 @@ package victoriametrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -107,7 +108,14 @@ func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMet
 		}
 		// If restart failed, try deleting the container and creating fresh
 		c.Log.Warn("restart of existing container failed, recreating", "error", err)
-		c.CleanupExistingContainer(ctx, existingContainer)
+		cleanupErr := c.CleanupExistingContainer(ctx, existingContainer)
+		if cleanupErr != nil {
+			return errors.Join(err, fmt.Errorf("cleaning up failed victoriametrics restart: %w", cleanupErr))
+		}
+		c.ClearRuntimeState()
+		if ctx.Err() != nil {
+			return err
+		}
 	}
 
 	c.Log.Info("starting victoriametrics with host networking", "http_port", config.HTTPPort)
@@ -123,22 +131,31 @@ func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMet
 	// Start container with structured logging
 	task, err := c.createTask(ctx, container)
 	if err != nil {
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return fmt.Errorf("failed to create victoriametrics task: %w", err)
+		startErr := fmt.Errorf("failed to create victoriametrics task: %w", err)
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
+		return errors.Join(startErr, cleanupErr)
 	}
 
 	err = task.Start(ctx)
 	if err != nil {
-		task.Delete(ctx)
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return fmt.Errorf("failed to start victoriametrics task: %w", err)
+		startErr := fmt.Errorf("failed to start victoriametrics task: %w", err)
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
+		return errors.Join(startErr, cleanupErr)
 	}
 
 	// Wait for VictoriaMetrics to be ready
 	if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
-		task.Delete(ctx)
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return err
+		cleanupErr := c.CleanupExistingContainer(ctx, container)
+		if cleanupErr == nil {
+			c.ClearRuntimeState()
+		}
+		return errors.Join(err, cleanupErr)
 	}
 
 	c.SetTask(task)


### PR DESCRIPTION
The new boot graph made it much easier to cancel etcd while it was adopting an existing container and still waiting for readiness. That cleanup reused the canceled startup context, so containerd never stopped the task, the container could not be deleted, and the component forgot the handles needed to retry on shutdown.

This makes cleanup independent from the startup context while keeping each containerd call bounded. Cleanup failures now stay visible and retain resource state for the graph's later `Stop`; the same contract applies to the other managed components that share this lifecycle. A containerd regression test covers cancellation during etcd adoption.

Part of MIR-1710
