### PR TITLE
Make `miren cluster add` scriptable

### DIFF
--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -332,6 +332,12 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 	// mode, where cloud is never asked and neither is knowable.
 	var cloudName, organizationName string
 
+	// Whether the caller asked for cloud routing, as opposed to the code
+	// choosing it below. Captured before opts.viaCloud can be set, because the
+	// two cases warrant different treatment: a route chosen here has already
+	// been probed, while one the caller named has not been checked at all.
+	explicitViaCloud := opts.viaCloud
+
 	if address == "" {
 		ctx.Info("Fetching available clusters from identity server...")
 
@@ -416,10 +422,22 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 		}
 
 		if opts.viaCloud {
-			// No address, no probe, no certificate. Every one of those describes
-			// dialing the cluster, which is the thing this entry exists to avoid
-			// — and probing would just fail slowly before writing the entry that
-			// was going to work.
+			// No address and no certificate: both describe dialing the cluster,
+			// which is the thing this entry exists to avoid.
+			//
+			// The route itself is checked when the caller asked for it by name,
+			// rather than when it was chosen above (which already probed). The
+			// entry is written either way, because --via-cloud says how this
+			// cluster is reached and not that it answers this minute, and a
+			// cluster can reasonably be offline while somebody sets it up. But
+			// an entry that cannot work right now is worth saying out loud,
+			// since otherwise the first sign of it is an unrelated command
+			// failing later.
+			if explicitViaCloud && !canFallBackToCloud(ctx, mainConfig, identityName, identity, selectedCluster) {
+				ctx.Warn("%s did not answer through cloud just now, so commands to it will fail until it reconnects.", selectedCluster.Name)
+				ctx.Warn("Adding it anyway, since --via-cloud records how to reach it rather than that it is up.")
+			}
+
 			announceClusterAdd(ctx, selectedCluster.Name, localName, "routed through Miren Cloud")
 		} else {
 			// Store all available addresses

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -28,7 +28,8 @@ var skipAddresses = map[string]bool{
 	"localhost.localdomain": true,
 }
 
-func ClusterAdd(ctx *Context, opts struct {
+type clusterAddOpts struct {
+	FormatOptions
 	Identity     string `short:"i" long:"identity" description:"Name of the identity to use (optional - will use the only one if single)"`
 	Cluster      string `short:"c" long:"cluster" description:"Name of the cluster to add, looked up in Miren Cloud unless --address is given (optional - will list available)"`
 	Address      string `short:"a" long:"address" description:"Address/hostname of the cluster (optional - will use from selected cluster)"`
@@ -36,8 +37,16 @@ func ClusterAdd(ctx *Context, opts struct {
 	Organization string `long:"organization" description:"Organization the named cluster belongs to, for when the same name exists in more than one"`
 	Force        bool   `short:"f" long:"force" description:"Overwrite existing cluster configuration"`
 	ViaCloud     bool   `long:"via-cloud" description:"Reach the cluster through Miren Cloud instead of dialing it, for a cluster this machine has no route to"`
-}) error {
-	return addCluster(ctx, addClusterOptions{
+}
+
+func ClusterAdd(ctx *Context, opts clusterAddOpts) error {
+	// Adding a cluster narrates itself as it goes, and in JSON mode stdout
+	// belongs to the result document alone.
+	if opts.IsJSON() {
+		defer ctx.ProgressToStderr()()
+	}
+
+	added, err := addCluster(ctx, addClusterOptions{
 		identityName: opts.Identity,
 		clusterName:  opts.Cluster,
 		address:      opts.Address,
@@ -45,14 +54,22 @@ func ClusterAdd(ctx *Context, opts struct {
 		organization: opts.Organization,
 		force:        opts.Force,
 		viaCloud:     opts.ViaCloud,
+		jsonOutput:   opts.IsJSON(),
 	})
+
+	if !opts.IsJSON() {
+		return err
+	}
+
+	return reportClusterAdd(ctx, added, err)
 }
 
 // AddClusterInteractive prompts the user to select and add a cluster interactively.
 // It auto-selects the identity if only one is available.
 // Returns nil if a cluster was successfully added.
 func AddClusterInteractive(ctx *Context) error {
-	return addCluster(ctx, addClusterOptions{})
+	_, err := addCluster(ctx, addClusterOptions{})
+	return err
 }
 
 type addClusterOptions struct {
@@ -75,6 +92,12 @@ type addClusterOptions struct {
 	// cluster's XID, and asking cloud which clusters you have is the only way
 	// to learn it.
 	viaCloud bool
+
+	// jsonOutput means the caller wants a document, not a conversation. The
+	// steps that would put a question on the screen — the cluster picker, the
+	// overwrite prompt — become errors it can act on instead, even when there
+	// is a terminal attached and asking would have worked.
+	jsonOutput bool
 }
 
 // canFallBackToCloud reports whether a cluster that would not answer a direct
@@ -132,10 +155,10 @@ func findClusterByName(clusters []ClusterResponse, name, organization string) (*
 	case 1:
 		return matches[0], nil
 	case 0:
-		return nil, fmt.Errorf("no cluster named %q. Available clusters: %s",
+		return nil, codedErrorf(codeClusterNotFound, "no cluster named %q. Available clusters: %s",
 			name, describeClusters(candidates))
 	default:
-		return nil, fmt.Errorf("%d clusters are named %q (%s). Pick one with --organization",
+		return nil, codedErrorf(codeAmbiguousCluster, "%d clusters are named %q (%s). Pick one with --organization",
 			len(matches), name, describeClusters(derefClusters(matches)))
 	}
 }
@@ -161,7 +184,7 @@ func clustersInOrganization(clusters []ClusterResponse, organization string) ([]
 	}
 
 	if len(matched) == 0 {
-		return nil, fmt.Errorf("no clusters in organization %q. Your clusters are in: %s",
+		return nil, codedErrorf(codeUnknownOrganization, "no clusters in organization %q. Your clusters are in: %s",
 			organization, organizationNames(clusters))
 	}
 
@@ -210,30 +233,44 @@ func organizationNames(clusters []ClusterResponse) string {
 	return strings.Join(names, ", ")
 }
 
-func addCluster(ctx *Context, opts addClusterOptions) error {
+func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 	identityName, clusterName, address, force := opts.identityName, opts.clusterName, opts.address, opts.force
 
 	if opts.viaCloud && address != "" {
-		return fmt.Errorf("--via-cloud and --address are mutually exclusive: routing through cloud is for a cluster you have no address for")
+		return nil, codedErrorf(codeInvalidFlags, "--via-cloud and --address are mutually exclusive: routing through cloud is for a cluster you have no address for")
 	}
 	if opts.localName != "" && address != "" {
-		return fmt.Errorf("--as and --address are mutually exclusive: with --address nothing is looked up in cloud, so --cluster is already the local name")
+		return nil, codedErrorf(codeInvalidFlags, "--as and --address are mutually exclusive: with --address nothing is looked up in cloud, so --cluster is already the local name")
 	}
 	if opts.organization != "" && address != "" {
-		return fmt.Errorf("--organization and --address are mutually exclusive: with --address nothing is looked up in cloud")
+		return nil, codedErrorf(codeInvalidFlags, "--organization and --address are mutually exclusive: with --address nothing is looked up in cloud")
 	}
 	if opts.localName != "" && clusterName == "" {
-		return fmt.Errorf("--as needs --cluster to say which cluster to rename; the picker asks for a local name itself")
+		return nil, codedErrorf(codeInvalidFlags, "--as needs --cluster to say which cluster to rename; the picker asks for a local name itself")
 	}
 	// Silently ignoring it would be worse: it reads as a filter that was
 	// applied, and the picker shows every cluster either way.
 	if opts.organization != "" && clusterName == "" {
-		return fmt.Errorf("--organization only narrows the lookup for --cluster; the picker already shows which organization each cluster is in")
+		return nil, codedErrorf(codeInvalidFlags, "--organization only narrows the lookup for --cluster; the picker already shows which organization each cluster is in")
+	}
+	// Checked here with the other flag combinations rather than where the
+	// address is used: an address with nothing to call it is wrong on its face,
+	// and leaving it until after identity resolution meant reporting whatever
+	// that found instead — "multiple identities available" for a command whose
+	// real problem was a missing --cluster.
+	if address != "" && clusterName == "" {
+		return nil, codedErrorf(codeInvalidFlags, "--address needs --cluster to say what to call the cluster locally; drop --address to look one up in Miren Cloud instead")
+	}
+	// The picker cannot answer to a caller that wanted a document, so say what
+	// to do instead of opening a list nobody is watching.
+	if opts.jsonOutput && clusterName == "" && address == "" {
+		return nil, codedErrorf(codeInteractiveRequired,
+			"choosing a cluster from a list needs a person; name one with --cluster (run 'miren cluster available' to see them) or give --cluster and --address")
 	}
 	// Load the main config to check if the identity exists
 	mainConfig, err := clientconfig.LoadConfig()
 	if err != nil && err != clientconfig.ErrNoConfig {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return nil, codedErrorf(codeConfigLoadFailed, "failed to load configuration: %w", err)
 	}
 
 	// Detect manual mode: an address was given, so the cluster is dialed
@@ -250,12 +287,12 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		identityName, err = pickCloudIdentity(ctx, mainConfig, identityName,
 			", or use --cluster and --address to add a cluster directly")
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else if identityName != "" {
 		// Manual mode with explicit --identity: validate it exists
 		if mainConfig == nil || !mainConfig.HasIdentities() {
-			return fmt.Errorf("identity %q not found: no identities configured", identityName)
+			return nil, codedErrorf(codeIdentityNotFound, "identity %q not found: no identities configured", identityName)
 		}
 	} else if mainConfig != nil {
 		// Manual mode with no --identity. Optional isn't the same as unwanted:
@@ -271,7 +308,7 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 			identityName = names[0]
 			ctx.Info("Using identity '%s' (only one available)", identityName)
 		default:
-			return fmt.Errorf("multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
+			return nil, codedErrorf(codeMultipleIdentities, "multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
 		}
 	}
 
@@ -280,7 +317,7 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 	if identityName != "" {
 		identity, err = lookupIdentity(mainConfig, identityName)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -291,16 +328,20 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 	var allAddresses []string
 	var clusterXID string
 
+	// What the cluster is called in cloud, and whose it is. Empty in manual
+	// mode, where cloud is never asked and neither is knowable.
+	var cloudName, organizationName string
+
 	if address == "" {
 		ctx.Info("Fetching available clusters from identity server...")
 
 		clusters, err := fetchAvailableClusters(ctx, mainConfig, identityName, identity)
 		if err != nil {
-			return fmt.Errorf("failed to fetch available clusters: %w", err)
+			return nil, codedErrorf(codeCloudRequestFailed, "failed to fetch available clusters: %w", err)
 		}
 
 		if len(clusters) == 0 {
-			return fmt.Errorf("no clusters available for your account")
+			return nil, codedErrorf(codeNoClusters, "no clusters available for your account")
 		}
 
 		var (
@@ -315,7 +356,7 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		if clusterName != "" {
 			selectedCluster, err = findClusterByName(clusters, clusterName, opts.organization)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			localName = clusterName
@@ -335,7 +376,7 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 			// on a dev machine can pin whatever is listening there under a
 			// remote cluster's name.
 			if !opts.viaCloud && !selectedCluster.hasReachableAddress() && !cloudRoutable[selectedCluster.XID] {
-				return fmt.Errorf("%s has %s, and cloud cannot reach it either; to connect: %s",
+				return nil, codedErrorf(codeClusterUnreachable, "%s has %s, and cloud cannot reach it either; to connect: %s",
 					selectedCluster.Name, unreachableAddressNote, unreachableAddressHelp)
 			}
 		} else {
@@ -349,12 +390,14 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 			// Present cluster selection to user and get local name
 			selectedCluster, localName, err = selectClusterFromList(ctx, clusters, cloudRoutable)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
 		clusterName = localName
 		clusterXID = selectedCluster.XID
+		cloudName = selectedCluster.Name
+		organizationName = selectedCluster.OrganizationName
 
 		// A cluster nothing can dial, which cloud reports it can reach. Routing
 		// through cloud is not a fallback here so much as the only way it was
@@ -363,7 +406,7 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		// establish that the cluster will answer over it.
 		if !opts.viaCloud && cloudRoutable[selectedCluster.XID] {
 			if !canFallBackToCloud(ctx, mainConfig, identityName, identity, selectedCluster) {
-				return fmt.Errorf(
+				return nil, codedErrorf(codeClusterUnreachable,
 					"%s advertises no address this machine can dial, and did not answer through cloud either; "+
 						"if its runtime predates cloud-routed RPC, upgrade it or add the cluster from a network that can reach it",
 					selectedCluster.Name)
@@ -390,7 +433,7 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 				// machine is not on. Cloud may still hold a link to it, and if
 				// it does, the entry that works is the routed one.
 				if !canFallBackToCloud(ctx, mainConfig, identityName, identity, selectedCluster) {
-					return err
+					return nil, codedErrorf(codeClusterUnreachable, "%w", err)
 				}
 
 				ctx.Info("Could not reach %s directly, but cloud has a link to it.", selectedCluster.Name)
@@ -409,8 +452,6 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 				announceClusterAdd(ctx, selectedCluster.Name, localName, "connected to "+workingAddress)
 			}
 		}
-	} else if clusterName == "" {
-		return fmt.Errorf("--address needs --cluster to say what to call the cluster locally; drop --address to look one up in Miren Cloud instead")
 	} else {
 		// Manual mode - address was specified directly
 		ctx.Info("Connecting to %s to extract TLS certificate...", address)
@@ -418,7 +459,7 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		// Extract the TLS certificate from the server
 		cert, err := extractTLSCertificate(ctx, address)
 		if err != nil {
-			return fmt.Errorf("failed to extract TLS certificate: %w", err)
+			return nil, codedErrorf(codeClusterUnreachable, "failed to extract TLS certificate: %w", err)
 		}
 		clusterCert = cert
 		ctx.Completed("Successfully extracted TLS certificate (fingerprint: %s)", cert.Fingerprint)
@@ -458,13 +499,16 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		if err == clientconfig.ErrNoConfig {
 			mainConfig = clientconfig.NewConfig()
 		} else {
-			return fmt.Errorf("failed to load client config: %w", err)
+			return nil, codedErrorf(codeConfigLoadFailed, "failed to load client config: %w", err)
 		}
 	}
 
 	// Check if the leaf config already exists (by trying to get the cluster)
 	if mainConfig.HasCluster(clusterName) && !force {
-		if ui.IsInteractive() {
+		// A caller wanting a document gets the decision handed back rather than
+		// a prompt, even at a terminal: overwriting somebody's cluster entry is
+		// not a call to make on their behalf because nobody was watching.
+		if ui.IsInteractive() && !opts.jsonOutput {
 			// Prompt user to choose: overwrite or cancel
 			items := []ui.PickerItem{
 				ui.SimplePickerItem{Text: "Overwrite existing configuration"},
@@ -474,14 +518,14 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 			title := fmt.Sprintf("Cluster %q already exists", clusterName)
 			selected, err := ui.RunPicker(items, ui.WithTitle(title))
 			if err != nil {
-				return fmt.Errorf("failed to run picker: %w", err)
+				return nil, codedErrorf(codeInteractiveRequired, "failed to run picker: %w", err)
 			}
 			if selected == nil || selected.ID() == "Cancel" {
-				return fmt.Errorf("cancelled")
+				return nil, codedErrorf(codeCancelled, "cancelled")
 			}
 			// User chose to overwrite, continue
 		} else {
-			return fmt.Errorf("cluster configuration %q already exists. Use --force to overwrite", clusterName)
+			return nil, codedErrorf(codeClusterExists, "cluster configuration %q already exists. Use --force to overwrite", clusterName)
 		}
 	}
 
@@ -498,14 +542,14 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 	if mainConfig.GetClusterCount() == 1 {
 		// If this is the first cluster, set it as active
 		if err := mainConfig.SetActiveCluster(clusterName); err != nil {
-			return fmt.Errorf("failed to set active cluster: %w", err)
+			return nil, codedErrorf(codeConfigWriteFailed, "failed to set active cluster: %w", err)
 		}
 		ctx.Info("Setting %q as the active cluster", clusterName)
 	}
 
 	// Save the main config (which will also save the leaf config)
 	if err := mainConfig.Save(); err != nil {
-		return fmt.Errorf("failed to save cluster configuration: %w", err)
+		return nil, codedErrorf(codeConfigWriteFailed, "failed to save cluster configuration: %w", err)
 	}
 
 	if opts.viaCloud {
@@ -527,7 +571,22 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		ctx.Info("  miren cluster switch %s", clusterName)
 	}
 
-	return nil
+	added := &addedCluster{
+		Name:       clusterName,
+		XID:        clusterXID,
+		Address:    address,
+		ViaCloud:   opts.viaCloud,
+		Identity:   identityName,
+		Insecure:   clusterConfig.Insecure,
+		Active:     mainConfig.ActiveCluster() == clusterName,
+		ConfigFile: mainConfig.GetClusterSource(clusterName),
+	}
+	if cloudName != "" && cloudName != clusterName {
+		added.CloudName = cloudName
+	}
+	added.Organization = organizationName
+
+	return added, nil
 }
 
 // normalizeAddress handles robust address normalization for various formats:

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -118,18 +118,9 @@ func announceClusterAdd(ctx *Context, remoteName, localName, how string) {
 // as a fallback, so a name that is exactly right can never lose to one that
 // merely differs in case.
 func findClusterByName(clusters []ClusterResponse, name, organization string) (*ClusterResponse, error) {
-	candidates := clusters
-	if organization != "" {
-		candidates = nil
-		for _, cluster := range clusters {
-			if strings.EqualFold(cluster.OrganizationName, organization) || cluster.OrganizationXID == organization {
-				candidates = append(candidates, cluster)
-			}
-		}
-		if len(candidates) == 0 {
-			return nil, fmt.Errorf("no clusters in organization %q. Your clusters are in: %s",
-				organization, organizationNames(clusters))
-		}
+	candidates, err := clustersInOrganization(clusters, organization)
+	if err != nil {
+		return nil, err
 	}
 
 	matches := matchClusterName(candidates, func(clusterName string) bool { return clusterName == name })
@@ -147,6 +138,34 @@ func findClusterByName(clusters []ClusterResponse, name, organization string) (*
 		return nil, fmt.Errorf("%d clusters are named %q (%s). Pick one with --organization",
 			len(matches), name, describeClusters(derefClusters(matches)))
 	}
+}
+
+// clustersInOrganization narrows a cluster list to one organization, named
+// either by its display name or by its id. An organization that matches nothing
+// is an error rather than an empty list, because the overwhelmingly likely
+// cause is a misspelled name, and an empty list reads as "you have no clusters
+// there" — a different and more alarming claim.
+//
+// Shared by the commands that take --organization so the flag means the same
+// thing whether it is narrowing a lookup or a listing.
+func clustersInOrganization(clusters []ClusterResponse, organization string) ([]ClusterResponse, error) {
+	if organization == "" {
+		return clusters, nil
+	}
+
+	var matched []ClusterResponse
+	for _, cluster := range clusters {
+		if strings.EqualFold(cluster.OrganizationName, organization) || cluster.OrganizationXID == organization {
+			matched = append(matched, cluster)
+		}
+	}
+
+	if len(matched) == 0 {
+		return nil, fmt.Errorf("no clusters in organization %q. Your clusters are in: %s",
+			organization, organizationNames(clusters))
+	}
+
+	return matched, nil
 }
 
 func matchClusterName(clusters []ClusterResponse, match func(name string) bool) []*ClusterResponse {
@@ -228,20 +247,10 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 	// In discovery mode, identity is required to fetch available clusters.
 	if !manualMode {
 		// Discovery mode — identity is required
-		if mainConfig == nil || !mainConfig.HasIdentities() {
-			return fmt.Errorf("no identities configured. Please run 'miren login' first, or use --cluster and --address to add a cluster directly")
-		}
-
-		if identityName == "" {
-			availableIdentities := mainConfig.GetIdentityNames()
-			if len(availableIdentities) == 1 {
-				identityName = availableIdentities[0]
-				ctx.Info("Using identity '%s' (only one available)", identityName)
-			} else if len(availableIdentities) > 1 {
-				return fmt.Errorf("multiple identities available, please specify one with --identity: %s", strings.Join(availableIdentities, ", "))
-			} else {
-				return fmt.Errorf("no identities configured. Please run 'miren login' first, or use --cluster and --address to add a cluster directly")
-			}
+		identityName, err = pickCloudIdentity(ctx, mainConfig, identityName,
+			", or use --cluster and --address to add a cluster directly")
+		if err != nil {
+			return err
 		}
 	} else if identityName != "" {
 		// Manual mode with explicit --identity: validate it exists
@@ -269,17 +278,9 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 	// Look up identity if one was specified (skip if manual mode with no identity)
 	var identity *clientconfig.IdentityConfig
 	if identityName != "" {
-		if mainConfig == nil {
-			return fmt.Errorf("identity %q not found in configuration", identityName)
-		}
-		var err error
-		identity, err = mainConfig.GetIdentity(identityName)
+		identity, err = lookupIdentity(mainConfig, identityName)
 		if err != nil {
-			availableIdentities := mainConfig.GetIdentityNames()
-			if len(availableIdentities) > 0 {
-				return fmt.Errorf("identity %q not found. Available identities: %v", identityName, availableIdentities)
-			}
-			return fmt.Errorf("identity %q not found in configuration", identityName)
+			return err
 		}
 	}
 

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -270,7 +270,7 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 	// Load the main config to check if the identity exists
 	mainConfig, err := clientconfig.LoadConfig()
 	if err != nil && err != clientconfig.ErrNoConfig {
-		return nil, codedErrorf(codeConfigLoadFailed, "failed to load configuration: %w", err)
+		return nil, codedErrorf(codeConfigError, "failed to load configuration: %w", err)
 	}
 
 	// Detect manual mode: an address was given, so the cluster is dialed
@@ -292,7 +292,7 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 	} else if identityName != "" {
 		// Manual mode with explicit --identity: validate it exists
 		if mainConfig == nil || !mainConfig.HasIdentities() {
-			return nil, codedErrorf(codeIdentityNotFound, "identity %q not found: no identities configured", identityName)
+			return nil, codedErrorf(codeIdentityError, "identity %q not found: no identities configured", identityName)
 		}
 	} else if mainConfig != nil {
 		// Manual mode with no --identity. Optional isn't the same as unwanted:
@@ -308,7 +308,7 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 			identityName = names[0]
 			ctx.Info("Using identity '%s' (only one available)", identityName)
 		default:
-			return nil, codedErrorf(codeMultipleIdentities, "multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
+			return nil, codedErrorf(codeIdentityError, "multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
 		}
 	}
 
@@ -341,7 +341,7 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 		}
 
 		if len(clusters) == 0 {
-			return nil, codedErrorf(codeNoClusters, "no clusters available for your account")
+			return nil, codedErrorf(codeClusterNotFound, "no clusters available for your account")
 		}
 
 		var (
@@ -499,7 +499,7 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 		if err == clientconfig.ErrNoConfig {
 			mainConfig = clientconfig.NewConfig()
 		} else {
-			return nil, codedErrorf(codeConfigLoadFailed, "failed to load client config: %w", err)
+			return nil, codedErrorf(codeConfigError, "failed to load client config: %w", err)
 		}
 	}
 
@@ -521,7 +521,10 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 				return nil, codedErrorf(codeInteractiveRequired, "failed to run picker: %w", err)
 			}
 			if selected == nil || selected.ID() == "Cancel" {
-				return nil, codedErrorf(codeCancelled, "cancelled")
+				// No code: this branch only runs for a person answering a
+				// prompt, and JSON mode never opens one, so a code here would
+				// be a contract entry that can never appear in a document.
+				return nil, fmt.Errorf("cancelled")
 			}
 			// User chose to overwrite, continue
 		} else {
@@ -542,14 +545,14 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 	if mainConfig.GetClusterCount() == 1 {
 		// If this is the first cluster, set it as active
 		if err := mainConfig.SetActiveCluster(clusterName); err != nil {
-			return nil, codedErrorf(codeConfigWriteFailed, "failed to set active cluster: %w", err)
+			return nil, codedErrorf(codeConfigError, "failed to set active cluster: %w", err)
 		}
 		ctx.Info("Setting %q as the active cluster", clusterName)
 	}
 
 	// Save the main config (which will also save the leaf config)
 	if err := mainConfig.Save(); err != nil {
-		return nil, codedErrorf(codeConfigWriteFailed, "failed to save cluster configuration: %w", err)
+		return nil, codedErrorf(codeConfigError, "failed to save cluster configuration: %w", err)
 	}
 
 	if opts.viaCloud {

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -375,7 +375,7 @@ func addCluster(ctx *Context, opts addClusterOptions) (*addedCluster, error) {
 			// falling through would probe localhost as a last resort — which
 			// on a dev machine can pin whatever is listening there under a
 			// remote cluster's name.
-			if !opts.viaCloud && !selectedCluster.hasReachableAddress() && !cloudRoutable[selectedCluster.XID] {
+			if !opts.viaCloud && !selectedCluster.HasReachableAddress() && !cloudRoutable[selectedCluster.XID] {
 				return nil, codedErrorf(codeClusterUnreachable, "%s has %s, and cloud cannot reach it either; to connect: %s",
 					selectedCluster.Name, unreachableAddressNote, unreachableAddressHelp)
 			}

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -29,16 +29,20 @@ var skipAddresses = map[string]bool{
 }
 
 func ClusterAdd(ctx *Context, opts struct {
-	Identity string `short:"i" long:"identity" description:"Name of the identity to use (optional - will use the only one if single)"`
-	Cluster  string `short:"c" long:"cluster" description:"Name of the cluster to create (optional - will list available)"`
-	Address  string `short:"a" long:"address" description:"Address/hostname of the cluster (optional - will use from selected cluster)"`
-	Force    bool   `short:"f" long:"force" description:"Overwrite existing cluster configuration"`
-	ViaCloud bool   `long:"via-cloud" description:"Reach the cluster through Miren Cloud instead of dialing it, for a cluster this machine has no route to"`
+	Identity     string `short:"i" long:"identity" description:"Name of the identity to use (optional - will use the only one if single)"`
+	Cluster      string `short:"c" long:"cluster" description:"Name of the cluster to add, looked up in Miren Cloud unless --address is given (optional - will list available)"`
+	Address      string `short:"a" long:"address" description:"Address/hostname of the cluster (optional - will use from selected cluster)"`
+	As           string `long:"as" description:"Local name to store the cluster under, when it should differ from its name in Miren Cloud"`
+	Organization string `long:"organization" description:"Organization the named cluster belongs to, for when the same name exists in more than one"`
+	Force        bool   `short:"f" long:"force" description:"Overwrite existing cluster configuration"`
+	ViaCloud     bool   `long:"via-cloud" description:"Reach the cluster through Miren Cloud instead of dialing it, for a cluster this machine has no route to"`
 }) error {
 	return addCluster(ctx, addClusterOptions{
 		identityName: opts.Identity,
 		clusterName:  opts.Cluster,
 		address:      opts.Address,
+		localName:    opts.As,
+		organization: opts.Organization,
 		force:        opts.Force,
 		viaCloud:     opts.ViaCloud,
 	})
@@ -56,6 +60,15 @@ type addClusterOptions struct {
 	clusterName  string
 	address      string
 	force        bool
+
+	// localName overrides the name the cluster is stored under locally. The
+	// picker asks for one; naming a cluster on the command line skips that
+	// prompt, so this is how the same choice is made without it.
+	localName string
+
+	// organization narrows the cloud lookup when clusterName exists in more
+	// than one of them.
+	organization string
 
 	// viaCloud writes an entry that reaches the cluster through Miren Cloud.
 	// It only makes sense in discovery mode: routing through cloud needs the
@@ -94,11 +107,109 @@ func announceClusterAdd(ctx *Context, remoteName, localName, how string) {
 	ctx.Info("Adding cluster '%s' (%s)", remoteName, how)
 }
 
+// findClusterByName picks the cluster the caller named out of the list cloud
+// returned, standing in for the interactive picker when the name is already
+// known.
+//
+// Cluster names are unique within an organization but not across them, so an
+// ambiguous name is refused rather than guessed at: binding the wrong
+// production cluster to the right local name is a worse outcome than being
+// asked for --organization. Matching is exact first and case-insensitive only
+// as a fallback, so a name that is exactly right can never lose to one that
+// merely differs in case.
+func findClusterByName(clusters []ClusterResponse, name, organization string) (*ClusterResponse, error) {
+	candidates := clusters
+	if organization != "" {
+		candidates = nil
+		for _, cluster := range clusters {
+			if strings.EqualFold(cluster.OrganizationName, organization) || cluster.OrganizationXID == organization {
+				candidates = append(candidates, cluster)
+			}
+		}
+		if len(candidates) == 0 {
+			return nil, fmt.Errorf("no clusters in organization %q. Your clusters are in: %s",
+				organization, organizationNames(clusters))
+		}
+	}
+
+	matches := matchClusterName(candidates, func(clusterName string) bool { return clusterName == name })
+	if len(matches) == 0 {
+		matches = matchClusterName(candidates, func(clusterName string) bool { return strings.EqualFold(clusterName, name) })
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return nil, fmt.Errorf("no cluster named %q. Available clusters: %s",
+			name, describeClusters(candidates))
+	default:
+		return nil, fmt.Errorf("%d clusters are named %q (%s). Pick one with --organization",
+			len(matches), name, describeClusters(derefClusters(matches)))
+	}
+}
+
+func matchClusterName(clusters []ClusterResponse, match func(name string) bool) []*ClusterResponse {
+	var matches []*ClusterResponse
+	for i := range clusters {
+		if match(clusters[i].Name) {
+			matches = append(matches, &clusters[i])
+		}
+	}
+	return matches
+}
+
+func derefClusters(clusters []*ClusterResponse) []ClusterResponse {
+	out := make([]ClusterResponse, 0, len(clusters))
+	for _, cluster := range clusters {
+		out = append(out, *cluster)
+	}
+	return out
+}
+
+// describeClusters renders clusters as "name (organization)" so an error about
+// the wrong name is actionable without running a second command.
+func describeClusters(clusters []ClusterResponse) string {
+	described := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		described = append(described, fmt.Sprintf("%s (%s)", cluster.Name, cluster.OrganizationName))
+	}
+	slices.Sort(described)
+	return strings.Join(described, ", ")
+}
+
+// organizationNames lists the organizations the given clusters belong to, once
+// each, for the error about an organization that matched nothing.
+func organizationNames(clusters []ClusterResponse) string {
+	var names []string
+	for _, cluster := range clusters {
+		if !slices.Contains(names, cluster.OrganizationName) {
+			names = append(names, cluster.OrganizationName)
+		}
+	}
+	slices.Sort(names)
+	return strings.Join(names, ", ")
+}
+
 func addCluster(ctx *Context, opts addClusterOptions) error {
 	identityName, clusterName, address, force := opts.identityName, opts.clusterName, opts.address, opts.force
 
 	if opts.viaCloud && address != "" {
 		return fmt.Errorf("--via-cloud and --address are mutually exclusive: routing through cloud is for a cluster you have no address for")
+	}
+	if opts.localName != "" && address != "" {
+		return fmt.Errorf("--as and --address are mutually exclusive: with --address nothing is looked up in cloud, so --cluster is already the local name")
+	}
+	if opts.organization != "" && address != "" {
+		return fmt.Errorf("--organization and --address are mutually exclusive: with --address nothing is looked up in cloud")
+	}
+	if opts.localName != "" && clusterName == "" {
+		return fmt.Errorf("--as needs --cluster to say which cluster to rename; the picker asks for a local name itself")
+	}
+	// Silently ignoring it would be worse: it reads as a filter that was
+	// applied, and the picker shows every cluster either way.
+	if opts.organization != "" && clusterName == "" {
+		return fmt.Errorf("--organization only narrows the lookup for --cluster; the picker already shows which organization each cluster is in")
 	}
 	// Load the main config to check if the identity exists
 	mainConfig, err := clientconfig.LoadConfig()
@@ -106,8 +217,11 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Detect manual mode: both --cluster and --address provided
-	manualMode := clusterName != "" && address != ""
+	// Detect manual mode: an address was given, so the cluster is dialed
+	// directly and cloud is never asked anything. Naming a cluster without an
+	// address is a cloud lookup like the picker, and needs an identity for the
+	// same reason.
+	manualMode := address != ""
 
 	// In manual mode, identity is optional (a CI runner authenticates with an
 	// OIDC token from its environment and has none configured).
@@ -169,12 +283,14 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		}
 	}
 
-	// If no cluster name or address provided, query the identity server for available clusters
+	// With no address to dial, the cluster comes from cloud — either named on
+	// the command line or chosen from the picker. Both land on the same
+	// selected cluster and then share every decision about how to reach it.
 	var clusterCert *clusterCertificate
 	var allAddresses []string
 	var clusterXID string
 
-	if clusterName == "" && address == "" {
+	if address == "" {
 		ctx.Info("Fetching available clusters from identity server...")
 
 		clusters, err := fetchAvailableClusters(ctx, mainConfig, identityName, identity)
@@ -186,21 +302,54 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 			return fmt.Errorf("no clusters available for your account")
 		}
 
-		// Which of the undialable clusters cloud can still reach. Asked before
-		// the picker so a cluster that works is offered as one, rather than
-		// greyed out for advertising no address it was never going to have.
-		//
-		// Skipped when the caller already said --via-cloud, since the answer
-		// would change nothing.
-		var cloudRoutable map[string]bool
-		if !opts.viaCloud {
-			cloudRoutable = cloudRoutableClusters(ctx, mainConfig, identityName, identity, clusters)
-		}
+		var (
+			selectedCluster *ClusterResponse
+			localName       string
+			// Which of the undialable clusters cloud can still reach. Skipped
+			// when the caller already said --via-cloud, since the answer would
+			// change nothing.
+			cloudRoutable map[string]bool
+		)
 
-		// Present cluster selection to user and get local name
-		selectedCluster, localName, err := selectClusterFromList(ctx, clusters, cloudRoutable)
-		if err != nil {
-			return err
+		if clusterName != "" {
+			selectedCluster, err = findClusterByName(clusters, clusterName, opts.organization)
+			if err != nil {
+				return err
+			}
+
+			localName = clusterName
+			if opts.localName != "" {
+				localName = opts.localName
+			}
+
+			// Only the one cluster is asked about, since no list is being
+			// rendered and the other answers would go unused.
+			if !opts.viaCloud {
+				cloudRoutable = cloudRoutableClusters(ctx, mainConfig, identityName, identity, []ClusterResponse{*selectedCluster})
+			}
+
+			// The picker greys out a cluster with nothing to dial that cloud
+			// cannot reach either. Named, there is no row to grey out, and
+			// falling through would probe localhost as a last resort — which
+			// on a dev machine can pin whatever is listening there under a
+			// remote cluster's name.
+			if !opts.viaCloud && !selectedCluster.hasReachableAddress() && !cloudRoutable[selectedCluster.XID] {
+				return fmt.Errorf("%s has %s, and cloud cannot reach it either; to connect: %s",
+					selectedCluster.Name, unreachableAddressNote, unreachableAddressHelp)
+			}
+		} else {
+			// Asked before the picker so a cluster that works is offered as
+			// one, rather than greyed out for advertising no address it was
+			// never going to have.
+			if !opts.viaCloud {
+				cloudRoutable = cloudRoutableClusters(ctx, mainConfig, identityName, identity, clusters)
+			}
+
+			// Present cluster selection to user and get local name
+			selectedCluster, localName, err = selectClusterFromList(ctx, clusters, cloudRoutable)
+			if err != nil {
+				return err
+			}
 		}
 
 		clusterName = localName
@@ -259,10 +408,8 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 				announceClusterAdd(ctx, selectedCluster.Name, localName, "connected to "+workingAddress)
 			}
 		}
-	} else if opts.viaCloud {
-		return fmt.Errorf("--via-cloud needs to look the cluster up in cloud, so it can't be combined with --cluster; run `miren cluster add --via-cloud` and pick from the list")
-	} else if clusterName == "" || address == "" {
-		return fmt.Errorf("both --cluster and --address must be specified, or neither (to list available clusters)")
+	} else if clusterName == "" {
+		return fmt.Errorf("--address needs --cluster to say what to call the cluster locally; drop --address to look one up in Miren Cloud instead")
 	} else {
 		// Manual mode - address was specified directly
 		ctx.Info("Connecting to %s to extract TLS certificate...", address)

--- a/cli/commands/cluster_add_byname_test.go
+++ b/cli/commands/cluster_add_byname_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"net/http"
 	"testing"
 
@@ -107,4 +108,31 @@ func TestAddClusterByNameReportsAnUnknownName(t *testing.T) {
 	r.Error(err)
 	r.Contains(err.Error(), `no cluster named "produciton"`)
 	r.Contains(err.Error(), "prod (Acme)")
+}
+
+// `--via-cloud` records how a cluster is reached, not that it is up, so the
+// entry is written even when the route does not answer. The warning is what
+// keeps that from surfacing later as an unrelated command failing.
+func TestAddClusterByNameWarnsWhenTheCloudRouteIsSilent(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, []ClusterResponse{
+		{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme"},
+	}, nil)
+	configWithIdentity(t, srv.URL)
+
+	ctx := presenceContext(t)
+	added, err := addCluster(ctx, addClusterOptions{clusterName: "prod", viaCloud: true})
+	r.NoError(err)
+	r.True(added.ViaCloud)
+
+	said := ctx.Stdout.(*bytes.Buffer).String()
+	r.Contains(said, "did not answer through cloud")
+	r.Contains(said, "Adding it anyway")
+
+	cfg, err := clientconfig.LoadConfig()
+	r.NoError(err)
+	cluster, err := cfg.GetCluster("prod")
+	r.NoError(err, "the entry is written even though the route did not answer")
+	r.True(cluster.ViaCloud)
 }

--- a/cli/commands/cluster_add_byname_test.go
+++ b/cli/commands/cluster_add_byname_test.go
@@ -1,35 +1,21 @@
 package commands
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/cloudapi/cloudapitest"
 )
 
-// fakeCloud serves the two endpoints `miren cluster add` asks about in
-// discovery mode: the list of clusters on the account, and whether cloud
-// currently holds a link to a given one.
-func fakeCloud(t *testing.T, clusters []ClusterResponse, online map[string]bool) *httptest.Server {
+// fakeCloud stands up a cloud holding the given clusters, reporting online for
+// the ones set to true.
+func fakeCloud(t *testing.T, clusters []ClusterResponse, online map[string]bool) *cloudapitest.Server {
 	t.Helper()
 
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/api/v1/users/clusters", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": clusters})
-	})
-
-	mux.HandleFunc("/api/v1/clusters/{xid}/online", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"online": online[r.PathValue("xid")]})
-	})
-
-	srv := httptest.NewServer(mux)
+	srv := cloudapitest.NewServer(clusters, online, http.StatusOK)
 	t.Cleanup(srv.Close)
 
 	return srv

--- a/cli/commands/cluster_add_byname_test.go
+++ b/cli/commands/cluster_add_byname_test.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/clientconfig"
+)
+
+// fakeCloud serves the two endpoints `miren cluster add` asks about in
+// discovery mode: the list of clusters on the account, and whether cloud
+// currently holds a link to a given one.
+func fakeCloud(t *testing.T, clusters []ClusterResponse, online map[string]bool) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/users/clusters", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": clusters})
+	})
+
+	mux.HandleFunc("/api/v1/clusters/{xid}/online", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"online": online[r.PathValue("xid")]})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// configWithIdentity points the client config at a scratch directory holding a
+// single identity, which is the state someone is in right after `miren login`.
+func configWithIdentity(t *testing.T, issuer string) {
+	t.Helper()
+
+	t.Setenv(clientconfig.EnvConfigPath, t.TempDir())
+
+	cfg := clientconfig.NewConfig()
+	cfg.SetIdentity("cloud", &clientconfig.IdentityConfig{
+		Type:   clientconfig.IdentityToken,
+		Issuer: issuer,
+		Token:  freshLoginJWT(t),
+	})
+	require.NoError(t, cfg.Save())
+}
+
+// The case this feature exists for: the name is already known, so no picker is
+// involved, and the entry still comes out shaped by the same routing decision
+// the picker path would have made.
+func TestAddClusterByNameRoutedThroughCloud(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, []ClusterResponse{
+		{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme"},
+	}, nil)
+	configWithIdentity(t, srv.URL)
+
+	err := addCluster(presenceContext(t), addClusterOptions{
+		clusterName: "prod",
+		localName:   "acme-prod",
+		viaCloud:    true,
+	})
+	r.NoError(err)
+
+	cfg, err := clientconfig.LoadConfig()
+	r.NoError(err)
+
+	cluster, err := cfg.GetCluster("acme-prod")
+	r.NoError(err, "--as decides the local name, and nothing prompted for one")
+	r.True(cluster.ViaCloud)
+	r.Equal("cluster-prod", cluster.XID)
+	r.Empty(cluster.Hostname, "a routed entry is never dialed, so an address would be a trap")
+	r.Empty(cluster.CACert)
+	r.True(cluster.Insecure, "the test cloud is http, so the entry has to admit it sends credentials in the clear")
+
+	_, err = cfg.GetCluster("prod")
+	r.Error(err, "the cloud name is not also written")
+}
+
+// A cluster nothing can dial and cloud cannot reach is a dead end. The picker
+// greys it out; named, it has to be refused outright — falling through would
+// probe localhost and could pin whatever is listening there under a remote
+// cluster's name.
+func TestAddClusterByNameRefusesAnUnreachableCluster(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, []ClusterResponse{
+		{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme"},
+	}, map[string]bool{"cluster-prod": false})
+	configWithIdentity(t, srv.URL)
+
+	err := addCluster(presenceContext(t), addClusterOptions{clusterName: "prod"})
+	r.Error(err)
+	r.Contains(err.Error(), unreachableAddressNote)
+	r.Contains(err.Error(), unreachableAddressHelp)
+
+	cfg, err := clientconfig.LoadConfig()
+	r.NoError(err)
+	_, err = cfg.GetCluster("prod")
+	r.Error(err, "nothing is written for a cluster that could not be reached")
+}
+
+// The name is matched against cloud's list, so a typo is caught before any
+// connection is attempted and the error says what was actually available.
+func TestAddClusterByNameReportsAnUnknownName(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, []ClusterResponse{
+		{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme"},
+	}, nil)
+	configWithIdentity(t, srv.URL)
+
+	err := addCluster(presenceContext(t), addClusterOptions{clusterName: "produciton"})
+	r.Error(err)
+	r.Contains(err.Error(), `no cluster named "produciton"`)
+	r.Contains(err.Error(), "prod (Acme)")
+}

--- a/cli/commands/cluster_add_byname_test.go
+++ b/cli/commands/cluster_add_byname_test.go
@@ -62,7 +62,7 @@ func TestAddClusterByNameRoutedThroughCloud(t *testing.T) {
 	}, nil)
 	configWithIdentity(t, srv.URL)
 
-	err := addCluster(presenceContext(t), addClusterOptions{
+	_, err := addCluster(presenceContext(t), addClusterOptions{
 		clusterName: "prod",
 		localName:   "acme-prod",
 		viaCloud:    true,
@@ -96,7 +96,7 @@ func TestAddClusterByNameRefusesAnUnreachableCluster(t *testing.T) {
 	}, map[string]bool{"cluster-prod": false})
 	configWithIdentity(t, srv.URL)
 
-	err := addCluster(presenceContext(t), addClusterOptions{clusterName: "prod"})
+	_, err := addCluster(presenceContext(t), addClusterOptions{clusterName: "prod"})
 	r.Error(err)
 	r.Contains(err.Error(), unreachableAddressNote)
 	r.Contains(err.Error(), unreachableAddressHelp)
@@ -117,7 +117,7 @@ func TestAddClusterByNameReportsAnUnknownName(t *testing.T) {
 	}, nil)
 	configWithIdentity(t, srv.URL)
 
-	err := addCluster(presenceContext(t), addClusterOptions{clusterName: "produciton"})
+	_, err := addCluster(presenceContext(t), addClusterOptions{clusterName: "produciton"})
 	r.Error(err)
 	r.Contains(err.Error(), `no cluster named "produciton"`)
 	r.Contains(err.Error(), "prod (Acme)")

--- a/cli/commands/cluster_add_json.go
+++ b/cli/commands/cluster_add_json.go
@@ -150,13 +150,16 @@ const clusterAddJSONDoc = "With `--format json`, the command prints one result d
 	"on stdout; progress and warnings go to stderr. A failure is reported both as a " +
 	"document and as a non-zero exit status.\n\n" +
 	"```json\n" +
-	"{\"ok\": true, \"cluster\": {\"name\": \"prod\", \"cloud_name\": \"prod\", \"xid\": \"cluster-...\",\n" +
-	"                          \"organization\": \"Acme\", \"address\": \"10.0.0.1:8443\",\n" +
-	"                          \"via_cloud\": false, \"identity\": \"cloud\", \"active\": true,\n" +
+	"{\"ok\": true, \"cluster\": {\"name\": \"prod\", \"xid\": \"cluster-...\", \"organization\": \"Acme\",\n" +
+	"                          \"address\": \"10.0.0.1:8443\", \"via_cloud\": false,\n" +
+	"                          \"identity\": \"cloud\", \"active\": true,\n" +
 	"                          \"config_file\": \"~/.config/miren/clientconfig.d/prod.yaml\"}}\n" +
 	"\n" +
 	"{\"ok\": false, \"error\": {\"code\": \"cluster_not_found\", \"message\": \"no cluster named ...\"}}\n" +
 	"```\n\n" +
+	"`name` is the local name, which is what every other command takes. `cloud_name` " +
+	"appears alongside it only when `--as` stored the cluster under a different name than " +
+	"it has in Miren Cloud, and `address` is absent for a cluster reached through cloud.\n\n" +
 	"Messages are written for people and will be reworded. The code is the stable part:\n\n" +
 	"| Code | Meaning |\n" +
 	"|------|---------|\n" +

--- a/cli/commands/cluster_add_json.go
+++ b/cli/commands/cluster_add_json.go
@@ -1,0 +1,132 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+)
+
+// The codes a caller can branch on. They exist because the message is written
+// for a person and will be reworded; the code is the part a script is allowed
+// to depend on, so each one names a distinct situation with a distinct fix.
+const (
+	// codeInvalidFlags is a combination of flags that cannot mean anything,
+	// caught before any work is done.
+	codeInvalidFlags = "invalid_flags"
+
+	// codeInteractiveRequired is a request that can only be answered by asking
+	// a person — picking from a list, or confirming an overwrite.
+	codeInteractiveRequired = "interactive_required"
+
+	codeNoIdentities       = "no_identities"
+	codeMultipleIdentities = "multiple_identities"
+	codeIdentityNotFound   = "identity_not_found"
+
+	// codeCloudRequestFailed is cloud failing to answer, as opposed to
+	// answering with something unwelcome.
+	codeCloudRequestFailed = "cloud_request_failed"
+
+	codeNoClusters          = "no_clusters"
+	codeUnknownOrganization = "unknown_organization"
+	codeClusterNotFound     = "cluster_not_found"
+	codeAmbiguousCluster    = "ambiguous_cluster"
+
+	// codeClusterUnreachable is a cluster that exists and could not be reached,
+	// which is the one failure worth retrying later.
+	codeClusterUnreachable = "cluster_unreachable"
+
+	// codeClusterExists is a local name already in use, cleared by --force or
+	// by choosing another name with --as.
+	codeClusterExists = "cluster_exists"
+
+	codeConfigLoadFailed  = "config_load_failed"
+	codeConfigWriteFailed = "config_write_failed"
+	codeCancelled         = "cancelled"
+
+	// codeUnknown is what an error that was never given a code reports as.
+	// Callers should treat it as a failure they cannot interpret.
+	codeUnknown = "unknown"
+)
+
+// codedError carries a machine-readable code alongside an ordinary error, so
+// the same failure can be rendered as a sentence for a person or as a code for
+// a script without the two being written separately and drifting apart.
+type codedError struct {
+	code string
+	err  error
+}
+
+func (e *codedError) Error() string { return e.err.Error() }
+func (e *codedError) Unwrap() error { return e.err }
+
+func codedErrorf(code, format string, args ...any) error {
+	return &codedError{code: code, err: fmt.Errorf(format, args...)}
+}
+
+// errorCode reports the code an error carries, looking through wrapping.
+func errorCode(err error) string {
+	var coded *codedError
+	if errors.As(err, &coded) {
+		return coded.code
+	}
+	return codeUnknown
+}
+
+// commandError is a failure as a caller reads it.
+type commandError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// addedCluster describes what was written to the config.
+type addedCluster struct {
+	// Name is the local name, which is what every other command takes.
+	Name string `json:"name"`
+
+	// CloudName is its name in Miren Cloud, present when it was looked up
+	// there and different from the local name.
+	CloudName    string `json:"cloud_name,omitempty"`
+	XID          string `json:"xid,omitempty"`
+	Organization string `json:"organization,omitempty"`
+
+	// Address is empty for a cluster reached through cloud, which is dialed at
+	// no address of its own.
+	Address  string `json:"address,omitempty"`
+	ViaCloud bool   `json:"via_cloud"`
+
+	Identity string `json:"identity,omitempty"`
+
+	// Insecure records that commands to this cluster send credentials over an
+	// unencrypted connection, which happens with a cloud reached over http.
+	Insecure bool `json:"insecure,omitempty"`
+
+	// Active reports that this is now the cluster commands use by default.
+	Active     bool   `json:"active"`
+	ConfigFile string `json:"config_file,omitempty"`
+}
+
+// clusterAddResult is the document `cluster add --format json` prints. Exactly
+// one of Cluster and Error is set, and OK says which without the caller having
+// to check for a key's absence.
+type clusterAddResult struct {
+	OK      bool          `json:"ok"`
+	Cluster *addedCluster `json:"cluster,omitempty"`
+	Error   *commandError `json:"error,omitempty"`
+}
+
+// reportClusterAdd prints the result document.
+//
+// A failure is reported both ways: as a document on stdout and as a non-zero
+// exit status, because a caller that only checks the exit code and one that
+// only reads the document should reach the same conclusion. The error is not
+// returned, since returning it would print the human-readable line too and
+// leave the caller holding a document plus a stray sentence.
+func reportClusterAdd(ctx *Context, added *addedCluster, err error) error {
+	if err != nil {
+		ctx.SetExitCode(1)
+		return PrintJSON(clusterAddResult{
+			Error: &commandError{Code: errorCode(err), Message: err.Error()},
+		})
+	}
+
+	return PrintJSON(clusterAddResult{OK: true, Cluster: added})
+}

--- a/cli/commands/cluster_add_json.go
+++ b/cli/commands/cluster_add_json.go
@@ -14,21 +14,33 @@ const (
 	codeInvalidFlags = "invalid_flags"
 
 	// codeInteractiveRequired is a request that can only be answered by asking
-	// a person — picking from a list, or confirming an overwrite.
+	// a person: picking from a list, or confirming an overwrite.
 	codeInteractiveRequired = "interactive_required"
 
-	codeNoIdentities       = "no_identities"
-	codeMultipleIdentities = "multiple_identities"
-	codeIdentityNotFound   = "identity_not_found"
+	// codeNoIdentities means nobody is logged in. It is separate from
+	// codeIdentityError because the fix is a person running `miren login`,
+	// not a different argument.
+	codeNoIdentities = "no_identities"
+
+	// codeIdentityError is an identity that was named and not found, or one
+	// that has to be named and was not. Either way the caller passes a
+	// different --identity, and the message says which.
+	codeIdentityError = "identity_error"
 
 	// codeCloudRequestFailed is cloud failing to answer, as opposed to
 	// answering with something unwelcome.
 	codeCloudRequestFailed = "cloud_request_failed"
 
-	codeNoClusters          = "no_clusters"
+	// codeClusterNotFound covers both a name that matched nothing and an
+	// account with no clusters at all. The distinction changes the message,
+	// not what the caller can do about it.
+	codeClusterNotFound = "cluster_not_found"
+
+	// codeAmbiguousCluster means the name matched clusters in more than one
+	// organization, cleared by --organization.
+	codeAmbiguousCluster = "ambiguous_cluster"
+
 	codeUnknownOrganization = "unknown_organization"
-	codeClusterNotFound     = "cluster_not_found"
-	codeAmbiguousCluster    = "ambiguous_cluster"
 
 	// codeClusterUnreachable is a cluster that exists and could not be reached,
 	// which is the one failure worth retrying later.
@@ -38,9 +50,9 @@ const (
 	// by choosing another name with --as.
 	codeClusterExists = "cluster_exists"
 
-	codeConfigLoadFailed  = "config_load_failed"
-	codeConfigWriteFailed = "config_write_failed"
-	codeCancelled         = "cancelled"
+	// codeConfigError is the local config failing to load or to save. The
+	// caller cannot fix either one by asking differently.
+	codeConfigError = "config_error"
 
 	// codeUnknown is what an error that was never given a code reports as.
 	// Callers should treat it as a failure they cannot interpret.
@@ -130,3 +142,33 @@ func reportClusterAdd(ctx *Context, added *addedCluster, err error) error {
 
 	return PrintJSON(clusterAddResult{OK: true, Cluster: added})
 }
+
+// clusterAddJSONDoc is the extended description the docs generator renders on
+// the command's page. The codes are a contract callers write against, so they
+// belong somewhere a caller can read without opening the source.
+const clusterAddJSONDoc = "With `--format json`, the command prints one result document and nothing else " +
+	"on stdout; progress and warnings go to stderr. A failure is reported both as a " +
+	"document and as a non-zero exit status.\n\n" +
+	"```json\n" +
+	"{\"ok\": true, \"cluster\": {\"name\": \"prod\", \"cloud_name\": \"prod\", \"xid\": \"cluster-...\",\n" +
+	"                          \"organization\": \"Acme\", \"address\": \"10.0.0.1:8443\",\n" +
+	"                          \"via_cloud\": false, \"identity\": \"cloud\", \"active\": true,\n" +
+	"                          \"config_file\": \"~/.config/miren/clientconfig.d/prod.yaml\"}}\n" +
+	"\n" +
+	"{\"ok\": false, \"error\": {\"code\": \"cluster_not_found\", \"message\": \"no cluster named ...\"}}\n" +
+	"```\n\n" +
+	"Messages are written for people and will be reworded. The code is the stable part:\n\n" +
+	"| Code | Meaning |\n" +
+	"|------|---------|\n" +
+	"| `invalid_flags` | The flags given can't mean anything together. |\n" +
+	"| `interactive_required` | Answering needs a person. Name a cluster with `--cluster`, or use `--force` to overwrite. |\n" +
+	"| `no_identities` | Nobody is logged in. Run `miren login`. |\n" +
+	"| `identity_error` | The identity named wasn't found, or one has to be named with `--identity`. |\n" +
+	"| `cloud_request_failed` | Miren Cloud didn't answer. Worth retrying. |\n" +
+	"| `cluster_not_found` | No cluster by that name, or none on the account. |\n" +
+	"| `ambiguous_cluster` | The name exists in more than one organization. Add `--organization`. |\n" +
+	"| `unknown_organization` | No organization by that name. |\n" +
+	"| `cluster_unreachable` | The cluster exists and couldn't be reached. Worth retrying. |\n" +
+	"| `cluster_exists` | That local name is taken. Use `--force`, or `--as` to pick another. |\n" +
+	"| `config_error` | The local config couldn't be read or written. |\n" +
+	"| `unknown` | A failure with no code. Treat it as uninterpretable. |"

--- a/cli/commands/cluster_add_json_test.go
+++ b/cli/commands/cluster_add_json_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"regexp"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -236,4 +239,42 @@ func TestClusterAddRejectsAddressWithoutClusterBeforeIdentities(t *testing.T) {
 	r.Equal(1, exitCode)
 	r.Equal(codeInvalidFlags, result.Error.Code)
 	r.Contains(result.Error.Message, "--address needs --cluster")
+}
+
+// The documented table is what callers write against, so it has to list every
+// code the command can emit and nothing it can't. Drift here is worse than a
+// missing doc: a caller branches on a code that never arrives.
+func TestDocumentedCodesMatchTheConstants(t *testing.T) {
+	r := require.New(t)
+
+	emitted := []string{
+		codeInvalidFlags,
+		codeInteractiveRequired,
+		codeNoIdentities,
+		codeIdentityError,
+		codeCloudRequestFailed,
+		codeClusterNotFound,
+		codeAmbiguousCluster,
+		codeUnknownOrganization,
+		codeClusterUnreachable,
+		codeClusterExists,
+		codeConfigError,
+		codeUnknown,
+	}
+
+	var documented []string
+	for _, line := range strings.Split(clusterAddJSONDoc, "\n") {
+		if m := regexp.MustCompile("^\\| `([a-z_]+)` \\|").FindStringSubmatch(line); m != nil {
+			documented = append(documented, m[1])
+		}
+	}
+
+	sort.Strings(emitted)
+	sort.Strings(documented)
+	r.Equal(emitted, documented, "every code the command emits is documented, and nothing else is")
+
+	// And every documented code is a constant that some path actually uses.
+	for _, code := range documented {
+		r.NotEmpty(code)
+	}
 }

--- a/cli/commands/cluster_add_json_test.go
+++ b/cli/commands/cluster_add_json_test.go
@@ -1,0 +1,239 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/clientconfig"
+)
+
+// runClusterAdd drives the command the way the CLI wires it, with the context's
+// output going to the same place PrintJSON writes, so a stray progress line in
+// front of the document fails the test instead of the caller's parser.
+//
+// Returns the decoded document, raw stdout, and the exit code the CLI would
+// exit with.
+func runClusterAdd(t *testing.T, opts clusterAddOpts) (clusterAddResult, string, int) {
+	t.Helper()
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = stdout }()
+
+	ctx := &Context{Context: context.Background(), Stdout: w, Stderr: &bytes.Buffer{}}
+
+	require.NoError(t, ClusterAdd(ctx, opts), "a JSON run reports failure in the document, not as a returned error")
+
+	require.NoError(t, w.Close())
+	printed := &bytes.Buffer{}
+	_, err = printed.ReadFrom(r)
+	require.NoError(t, err)
+
+	var result clusterAddResult
+	require.NoError(t, json.Unmarshal(printed.Bytes(), &result),
+		"stdout has to be the result document and nothing else:\n%s", printed.String())
+
+	return result, printed.String(), ctx.exitCode
+}
+
+func jsonAddOpts(cluster string) clusterAddOpts {
+	return clusterAddOpts{
+		FormatOptions: FormatOptions{Format: "json"},
+		Cluster:       cluster,
+	}
+}
+
+// What a successful add tells a caller: the local name to use from here on, and
+// how the cluster will be reached.
+func TestClusterAddJSONSuccess(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, []ClusterResponse{
+		{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme"},
+	}, nil)
+	configWithIdentity(t, srv.URL)
+
+	opts := jsonAddOpts("prod")
+	opts.As = "acme-prod"
+	opts.ViaCloud = true
+
+	result, printed, exitCode := runClusterAdd(t, opts)
+
+	r.True(result.OK)
+	r.Zero(exitCode)
+	r.Nil(result.Error)
+	r.NotContains(printed, "Successfully added", "progress belongs on stderr")
+
+	added := result.Cluster
+	r.NotNil(added)
+	r.Equal("acme-prod", added.Name, "the local name is what every other command takes")
+	r.Equal("prod", added.CloudName)
+	r.Equal("cluster-prod", added.XID)
+	r.Equal("Acme", added.Organization)
+	r.True(added.ViaCloud)
+	r.Empty(added.Address, "a routed cluster is dialed at no address of its own")
+	r.Equal("cloud", added.Identity)
+	r.True(added.Insecure, "the test cloud is http, and the entry says so")
+	r.True(added.Active, "the first cluster added becomes the active one")
+	r.Contains(added.ConfigFile, "acme-prod.yaml")
+}
+
+// A failure has to be legible twice over: as a document a caller can branch on,
+// and as a non-zero exit status for one that only checks that.
+func TestClusterAddJSONReportsFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     func() clusterAddOpts
+		wantCode string
+		wantIn   string
+	}{
+		{
+			name:     "flags that cannot mean anything",
+			opts:     func() clusterAddOpts { o := jsonAddOpts(""); o.As = "x"; return o },
+			wantCode: codeInvalidFlags,
+			wantIn:   "--as needs --cluster",
+		},
+		{
+			// The one that matters most for an agent: no list to pick from, so
+			// say what to run instead.
+			name:     "picking from a list needs a person",
+			opts:     func() clusterAddOpts { return jsonAddOpts("") },
+			wantCode: codeInteractiveRequired,
+			wantIn:   "miren cluster available",
+		},
+		{
+			name:     "no such cluster",
+			opts:     func() clusterAddOpts { return jsonAddOpts("produciton") },
+			wantCode: codeClusterNotFound,
+			wantIn:   `no cluster named "produciton"`,
+		},
+		{
+			name:     "ambiguous name",
+			opts:     func() clusterAddOpts { return jsonAddOpts("shared") },
+			wantCode: codeAmbiguousCluster,
+			wantIn:   "--organization",
+		},
+		{
+			name:     "unknown organization",
+			opts:     func() clusterAddOpts { o := jsonAddOpts("prod"); o.Organization = "Initech"; return o },
+			wantCode: codeUnknownOrganization,
+			wantIn:   `no clusters in organization "Initech"`,
+		},
+		{
+			// Exists, cannot be reached, and worth retrying later — which is
+			// why it has a code of its own.
+			name:     "cluster nothing can reach",
+			opts:     func() clusterAddOpts { return jsonAddOpts("behind-nat") },
+			wantCode: codeClusterUnreachable,
+			wantIn:   unreachableAddressNote,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := require.New(t)
+
+			srv := fakeCloud(t, []ClusterResponse{
+				{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme"},
+				{Name: "behind-nat", XID: "cluster-nat", OrganizationName: "Acme"},
+				{Name: "shared", XID: "cluster-a", OrganizationName: "Acme"},
+				{Name: "shared", XID: "cluster-g", OrganizationName: "Globex"},
+			}, nil)
+			configWithIdentity(t, srv.URL)
+
+			result, _, exitCode := runClusterAdd(t, test.opts())
+
+			r.False(result.OK)
+			r.Nil(result.Cluster)
+			r.Equal(1, exitCode, "a caller checking only the exit status has to see the failure too")
+
+			r.NotNil(result.Error)
+			r.Equal(test.wantCode, result.Error.Code)
+			r.Contains(result.Error.Message, test.wantIn)
+		})
+	}
+}
+
+// Overwriting an existing entry is a decision to hand back, not one to make
+// because nobody was watching.
+func TestClusterAddJSONRefusesToOverwrite(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, []ClusterResponse{
+		{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme"},
+	}, nil)
+	configWithIdentity(t, srv.URL)
+
+	cfg, err := clientconfig.LoadConfig()
+	r.NoError(err)
+	cfg.SetCluster("prod", &clientconfig.ClusterConfig{Hostname: "10.0.0.9:8443", Identity: "cloud"})
+	r.NoError(cfg.Save())
+
+	opts := jsonAddOpts("prod")
+	opts.ViaCloud = true
+
+	result, _, exitCode := runClusterAdd(t, opts)
+
+	r.False(result.OK)
+	r.Equal(1, exitCode)
+	r.Equal(codeClusterExists, result.Error.Code)
+	r.Contains(result.Error.Message, "--force")
+
+	// And the existing entry is untouched.
+	cfg, err = clientconfig.LoadConfig()
+	r.NoError(err)
+	cluster, err := cfg.GetCluster("prod")
+	r.NoError(err)
+	r.Equal("10.0.0.9:8443", cluster.Hostname)
+	r.False(cluster.ViaCloud)
+
+	// --force is how a caller says to go ahead.
+	opts.Force = true
+	result, _, exitCode = runClusterAdd(t, opts)
+	r.True(result.OK)
+	r.Zero(exitCode)
+	r.True(result.Cluster.ViaCloud)
+}
+
+// An error that was never given a code still has to report one, or a caller
+// switching on it falls through silently.
+func TestErrorCodeFallsBackToUnknown(t *testing.T) {
+	require.Equal(t, codeUnknown, errorCode(context.Canceled))
+	require.Equal(t, codeInvalidFlags, errorCode(codedErrorf(codeInvalidFlags, "nope")))
+}
+
+// The flag checks run before anything is loaded, so a bad combination is
+// reported as itself. This used to be checked after identity resolution, where
+// an account with several identities got told to pick one instead.
+func TestClusterAddRejectsAddressWithoutClusterBeforeIdentities(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, []ClusterResponse{
+		{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme"},
+	}, nil)
+	configWithIdentity(t, srv.URL)
+
+	cfg, err := clientconfig.LoadConfig()
+	r.NoError(err)
+	cfg.SetIdentity("second", &clientconfig.IdentityConfig{
+		Type:   clientconfig.IdentityToken,
+		Issuer: srv.URL,
+		Token:  freshLoginJWT(t),
+	})
+	r.NoError(cfg.Save())
+
+	opts := clusterAddOpts{FormatOptions: FormatOptions{Format: "json"}, Address: "10.0.0.1:8443"}
+	result, _, exitCode := runClusterAdd(t, opts)
+
+	r.False(result.OK)
+	r.Equal(1, exitCode)
+	r.Equal(codeInvalidFlags, result.Error.Code)
+	r.Contains(result.Error.Message, "--address needs --cluster")
+}

--- a/cli/commands/cluster_add_test.go
+++ b/cli/commands/cluster_add_test.go
@@ -270,11 +270,16 @@ func TestClusterAddFlagValidation(t *testing.T) {
 			opts:    addClusterOptions{clusterName: "prod", address: "10.0.0.1:8443", viaCloud: true},
 			wantErr: "--via-cloud and --address are mutually exclusive",
 		},
+		{
+			name:    "address without cluster",
+			opts:    addClusterOptions{address: "10.0.0.1:8443"},
+			wantErr: "--address needs --cluster",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := addCluster(presenceContext(t), test.opts)
+			_, err := addCluster(presenceContext(t), test.opts)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), test.wantErr)
 		})

--- a/cli/commands/cluster_add_test.go
+++ b/cli/commands/cluster_add_test.go
@@ -126,3 +126,157 @@ func TestNormalizeAddress(t *testing.T) {
 		})
 	}
 }
+
+// The cluster list an account with two organizations gets back, including the
+// name collision that makes --organization necessary.
+func namedClusters() []ClusterResponse {
+	return []ClusterResponse{
+		{Name: "prod", XID: "cluster-acme-prod", OrganizationName: "Acme", OrganizationXID: "org-acme"},
+		{Name: "prod", XID: "cluster-globex-prod", OrganizationName: "Globex", OrganizationXID: "org-globex"},
+		{Name: "staging", XID: "cluster-acme-staging", OrganizationName: "Acme", OrganizationXID: "org-acme"},
+	}
+}
+
+func TestFindClusterByName(t *testing.T) {
+	tests := []struct {
+		name         string
+		cluster      string
+		organization string
+		wantXID      string
+		wantErr      []string
+	}{
+		{
+			name:    "exact match",
+			cluster: "staging",
+			wantXID: "cluster-acme-staging",
+		},
+		{
+			// Convenience for anyone typing a name back from a listing, but
+			// only once nothing matched exactly.
+			name:    "case insensitive match",
+			cluster: "STAGING",
+			wantXID: "cluster-acme-staging",
+		},
+		{
+			name:    "no such cluster names the ones that exist",
+			cluster: "nope",
+			wantErr: []string{`no cluster named "nope"`, "prod (Acme)", "prod (Globex)", "staging (Acme)"},
+		},
+		{
+			// Guessing here would bind the wrong production cluster under the
+			// right local name.
+			name:    "ambiguous name is refused",
+			cluster: "prod",
+			wantErr: []string{`2 clusters are named "prod"`, "prod (Acme)", "prod (Globex)", "--organization"},
+		},
+		{
+			name:         "organization resolves the ambiguity",
+			cluster:      "prod",
+			organization: "Globex",
+			wantXID:      "cluster-globex-prod",
+		},
+		{
+			name:         "organization matches case insensitively",
+			cluster:      "prod",
+			organization: "acme",
+			wantXID:      "cluster-acme-prod",
+		},
+		{
+			// The XID is what a script has on hand, and it is unambiguous in a
+			// way the display name is not.
+			name:         "organization matches by xid",
+			cluster:      "prod",
+			organization: "org-globex",
+			wantXID:      "cluster-globex-prod",
+		},
+		{
+			name:         "unknown organization names the real ones",
+			cluster:      "prod",
+			organization: "Initech",
+			wantErr:      []string{`no clusters in organization "Initech"`, "Acme, Globex"},
+		},
+		{
+			name:         "organization narrows before the name is matched",
+			cluster:      "staging",
+			organization: "Globex",
+			wantErr:      []string{`no cluster named "staging"`, "prod (Globex)"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := require.New(t)
+
+			found, err := findClusterByName(namedClusters(), test.cluster, test.organization)
+
+			if len(test.wantErr) > 0 {
+				r.Error(err)
+				for _, want := range test.wantErr {
+					r.Contains(err.Error(), want)
+				}
+				r.Nil(found)
+				return
+			}
+
+			r.NoError(err)
+			r.Equal(test.wantXID, found.XID)
+		})
+	}
+}
+
+// A name that matches exactly must win over one that only matches case
+// insensitively, or two clusters differing in case would read as ambiguous.
+func TestFindClusterByNamePrefersTheExactMatch(t *testing.T) {
+	clusters := []ClusterResponse{
+		{Name: "Prod", XID: "cluster-upper", OrganizationName: "Acme"},
+		{Name: "prod", XID: "cluster-lower", OrganizationName: "Acme"},
+	}
+
+	found, err := findClusterByName(clusters, "prod", "")
+	require.NoError(t, err)
+	require.Equal(t, "cluster-lower", found.XID)
+}
+
+// The flag combinations that are refused before anything is fetched or dialed,
+// which is what makes them testable without a cloud or a cluster.
+func TestClusterAddFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    addClusterOptions
+		wantErr string
+	}{
+		{
+			name:    "as without cluster",
+			opts:    addClusterOptions{localName: "local-prod"},
+			wantErr: "--as needs --cluster",
+		},
+		{
+			name:    "as with address",
+			opts:    addClusterOptions{clusterName: "prod", address: "10.0.0.1:8443", localName: "local-prod"},
+			wantErr: "--as and --address are mutually exclusive",
+		},
+		{
+			name:    "organization with address",
+			opts:    addClusterOptions{clusterName: "prod", address: "10.0.0.1:8443", organization: "Acme"},
+			wantErr: "--organization and --address are mutually exclusive",
+		},
+		{
+			name:    "organization without cluster",
+			opts:    addClusterOptions{organization: "Acme"},
+			wantErr: "--organization only narrows the lookup for --cluster",
+		},
+		{
+			name:    "via-cloud with address",
+			opts:    addClusterOptions{clusterName: "prod", address: "10.0.0.1:8443", viaCloud: true},
+			wantErr: "--via-cloud and --address are mutually exclusive",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := addCluster(presenceContext(t), test.opts)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}

--- a/cli/commands/cluster_add_viacloud_test.go
+++ b/cli/commands/cluster_add_viacloud_test.go
@@ -4,63 +4,24 @@ import (
 	"bytes"
 	"context"
 	"net/http"
-	"net/http/httptest"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/cloudapi/cloudapitest"
 )
 
-// cloudPresenceServer stands in for cloud's per-cluster presence endpoint,
-// recording which clusters were asked about.
-// The recorder is returned as a function rather than a slice pointer because
-// the presence checks now run concurrently: reads and writes both have to hold
-// the lock, and handing back a pointer makes it easy to forget.
-func cloudPresenceServer(t *testing.T, online map[string]bool, status int) (*httptest.Server, func() []string) {
+// cloudPresenceServer stands in for cloud's presence endpoint, recording which
+// clusters were asked about. A thin wrapper over the shared fake so these tests
+// keep reading as they did.
+func cloudPresenceServer(t *testing.T, online map[string]bool, status int) (*cloudapitest.Server, func() []string) {
 	t.Helper()
 
-	var (
-		mu    sync.Mutex
-		asked []string
-	)
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if status != http.StatusOK {
-			w.WriteHeader(status)
-			return
-		}
-
-		// /api/v1/clusters/{xid}/online
-		xid := r.PathValue("xid")
-		if xid == "" {
-			// Fall back to parsing, since this server is not using a router.
-			parts := r.URL.Path
-			const prefix = "/api/v1/clusters/"
-			const suffix = "/online"
-			if len(parts) > len(prefix)+len(suffix) {
-				xid = parts[len(prefix) : len(parts)-len(suffix)]
-			}
-		}
-		mu.Lock()
-		asked = append(asked, xid)
-		mu.Unlock()
-
-		w.Header().Set("Content-Type", "application/json")
-		if online[xid] {
-			_, _ = w.Write([]byte(`{"cluster_xid":"` + xid + `","online":true}`))
-			return
-		}
-		_, _ = w.Write([]byte(`{"cluster_xid":"` + xid + `","online":false}`))
-	}))
+	srv := cloudapitest.NewServer(nil, online, status)
 	t.Cleanup(srv.Close)
 
-	return srv, func() []string {
-		mu.Lock()
-		defer mu.Unlock()
-		return append([]string(nil), asked...)
-	}
+	return srv, srv.Asked
 }
 
 func presenceTestConfig(t *testing.T, issuer string) (*clientconfig.Config, *clientconfig.IdentityConfig) {

--- a/cli/commands/cluster_available.go
+++ b/cli/commands/cluster_available.go
@@ -110,10 +110,10 @@ func ClusterAvailable(ctx *Context, opts clusterAvailableOpts) error {
 			Description:       cluster.Description,
 			APIAddresses:      cluster.APIAddresses,
 			CACertFingerprint: cluster.CACertFingerprint,
-			Reachable:         cluster.hasReachableAddress(),
+			Reachable:         cluster.HasReachableAddress(),
 		}
 
-		if opts.Check && !cluster.hasReachableAddress() {
+		if opts.Check && !cluster.HasReachableAddress() {
 			routable := cloudRoutable[cluster.XID]
 			entry.ViaCloud = &routable
 		}

--- a/cli/commands/cluster_available.go
+++ b/cli/commands/cluster_available.go
@@ -1,0 +1,218 @@
+package commands
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/charmbracelet/lipgloss"
+	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/theme"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// noDirectAddressNote describes a cluster advertising no address when nobody
+// has asked cloud whether it can reach it. Deliberately not
+// unreachableAddressNote: that one is a verdict, and without --check no verdict
+// has been reached.
+const noDirectAddressNote = "no direct address"
+
+// availableCluster is what one cluster in Miren Cloud looks like to a script.
+// Deliberately a shape of its own rather than ClusterResponse serialized
+// directly, so the wire format cloud happens to use is not the CLI's contract.
+type availableCluster struct {
+	Name              string   `json:"name"`
+	XID               string   `json:"xid"`
+	Organization      string   `json:"organization"`
+	OrganizationXID   string   `json:"organization_xid"`
+	Description       string   `json:"description,omitempty"`
+	APIAddresses      []string `json:"api_addresses,omitempty"`
+	CACertFingerprint string   `json:"ca_cert_fingerprint,omitempty"`
+
+	// Reachable reports that the cluster advertises at least one address to
+	// dial. Known without asking cloud anything.
+	Reachable bool `json:"reachable"`
+
+	// ViaCloud reports whether cloud holds a link to a cluster that advertises
+	// no address. Absent unless --check asked, because false and unasked are
+	// different answers and a caller cannot tell them apart from a bare false.
+	ViaCloud *bool `json:"via_cloud,omitempty"`
+
+	// Added reports that this cluster is already in the local config, matched
+	// by its id in cloud. A cluster added by --address carries no id, so it
+	// cannot be matched this way and reads as not added.
+	Added bool `json:"added"`
+
+	// LocalName is the name it was added under, which is not necessarily its
+	// name in cloud.
+	LocalName string `json:"local_name,omitempty"`
+}
+
+type clusterAvailableOpts struct {
+	FormatOptions
+	Identity     string `short:"i" long:"identity" description:"Name of the identity to use (optional - will use the only one if single)"`
+	Organization string `long:"organization" description:"Only list clusters in this organization"`
+	Check        bool   `long:"check" description:"Ask cloud whether it can reach the clusters that advertise no address"`
+}
+
+// ClusterAvailable lists the clusters Miren Cloud has for this account, which
+// is where the name `miren cluster add --cluster` wants comes from.
+func ClusterAvailable(ctx *Context, opts clusterAvailableOpts) error {
+	// Adopting an identity announces itself, and asking cloud about an
+	// unreachable cluster can warn. Both are progress, and in JSON mode stdout
+	// belongs to the document alone.
+	if opts.IsJSON() {
+		defer ctx.ProgressToStderr()()
+	}
+
+	config, err := clientconfig.LoadConfig()
+	if err != nil && err != clientconfig.ErrNoConfig {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	identityName, err := pickCloudIdentity(ctx, config, opts.Identity, "")
+	if err != nil {
+		return err
+	}
+
+	identity, err := lookupIdentity(config, identityName)
+	if err != nil {
+		return err
+	}
+
+	clusters, err := fetchAvailableClusters(ctx, config, identityName, identity)
+	if err != nil {
+		return fmt.Errorf("failed to fetch available clusters: %w", err)
+	}
+
+	clusters, err = clustersInOrganization(clusters, opts.Organization)
+	if err != nil {
+		return err
+	}
+
+	// Only asked for when requested: it costs a round trip per address-less
+	// cluster, and a listing should not make somebody wait for an answer they
+	// did not ask for.
+	var cloudRoutable map[string]bool
+	if opts.Check {
+		cloudRoutable = cloudRoutableClusters(ctx, config, identityName, identity, clusters)
+	}
+
+	added := addedClustersByXID(config)
+
+	available := make([]availableCluster, 0, len(clusters))
+	for _, cluster := range clusters {
+		entry := availableCluster{
+			Name:              cluster.Name,
+			XID:               cluster.XID,
+			Organization:      cluster.OrganizationName,
+			OrganizationXID:   cluster.OrganizationXID,
+			Description:       cluster.Description,
+			APIAddresses:      cluster.APIAddresses,
+			CACertFingerprint: cluster.CACertFingerprint,
+			Reachable:         cluster.hasReachableAddress(),
+		}
+
+		if opts.Check && !cluster.hasReachableAddress() {
+			routable := cloudRoutable[cluster.XID]
+			entry.ViaCloud = &routable
+		}
+
+		if localName, ok := added[cluster.XID]; ok && cluster.XID != "" {
+			entry.Added = true
+			entry.LocalName = localName
+		}
+
+		available = append(available, entry)
+	}
+
+	// Cloud returns them in whatever order it likes. Sorting makes two runs
+	// comparable, which matters more here than anywhere else: this output is
+	// meant to be read by scripts.
+	slices.SortFunc(available, func(a, b availableCluster) int {
+		if byOrg := cmp.Compare(a.Organization, b.Organization); byOrg != 0 {
+			return byOrg
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	if opts.IsJSON() {
+		return PrintJSON(available)
+	}
+
+	if len(available) == 0 {
+		ctx.Printf("No clusters available for your account\n")
+		return nil
+	}
+
+	return renderAvailableClusters(ctx, available, opts.Check)
+}
+
+// addedClustersByXID maps each locally configured cluster's id in cloud to the
+// name it was added under. Entries without an id — added by address rather than
+// discovered — cannot be matched to a cloud cluster and are left out.
+func addedClustersByXID(config *clientconfig.Config) map[string]string {
+	byXID := make(map[string]string)
+	if config == nil {
+		return byXID
+	}
+
+	_ = config.IterateClusters(func(name string, cluster *clientconfig.ClusterConfig) error {
+		if cluster.XID != "" {
+			byXID[cluster.XID] = name
+		}
+		return nil
+	})
+
+	return byXID
+}
+
+func renderAvailableClusters(ctx *Context, clusters []availableCluster, checked bool) error {
+	muted := lipgloss.NewStyle().Foreground(theme.Muted)
+
+	headers := []string{"NAME", "ORGANIZATION", "ADDRESS", "ADDED"}
+	rows := make([]ui.Row, 0, len(clusters))
+
+	var unchecked int
+	for _, cluster := range clusters {
+		var address string
+		switch {
+		case cluster.Reachable:
+			addresses := sortAddresses(cluster.APIAddresses)
+			address = formatAddressWithGrayPort(addresses[0])
+			if len(addresses) > 1 {
+				address = fmt.Sprintf("%s (+%d)", address, len(addresses)-1)
+			}
+		case cluster.ViaCloud == nil:
+			unchecked++
+			address = muted.Render(noDirectAddressNote)
+		case *cluster.ViaCloud:
+			address = muted.Render(viaCloudNote)
+		default:
+			address = muted.Render(unreachableAddressNote)
+		}
+
+		addedNote := muted.Render("-")
+		if cluster.Added {
+			addedNote = "yes"
+			if cluster.LocalName != cluster.Name {
+				addedNote = fmt.Sprintf("yes (as %s)", cluster.LocalName)
+			}
+		}
+
+		rows = append(rows, ui.Row{cluster.Name, cluster.Organization, address, addedNote})
+	}
+
+	table := ui.NewTable(
+		ui.WithColumns(ui.AutoSizeColumns(headers, rows, nil)),
+		ui.WithRows(rows),
+	)
+	ctx.Printf("%s\n", table.Render())
+
+	if unchecked > 0 && !checked {
+		ctx.Printf("\n%d cluster(s) advertise no address. Re-run with --check to ask cloud whether it can reach them.\n", unchecked)
+	}
+
+	ctx.Printf("\nAdd one with: miren cluster add --cluster <name>\n")
+	return nil
+}

--- a/cli/commands/cluster_available_test.go
+++ b/cli/commands/cluster_available_test.go
@@ -1,0 +1,218 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/clientconfig"
+)
+
+// availableClusterFixtures covers the three states a listing has to tell apart:
+// a cluster with an address, one with none, and one already added locally.
+func availableClusterFixtures() []ClusterResponse {
+	return []ClusterResponse{
+		{
+			Name: "prod", XID: "cluster-prod", OrganizationName: "Acme", OrganizationXID: "org-acme",
+			APIAddresses: []string{"10.0.0.1:8443", "127.0.0.1:8443"}, CACertFingerprint: "abc123",
+		},
+		{Name: "behind-nat", XID: "cluster-nat", OrganizationName: "Acme", OrganizationXID: "org-acme"},
+		{Name: "shared", XID: "cluster-shared", OrganizationName: "Globex", OrganizationXID: "org-globex"},
+	}
+}
+
+// runClusterAvailable drives the command the way the CLI wires it, with the
+// context's own output going to the same place PrintJSON writes. That wiring is
+// the point: with a separate buffer for the context, a progress line printed in
+// front of the JSON document goes unnoticed here and breaks every caller.
+//
+// Returns the decoded document (JSON mode only), everything that reached
+// stdout, and everything that reached stderr.
+func runClusterAvailable(t *testing.T, opts clusterAvailableOpts) ([]availableCluster, string, string, error) {
+	t.Helper()
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = stdout }()
+
+	stderr := &bytes.Buffer{}
+	ctx := &Context{Context: context.Background(), Stdout: w, Stderr: stderr}
+
+	cmdErr := ClusterAvailable(ctx, opts)
+
+	require.NoError(t, w.Close())
+	printed := &bytes.Buffer{}
+	_, err = printed.ReadFrom(r)
+	require.NoError(t, err)
+
+	if cmdErr != nil || !opts.IsJSON() {
+		return nil, printed.String(), stderr.String(), cmdErr
+	}
+
+	var clusters []availableCluster
+	require.NoError(t, json.Unmarshal(printed.Bytes(), &clusters),
+		"stdout has to be the JSON document and nothing else:\n%s", printed.String())
+
+	return clusters, printed.String(), stderr.String(), nil
+}
+
+// The JSON a script reads: every cluster cloud knows about, sorted, with enough
+// to hand a name straight to `miren cluster add --cluster`.
+func TestClusterAvailableJSON(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, availableClusterFixtures(), nil)
+	configWithIdentity(t, srv.URL)
+
+	clusters, printed, stderr, err := runClusterAvailable(t, clusterAvailableOpts{
+		FormatOptions: FormatOptions{Format: "json"},
+	})
+	r.NoError(err)
+	r.Len(clusters, 3)
+
+	// Adopting the lone identity says so, and that line has to land on stderr.
+	// On stdout it would sit in front of the array and break every parser.
+	r.Contains(stderr, "Using identity")
+	r.NotContains(printed, "Using identity")
+
+	// Sorted by organization, then name, so two runs can be compared.
+	r.Equal([]string{"behind-nat", "prod", "shared"}, []string{clusters[0].Name, clusters[1].Name, clusters[2].Name})
+
+	prod := clusters[1]
+	r.Equal("cluster-prod", prod.XID)
+	r.Equal("Acme", prod.Organization)
+	r.Equal("org-acme", prod.OrganizationXID)
+	r.Equal([]string{"10.0.0.1:8443", "127.0.0.1:8443"}, prod.APIAddresses)
+	r.Equal("abc123", prod.CACertFingerprint)
+	r.True(prod.Reachable)
+	r.False(prod.Added)
+
+	// Nobody asked cloud anything, so no claim is made either way.
+	r.Nil(clusters[0].ViaCloud, "without --check, an address-less cluster's route is unknown, not false")
+	r.False(clusters[0].Reachable)
+}
+
+// --check is what turns "advertises no address" into a usable answer, and the
+// two possible answers have to be distinguishable in the output.
+func TestClusterAvailableCheckReportsCloudRoutes(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, availableClusterFixtures(), map[string]bool{"cluster-nat": true})
+	configWithIdentity(t, srv.URL)
+
+	clusters, _, _, err := runClusterAvailable(t, clusterAvailableOpts{
+		FormatOptions: FormatOptions{Format: "json"},
+		Check:         true,
+	})
+	r.NoError(err)
+
+	byName := map[string]availableCluster{}
+	for _, cluster := range clusters {
+		byName[cluster.Name] = cluster
+	}
+
+	r.NotNil(byName["behind-nat"].ViaCloud)
+	r.True(*byName["behind-nat"].ViaCloud, "cloud holds a link to it, so it can be added")
+
+	r.NotNil(byName["shared"].ViaCloud)
+	r.False(*byName["shared"].ViaCloud, "cloud was asked and said no")
+
+	r.Nil(byName["prod"].ViaCloud, "a cluster with an address is never asked about")
+}
+
+// Already-added clusters are matched by their id in cloud, not their name, so
+// the answer survives being added under a different local name.
+func TestClusterAvailableMarksAddedClusters(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, availableClusterFixtures(), nil)
+	configWithIdentity(t, srv.URL)
+
+	cfg, err := clientconfig.LoadConfig()
+	r.NoError(err)
+	cfg.SetCluster("acme-prod", &clientconfig.ClusterConfig{
+		Hostname: "10.0.0.1:8443",
+		Identity: "cloud",
+		XID:      "cluster-prod",
+	})
+	// One added by address, which carries no id and so cannot be matched.
+	cfg.SetCluster("shared", &clientconfig.ClusterConfig{
+		Hostname: "192.168.1.5:8443",
+		Identity: "cloud",
+	})
+	r.NoError(cfg.Save())
+
+	clusters, _, _, err := runClusterAvailable(t, clusterAvailableOpts{
+		FormatOptions: FormatOptions{Format: "json"},
+	})
+	r.NoError(err)
+
+	byName := map[string]availableCluster{}
+	for _, cluster := range clusters {
+		byName[cluster.Name] = cluster
+	}
+
+	r.True(byName["prod"].Added)
+	r.Equal("acme-prod", byName["prod"].LocalName, "the local name is what you would pass to other commands")
+
+	r.False(byName["shared"].Added, "a local entry with no cluster id cannot be claimed as this cluster")
+	r.Empty(byName["shared"].LocalName)
+}
+
+func TestClusterAvailableFiltersByOrganization(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, availableClusterFixtures(), nil)
+	configWithIdentity(t, srv.URL)
+
+	clusters, _, _, err := runClusterAvailable(t, clusterAvailableOpts{
+		FormatOptions: FormatOptions{Format: "json"},
+		Organization:  "globex",
+	})
+	r.NoError(err)
+	r.Len(clusters, 1)
+	r.Equal("shared", clusters[0].Name)
+
+	// A misspelled organization is a mistake worth reporting, not an empty
+	// list that reads as "you have no clusters there".
+	_, _, _, err = runClusterAvailable(t, clusterAvailableOpts{
+		FormatOptions: FormatOptions{Format: "json"},
+		Organization:  "Initech",
+	})
+	r.Error(err)
+	r.Contains(err.Error(), `no clusters in organization "Initech"`)
+	r.Contains(err.Error(), "Acme, Globex")
+}
+
+// The table has to say which clusters are unresolved and how to resolve them,
+// or somebody reads "no direct address" as a verdict.
+func TestClusterAvailableTableExplainsUncheckedClusters(t *testing.T) {
+	r := require.New(t)
+
+	srv := fakeCloud(t, availableClusterFixtures(), nil)
+	configWithIdentity(t, srv.URL)
+
+	_, printed, _, err := runClusterAvailable(t, clusterAvailableOpts{})
+	r.NoError(err)
+
+	r.Contains(printed, "prod")
+	r.Contains(printed, noDirectAddressNote)
+	r.Contains(printed, "--check")
+	r.Contains(printed, "miren cluster add --cluster")
+}
+
+// Nothing can be asked of cloud without an identity, and the error has to say
+// how to get one.
+func TestClusterAvailableNeedsAnIdentity(t *testing.T) {
+	t.Setenv(clientconfig.EnvConfigPath, t.TempDir())
+
+	_, _, _, err := runClusterAvailable(t, clusterAvailableOpts{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "miren login")
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -809,6 +809,10 @@ miren deploy --analyze
 			Body: "miren cluster add --cluster my-cluster --as staging",
 		}),
 		WithExample(mflags.Example{
+			Name: "Add a cluster, reporting the result (and any failure) as JSON",
+			Body: "miren cluster add --cluster my-cluster --format json",
+		}),
+		WithExample(mflags.Example{
 			Name: "Add a cluster with a specific address",
 			Body: "miren cluster add --cluster my-cluster --address 10.0.0.1:8443",
 		}),

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -796,6 +796,7 @@ miren deploy --analyze
 		}),
 	))
 	d.Dispatch("cluster add", Infer("cluster add", "Add a new cluster configuration", ClusterAdd,
+		WithDescription(clusterAddJSONDoc),
 		WithExample(mflags.Example{
 			Name: "Add a cluster interactively",
 			Body: "miren cluster add",

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -781,6 +781,20 @@ miren deploy --analyze
 			Body: "miren cluster switch production",
 		}),
 	))
+	d.Dispatch("cluster available", Infer("cluster available", "List the clusters Miren Cloud has for your account", ClusterAvailable,
+		WithExample(mflags.Example{
+			Name: "List clusters you could add",
+			Body: "miren cluster available",
+		}),
+		WithExample(mflags.Example{
+			Name: "List as JSON",
+			Body: "miren cluster available --format json",
+		}),
+		WithExample(mflags.Example{
+			Name: "Ask cloud whether it can reach the clusters with no address",
+			Body: "miren cluster available --check",
+		}),
+	))
 	d.Dispatch("cluster add", Infer("cluster add", "Add a new cluster configuration", ClusterAdd,
 		WithExample(mflags.Example{
 			Name: "Add a cluster interactively",

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -787,6 +787,14 @@ miren deploy --analyze
 			Body: "miren cluster add",
 		}),
 		WithExample(mflags.Example{
+			Name: "Add a cluster by name, without the picker",
+			Body: "miren cluster add --cluster my-cluster",
+		}),
+		WithExample(mflags.Example{
+			Name: "Add a cluster by name under a different local name",
+			Body: "miren cluster add --cluster my-cluster --as staging",
+		}),
+		WithExample(mflags.Example{
 			Name: "Add a cluster with a specific address",
 			Body: "miren cluster add --cluster my-cluster --address 10.0.0.1:8443",
 		}),

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -211,7 +211,7 @@ func isPrivateAddress(host string) bool {
 // something to offer besides logging in, so each command can point at its own
 // way out while the rest of the message stays the same.
 func pickCloudIdentity(ctx *Context, config *clientconfig.Config, requested, suggestion string) (string, error) {
-	noIdentities := fmt.Errorf("no identities configured. Please run 'miren login' first%s", suggestion)
+	noIdentities := codedErrorf(codeNoIdentities, "no identities configured. Please run 'miren login' first%s", suggestion)
 
 	if config == nil || !config.HasIdentities() {
 		return "", noIdentities
@@ -228,7 +228,7 @@ func pickCloudIdentity(ctx *Context, config *clientconfig.Config, requested, sug
 	case 0:
 		return "", noIdentities
 	default:
-		return "", fmt.Errorf("multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
+		return "", codedErrorf(codeMultipleIdentities, "multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
 	}
 }
 
@@ -236,15 +236,15 @@ func pickCloudIdentity(ctx *Context, config *clientconfig.Config, requested, sug
 // it is not among them.
 func lookupIdentity(config *clientconfig.Config, name string) (*clientconfig.IdentityConfig, error) {
 	if config == nil {
-		return nil, fmt.Errorf("identity %q not found in configuration", name)
+		return nil, codedErrorf(codeIdentityNotFound, "identity %q not found in configuration", name)
 	}
 
 	identity, err := config.GetIdentity(name)
 	if err != nil {
 		if available := config.GetIdentityNames(); len(available) > 0 {
-			return nil, fmt.Errorf("identity %q not found. Available identities: %v", name, available)
+			return nil, codedErrorf(codeIdentityNotFound, "identity %q not found. Available identities: %v", name, available)
 		}
-		return nil, fmt.Errorf("identity %q not found in configuration", name)
+		return nil, codedErrorf(codeIdentityNotFound, "identity %q not found in configuration", name)
 	}
 
 	return identity, nil

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -562,7 +562,8 @@ func selectClusterFromList(ctx *Context, clusters []ClusterResponse, cloudRoutab
 			}
 			ctx.Printf("\n")
 		}
-		ctx.Printf("Re-run with --cluster and --address flags to select a specific cluster\n")
+		ctx.Printf("Re-run with --cluster <name> to add one of these without the picker\n")
+		ctx.Printf("(add --organization when the same name appears in more than one, or --address to dial a cluster directly)\n")
 		return nil, "", fmt.Errorf("interactive mode not available")
 	}
 

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -203,6 +203,53 @@ func isPrivateAddress(host string) bool {
 	return ip.IsPrivate()
 }
 
+// pickCloudIdentity chooses which configured identity to ask cloud with. A
+// lone identity is adopted, several are refused rather than guessed between,
+// and none is an error — every question for cloud is asked as somebody.
+//
+// suggestion is appended to the "no identities" error by callers that have
+// something to offer besides logging in, so each command can point at its own
+// way out while the rest of the message stays the same.
+func pickCloudIdentity(ctx *Context, config *clientconfig.Config, requested, suggestion string) (string, error) {
+	noIdentities := fmt.Errorf("no identities configured. Please run 'miren login' first%s", suggestion)
+
+	if config == nil || !config.HasIdentities() {
+		return "", noIdentities
+	}
+
+	if requested != "" {
+		return requested, nil
+	}
+
+	switch names := config.GetIdentityNames(); len(names) {
+	case 1:
+		ctx.Info("Using identity '%s' (only one available)", names[0])
+		return names[0], nil
+	case 0:
+		return "", noIdentities
+	default:
+		return "", fmt.Errorf("multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
+	}
+}
+
+// lookupIdentity resolves a named identity, naming the ones that do exist when
+// it is not among them.
+func lookupIdentity(config *clientconfig.Config, name string) (*clientconfig.IdentityConfig, error) {
+	if config == nil {
+		return nil, fmt.Errorf("identity %q not found in configuration", name)
+	}
+
+	identity, err := config.GetIdentity(name)
+	if err != nil {
+		if available := config.GetIdentityNames(); len(available) > 0 {
+			return nil, fmt.Errorf("identity %q not found. Available identities: %v", name, available)
+		}
+		return nil, fmt.Errorf("identity %q not found in configuration", name)
+	}
+
+	return identity, nil
+}
+
 // fetchAvailableClusters queries the identity server for available clusters.
 // identityName may be "" for an anonymous in-memory identity (e.g. during login
 // before it has been named), in which case token refreshes are not persisted.

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -2,12 +2,8 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net"
-	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -17,32 +13,16 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/cloudapi"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
-// ClusterResponse represents a cluster returned from the API
-type ClusterResponse struct {
-	XID               string         `json:"xid"`
-	Name              string         `json:"name"`
-	Description       string         `json:"description,omitempty"`
-	Tags              map[string]any `json:"tags"`
-	APIAddresses      []string       `json:"api_addresses,omitempty"`
-	CACertFingerprint string         `json:"ca_cert_fingerprint,omitempty"`
-	OrganizationXID   string         `json:"organization_xid"`
-	OrganizationName  string         `json:"organization_name"`
-}
-
-// hasReachableAddress reports whether the cloud advertised at least one API
-// address for this cluster. A cluster with none can't be dialed by any client,
-// so it would otherwise be silently hidden from `miren cluster add`. The most
-// common cause is a firewalled inbound port: miren connects over QUIC (UDP
-// 8443), and when the cloud's netcheck can't reach that port it drops the
-// discovered public IP, leaving the cluster advertising nothing. See MIR-1316.
-func (c ClusterResponse) hasReachableAddress() bool {
-	return len(c.APIAddresses) > 0
-}
+// ClusterResponse is a cluster as Miren Cloud describes it. Aliased rather
+// than redeclared so the commands keep their familiar name while the type,
+// and the API that returns it, live in one place.
+type ClusterResponse = cloudapi.Cluster
 
 const (
 	// unreachableAddressNote is the short, inline note shown in listings next to
@@ -250,62 +230,34 @@ func lookupIdentity(config *clientconfig.Config, name string) (*clientconfig.Ide
 	return identity, nil
 }
 
-// fetchAvailableClusters queries the identity server for available clusters.
-// identityName may be "" for an anonymous in-memory identity (e.g. during login
+// cloudClient builds a client for the cloud that issued this identity.
+//
+// identityName may be "" for an anonymous in-memory identity (during login,
 // before it has been named), in which case token refreshes are not persisted.
-func fetchAvailableClusters(ctx *Context, config *clientconfig.Config, identityName string, identity *clientconfig.IdentityConfig) ([]ClusterResponse, error) {
-	if identity.Type != clientconfig.IdentityKeypair && identity.Type != clientconfig.IdentityToken {
-		return nil, fmt.Errorf("cluster listing is only supported for keypair and token identities")
+func cloudClient(config *clientconfig.Config, identityName string, identity *clientconfig.IdentityConfig) (*cloudapi.Client, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("no identity to authenticate with")
 	}
-
-	// Get the issuer URL
-	issuerURL := identity.Issuer
-	if issuerURL == "" {
+	if identity.Type != clientconfig.IdentityKeypair && identity.Type != clientconfig.IdentityToken {
+		return nil, fmt.Errorf("talking to cloud is only supported for keypair and token identities")
+	}
+	if identity.Issuer == "" {
 		return nil, fmt.Errorf("identity has no issuer configured")
 	}
 
-	// Get JWT token
-	token, err := config.TokenForIdentity(ctx, identityName, identity, issuerURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to authenticate: %w", err)
-	}
+	return cloudapi.New(identity.Issuer, func(ctx context.Context) (string, error) {
+		return config.TokenForIdentity(ctx, identityName, identity, identity.Issuer)
+	})
+}
 
-	// Make request to fetch clusters
-	clustersURL, err := url.JoinPath(issuerURL, "/api/v1/users/clusters")
+// fetchAvailableClusters asks cloud which clusters this identity can see.
+func fetchAvailableClusters(ctx *Context, config *clientconfig.Config, identityName string, identity *clientconfig.IdentityConfig) ([]ClusterResponse, error) {
+	client, err := cloudClient(config, identityName, identity)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", clustersURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch clusters: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	// Define response structure
-	var response struct {
-		Clusters []ClusterResponse `json:"clusters"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	return response.Clusters, nil
+	return client.ListClusters(ctx)
 }
 
 // clusterOnlineInCloud asks cloud whether it currently holds a link to a
@@ -326,51 +278,12 @@ func clusterOnlineInCloud(
 		return false, nil
 	}
 
-	issuerURL := identity.Issuer
-	if issuerURL == "" {
-		return false, fmt.Errorf("identity has no issuer configured")
-	}
-
-	token, err := config.TokenForIdentity(ctx, identityName, identity, issuerURL)
-	if err != nil {
-		return false, fmt.Errorf("failed to authenticate: %w", err)
-	}
-
-	onlineURL, err := url.JoinPath(issuerURL, "/api/v1/clusters/", clusterXID, "/online")
+	client, err := cloudClient(config, identityName, identity)
 	if err != nil {
 		return false, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", onlineURL, nil)
-	if err != nil {
-		return false, err
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
-	// Short, because this runs while somebody is waiting at a prompt and a slow
-	// answer is worth no more than no answer: either way we fall back to
-	// treating the cluster as unroutable.
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return false, fmt.Errorf("cloud returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var response struct {
-		Online bool `json:"online"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return false, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	return response.Online, nil
+	return client.ClusterOnline(ctx, clusterXID)
 }
 
 const (
@@ -481,7 +394,7 @@ func cloudRoutableClusters(
 	)
 
 	for _, cluster := range clusters {
-		if cluster.hasReachableAddress() || cluster.XID == "" {
+		if cluster.HasReachableAddress() || cluster.XID == "" {
 			continue
 		}
 
@@ -543,7 +456,7 @@ func buildClusterPickerItems(clusters []ClusterResponse, cloudRoutable map[strin
 		itemID := fmt.Sprintf("cluster_%d", i)
 
 		var address string
-		if cluster.hasReachableAddress() {
+		if cluster.HasReachableAddress() {
 			reachableCount++
 			// Sort addresses to put localhost/0.0.0.0 last, then format the
 			// primary one with a grayed port.
@@ -594,7 +507,7 @@ func selectClusterFromList(ctx *Context, clusters []ClusterResponse, cloudRoutab
 			if cluster.Description != "" {
 				ctx.Printf("   Description: %s\n", cluster.Description)
 			}
-			if cluster.hasReachableAddress() {
+			if cluster.HasReachableAddress() {
 				ctx.Printf("   API Addresses:\n")
 				for _, addr := range cluster.APIAddresses {
 					ctx.Printf("     - %s\n", addr)

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -208,7 +208,7 @@ func pickCloudIdentity(ctx *Context, config *clientconfig.Config, requested, sug
 	case 0:
 		return "", noIdentities
 	default:
-		return "", codedErrorf(codeMultipleIdentities, "multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
+		return "", codedErrorf(codeIdentityError, "multiple identities available, please specify one with --identity: %s", strings.Join(names, ", "))
 	}
 }
 
@@ -216,15 +216,15 @@ func pickCloudIdentity(ctx *Context, config *clientconfig.Config, requested, sug
 // it is not among them.
 func lookupIdentity(config *clientconfig.Config, name string) (*clientconfig.IdentityConfig, error) {
 	if config == nil {
-		return nil, codedErrorf(codeIdentityNotFound, "identity %q not found in configuration", name)
+		return nil, codedErrorf(codeIdentityError, "identity %q not found in configuration", name)
 	}
 
 	identity, err := config.GetIdentity(name)
 	if err != nil {
 		if available := config.GetIdentityNames(); len(available) > 0 {
-			return nil, codedErrorf(codeIdentityNotFound, "identity %q not found. Available identities: %v", name, available)
+			return nil, codedErrorf(codeIdentityError, "identity %q not found. Available identities: %v", name, available)
 		}
-		return nil, codedErrorf(codeIdentityNotFound, "identity %q not found in configuration", name)
+		return nil, codedErrorf(codeIdentityError, "identity %q not found in configuration", name)
 	}
 
 	return identity, nil

--- a/cli/commands/config_bind_helpers_test.go
+++ b/cli/commands/config_bind_helpers_test.go
@@ -40,7 +40,7 @@ func TestHasReachableAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.cluster.hasReachableAddress())
+			assert.Equal(t, tt.want, tt.cluster.HasReachableAddress())
 		})
 	}
 }

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -262,6 +262,20 @@ func (c *Context) Warn(format string, args ...any) {
 	fmt.Fprintf(c.Stdout, "W "+format+"\n", args...)
 }
 
+// ProgressToStderr sends running commentary — Info, Warn, Completed, Printf —
+// to stderr, and returns a function restoring it.
+//
+// A command printing a machine-readable document has to keep stdout to itself:
+// one "Using identity 'cloud'" line in front of a JSON array turns it into
+// something no parser will accept, and the caller only finds out at the parse
+// error. The context is redirected in place rather than copied, because it
+// carries a live log level that must not be copied.
+func (c *Context) ProgressToStderr() (restore func()) {
+	previous := c.Stdout
+	c.Stdout = c.Stderr
+	return func() { c.Stdout = previous }
+}
+
 // printConfigWarning renders a config error to stderr. Uses TerminalError
 // for rich output when available, otherwise falls back to a plain warning.
 //

--- a/cli/commands/login.go
+++ b/cli/commands/login.go
@@ -786,7 +786,7 @@ func autoConfigureCluster(ctx *Context, identityName, cloudURL string, identity 
 	// Only clusters with a reachable address can be auto-configured.
 	var validClusters []ClusterResponse
 	for _, cluster := range clusters {
-		if cluster.hasReachableAddress() {
+		if cluster.HasReachableAddress() {
 			validClusters = append(validClusters, cluster)
 		}
 	}

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -86,6 +86,7 @@
     },
     "items": [
       "command/cluster-add",
+      "command/cluster-available",
       "command/cluster-current",
       "command/cluster-export-address",
       "command/cluster-list",

--- a/docs/docs/command/cluster-add.md
+++ b/docs/docs/command/cluster-add.md
@@ -17,9 +17,11 @@ miren cluster add [flags]
 ## Flags
 
 - `--address, -a` — Address/hostname of the cluster (optional - will use from selected cluster)
-- `--cluster, -c` — Name of the cluster to create (optional - will list available)
+- `--as` — Local name to store the cluster under, when it should differ from its name in Miren Cloud
+- `--cluster, -c` — Name of the cluster to add, looked up in Miren Cloud unless --address is given (optional - will list available)
 - `--force, -f` — Overwrite existing cluster configuration
 - `--identity, -i` — Name of the identity to use (optional - will use the only one if single)
+- `--organization` — Organization the named cluster belongs to, for when the same name exists in more than one
 - `--via-cloud` — Reach the cluster through Miren Cloud instead of dialing it, for a cluster this machine has no route to
 
 ## Global Options
@@ -34,6 +36,18 @@ miren cluster add [flags]
 
 ```bash
 miren cluster add
+```
+
+**Add a cluster by name, without the picker:**
+
+```bash
+miren cluster add --cluster my-cluster
+```
+
+**Add a cluster by name under a different local name:**
+
+```bash
+miren cluster add --cluster my-cluster --as staging
 ```
 
 **Add a cluster with a specific address:**

--- a/docs/docs/command/cluster-add.md
+++ b/docs/docs/command/cluster-add.md
@@ -20,7 +20,9 @@ miren cluster add [flags]
 - `--as` — Local name to store the cluster under, when it should differ from its name in Miren Cloud
 - `--cluster, -c` — Name of the cluster to add, looked up in Miren Cloud unless --address is given (optional - will list available)
 - `--force, -f` — Overwrite existing cluster configuration
+- `--format` — Output format (text, json) (default: `text`)
 - `--identity, -i` — Name of the identity to use (optional - will use the only one if single)
+- `--json` — Shorthand for --format json
 - `--organization` — Organization the named cluster belongs to, for when the same name exists in more than one
 - `--via-cloud` — Reach the cluster through Miren Cloud instead of dialing it, for a cluster this machine has no route to
 
@@ -48,6 +50,12 @@ miren cluster add --cluster my-cluster
 
 ```bash
 miren cluster add --cluster my-cluster --as staging
+```
+
+**Add a cluster, reporting the result (and any failure) as JSON:**
+
+```bash
+miren cluster add --cluster my-cluster --format json
 ```
 
 **Add a cluster with a specific address:**

--- a/docs/docs/command/cluster-add.md
+++ b/docs/docs/command/cluster-add.md
@@ -11,13 +11,15 @@ Add a new cluster configuration
 With `--format json`, the command prints one result document and nothing else on stdout; progress and warnings go to stderr. A failure is reported both as a document and as a non-zero exit status.
 
 ```json
-{"ok": true, "cluster": {"name": "prod", "cloud_name": "prod", "xid": "cluster-...",
-                          "organization": "Acme", "address": "10.0.0.1:8443",
-                          "via_cloud": false, "identity": "cloud", "active": true,
+{"ok": true, "cluster": {"name": "prod", "xid": "cluster-...", "organization": "Acme",
+                          "address": "10.0.0.1:8443", "via_cloud": false,
+                          "identity": "cloud", "active": true,
                           "config_file": "~/.config/miren/clientconfig.d/prod.yaml"}}
 
 {"ok": false, "error": {"code": "cluster_not_found", "message": "no cluster named ..."}}
 ```
+
+`name` is the local name, which is what every other command takes. `cloud_name` appears alongside it only when `--as` stored the cluster under a different name than it has in Miren Cloud, and `address` is absent for a cluster reached through cloud.
 
 Messages are written for people and will be reworded. The code is the stable part:
 

--- a/docs/docs/command/cluster-add.md
+++ b/docs/docs/command/cluster-add.md
@@ -8,6 +8,34 @@ description: "Add a new cluster configuration"
 
 Add a new cluster configuration
 
+With `--format json`, the command prints one result document and nothing else on stdout; progress and warnings go to stderr. A failure is reported both as a document and as a non-zero exit status.
+
+```json
+{"ok": true, "cluster": {"name": "prod", "cloud_name": "prod", "xid": "cluster-...",
+                          "organization": "Acme", "address": "10.0.0.1:8443",
+                          "via_cloud": false, "identity": "cloud", "active": true,
+                          "config_file": "~/.config/miren/clientconfig.d/prod.yaml"}}
+
+{"ok": false, "error": {"code": "cluster_not_found", "message": "no cluster named ..."}}
+```
+
+Messages are written for people and will be reworded. The code is the stable part:
+
+| Code | Meaning |
+|------|---------|
+| `invalid_flags` | The flags given can't mean anything together. |
+| `interactive_required` | Answering needs a person. Name a cluster with `--cluster`, or use `--force` to overwrite. |
+| `no_identities` | Nobody is logged in. Run `miren login`. |
+| `identity_error` | The identity named wasn't found, or one has to be named with `--identity`. |
+| `cloud_request_failed` | Miren Cloud didn't answer. Worth retrying. |
+| `cluster_not_found` | No cluster by that name, or none on the account. |
+| `ambiguous_cluster` | The name exists in more than one organization. Add `--organization`. |
+| `unknown_organization` | No organization by that name. |
+| `cluster_unreachable` | The cluster exists and couldn't be reached. Worth retrying. |
+| `cluster_exists` | That local name is taken. Use `--force`, or `--as` to pick another. |
+| `config_error` | The local config couldn't be read or written. |
+| `unknown` | A failure with no code. Treat it as uninterpretable. |
+
 ## Usage
 
 ```bash

--- a/docs/docs/command/cluster-available.md
+++ b/docs/docs/command/cluster-available.md
@@ -1,0 +1,53 @@
+---
+title: "miren cluster available"
+sidebar_label: "cluster available"
+description: "List the clusters Miren Cloud has for your account"
+---
+
+# miren cluster available
+
+List the clusters Miren Cloud has for your account
+
+## Usage
+
+```bash
+miren cluster available [flags]
+```
+
+## Flags
+
+- `--check` — Ask cloud whether it can reach the clusters that advertise no address
+- `--format` — Output format (text, json) (default: `text`)
+- `--identity, -i` — Name of the identity to use (optional - will use the only one if single)
+- `--json` — Shorthand for --format json
+- `--organization` — Only list clusters in this organization
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**List clusters you could add:**
+
+```bash
+miren cluster available
+```
+
+**List as JSON:**
+
+```bash
+miren cluster available --format json
+```
+
+**Ask cloud whether it can reach the clusters with no address:**
+
+```bash
+miren cluster available --check
+```
+
+## See also
+
+- [`miren cluster`](/command/cluster)

--- a/docs/docs/command/cluster.md
+++ b/docs/docs/command/cluster.md
@@ -38,6 +38,7 @@ miren cluster
 ## Subcommands
 
 - [`miren cluster add`](/command/cluster-add) — Add a new cluster configuration
+- [`miren cluster available`](/command/cluster-available) — List the clusters Miren Cloud has for your account
 - [`miren cluster current`](/command/cluster-current) — Show the pinned cluster for this app
 - [`miren cluster export-address`](/command/cluster-export-address) — Export cluster address with TLS fingerprint for MIREN_CLUSTER
 - [`miren cluster list`](/command/cluster-list) — List all configured clusters

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -81,6 +81,7 @@ Complete reference for all `miren` CLI commands.
 |---------|-------------|
 | [`miren cluster`](/command/cluster) | List configured clusters |
 | [`miren cluster add`](/command/cluster-add) | Add a new cluster configuration |
+| [`miren cluster available`](/command/cluster-available) | List the clusters Miren Cloud has for your account |
 | [`miren cluster current`](/command/cluster-current) | Show the pinned cluster for this app |
 | [`miren cluster export-address`](/command/cluster-export-address) | Export cluster address with TLS fingerprint for MIREN_CLUSTER |
 | [`miren cluster list`](/command/cluster-list) | List all configured clusters |

--- a/pkg/cloudapi/cloudapi.go
+++ b/pkg/cloudapi/cloudapi.go
@@ -1,0 +1,149 @@
+// Package cloudapi talks to Miren Cloud's HTTP API on behalf of a logged-in
+// user. It covers the endpoints the CLI needs to answer "what clusters do I
+// have, and can cloud reach this one", and it owns the base URL, the bearer
+// token, and the request and response decoding that go with them.
+//
+// Deciding which identity to use, what to render, and how to reach a cluster
+// stays with the caller. This package only makes the calls.
+package cloudapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// listTimeout bounds the cluster listing, which a person is usually
+	// waiting on.
+	listTimeout = 30 * time.Second
+
+	// onlineTimeout is shorter because the answer is worth no more than no
+	// answer: a caller that cannot find out treats the cluster as unreachable
+	// either way, so waiting longer buys nothing.
+	onlineTimeout = 10 * time.Second
+)
+
+// Cluster is a cluster as Miren Cloud describes it.
+type Cluster struct {
+	XID               string         `json:"xid"`
+	Name              string         `json:"name"`
+	Description       string         `json:"description,omitempty"`
+	Tags              map[string]any `json:"tags"`
+	APIAddresses      []string       `json:"api_addresses,omitempty"`
+	CACertFingerprint string         `json:"ca_cert_fingerprint,omitempty"`
+	OrganizationXID   string         `json:"organization_xid"`
+	OrganizationName  string         `json:"organization_name"`
+}
+
+// HasReachableAddress reports whether cloud advertised at least one API address
+// for this cluster. A cluster with none can't be dialed by any client, so it
+// would otherwise be silently hidden from `miren cluster add`. The most common
+// cause is a firewalled inbound port: miren connects over QUIC (UDP 8443), and
+// when cloud's netcheck can't reach that port it drops the discovered public
+// IP, leaving the cluster advertising nothing. See MIR-1316.
+func (c Cluster) HasReachableAddress() bool {
+	return len(c.APIAddresses) > 0
+}
+
+// TokenFunc returns a bearer token for the request about to be made. It is a
+// function rather than a string because tokens expire, and the caller holds the
+// machinery for refreshing and persisting them.
+type TokenFunc func(ctx context.Context) (string, error)
+
+// Client calls one Miren Cloud instance as one identity.
+type Client struct {
+	baseURL string
+	token   TokenFunc
+}
+
+// New returns a client for the cloud at baseURL, authenticating with token.
+func New(baseURL string, token TokenFunc) (*Client, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("no cloud URL configured")
+	}
+	if token == nil {
+		return nil, fmt.Errorf("no way to authenticate with %s", baseURL)
+	}
+
+	return &Client{baseURL: baseURL, token: token}, nil
+}
+
+// BaseURL is the cloud this client talks to. Callers use it to say which cloud
+// they are talking about, and to notice an unencrypted one.
+func (c *Client) BaseURL() string { return c.baseURL }
+
+// ListClusters returns every cluster the account can see.
+func (c *Client) ListClusters(ctx context.Context) ([]Cluster, error) {
+	var response struct {
+		Clusters []Cluster `json:"clusters"`
+	}
+
+	if err := c.get(ctx, listTimeout, &response, "/api/v1/users/clusters"); err != nil {
+		return nil, err
+	}
+
+	return response.Clusters, nil
+}
+
+// ClusterOnline reports whether cloud currently holds a link to the cluster,
+// which is the precondition for relaying calls to it.
+//
+// A cluster with no id cannot be asked about, and reports as not online rather
+// than as an error: the caller reaches the same decision either way.
+func (c *Client) ClusterOnline(ctx context.Context, clusterXID string) (bool, error) {
+	if clusterXID == "" {
+		return false, nil
+	}
+
+	var response struct {
+		Online bool `json:"online"`
+	}
+
+	if err := c.get(ctx, onlineTimeout, &response, "/api/v1/clusters/", clusterXID, "/online"); err != nil {
+		return false, err
+	}
+
+	return response.Online, nil
+}
+
+func (c *Client) get(ctx context.Context, timeout time.Duration, out any, pathParts ...string) error {
+	endpoint, err := url.JoinPath(c.baseURL, pathParts...)
+	if err != nil {
+		return err
+	}
+
+	token, err := c.token(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to authenticate: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("cloud returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cloudapi/cloudapi.go
+++ b/pkg/cloudapi/cloudapi.go
@@ -137,7 +137,10 @@ func (c *Client) get(ctx context.Context, timeout time.Duration, out any, pathPa
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		// Bounded: the body here only ever goes into an error message, and a
+		// proxy having a bad day can answer with something enormous. Reading
+		// all of it would turn a failed request into a failed process.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 		return fmt.Errorf("cloud returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 

--- a/pkg/cloudapi/cloudapi_test.go
+++ b/pkg/cloudapi/cloudapi_test.go
@@ -1,0 +1,134 @@
+package cloudapi_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/cloudapi"
+	"miren.dev/runtime/pkg/cloudapi/cloudapitest"
+)
+
+func staticToken(token string) cloudapi.TokenFunc {
+	return func(context.Context) (string, error) { return token, nil }
+}
+
+func TestListClusters(t *testing.T) {
+	r := require.New(t)
+
+	srv := cloudapitest.NewServer([]cloudapi.Cluster{
+		{Name: "prod", XID: "cluster-prod", OrganizationName: "Acme", APIAddresses: []string{"10.0.0.1:8443"}},
+		{Name: "behind-nat", XID: "cluster-nat", OrganizationName: "Acme"},
+	}, nil, http.StatusOK)
+	defer srv.Close()
+
+	client, err := cloudapi.New(srv.URL, staticToken("t"))
+	r.NoError(err)
+
+	clusters, err := client.ListClusters(context.Background())
+	r.NoError(err)
+	r.Len(clusters, 2)
+	r.Equal("cluster-prod", clusters[0].XID)
+	r.True(clusters[0].HasReachableAddress())
+	r.False(clusters[1].HasReachableAddress(), "a cluster advertising no address cannot be dialed")
+}
+
+func TestClusterOnline(t *testing.T) {
+	r := require.New(t)
+
+	srv := cloudapitest.NewServer(nil, map[string]bool{"cluster-up": true}, http.StatusOK)
+	defer srv.Close()
+
+	client, err := cloudapi.New(srv.URL, staticToken("t"))
+	r.NoError(err)
+
+	online, err := client.ClusterOnline(context.Background(), "cluster-up")
+	r.NoError(err)
+	r.True(online)
+
+	online, err = client.ClusterOnline(context.Background(), "cluster-down")
+	r.NoError(err)
+	r.False(online)
+
+	r.Equal([]string{"cluster-up", "cluster-down"}, srv.Asked())
+}
+
+// A cluster with no id can't be asked about. Reporting it as offline rather
+// than as an error keeps callers from having to special-case it, since both
+// answers lead to the same decision.
+func TestClusterOnlineWithoutAnID(t *testing.T) {
+	srv := cloudapitest.NewServer(nil, nil, http.StatusOK)
+	defer srv.Close()
+
+	client, err := cloudapi.New(srv.URL, staticToken("t"))
+	require.NoError(t, err)
+
+	online, err := client.ClusterOnline(context.Background(), "")
+	require.NoError(t, err)
+	require.False(t, online)
+	require.Empty(t, srv.Asked(), "no request is made for a cluster with no id")
+}
+
+// A cloud that refuses the question has not answered it, and the caller has to
+// be able to tell those apart.
+func TestRefusalIsAnError(t *testing.T) {
+	srv := cloudapitest.NewServer(nil, nil, http.StatusForbidden)
+	defer srv.Close()
+
+	client, err := cloudapi.New(srv.URL, staticToken("t"))
+	require.NoError(t, err)
+
+	_, err = client.ClusterOnline(context.Background(), "cluster-1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+}
+
+func TestSendsTheBearerToken(t *testing.T) {
+	var seen string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"clusters":[]}`))
+	}))
+	defer srv.Close()
+
+	client, err := cloudapi.New(srv.URL, staticToken("secret-token"))
+	require.NoError(t, err)
+
+	_, err = client.ListClusters(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "Bearer secret-token", seen)
+}
+
+// The token is fetched per request rather than held, so a refreshed one is
+// picked up without rebuilding the client.
+func TestTokenIsFetchedPerRequest(t *testing.T) {
+	calls := 0
+
+	srv := cloudapitest.NewServer(nil, nil, http.StatusOK)
+	defer srv.Close()
+
+	client, err := cloudapi.New(srv.URL, func(context.Context) (string, error) {
+		calls++
+		return "t", nil
+	})
+	require.NoError(t, err)
+
+	_, err = client.ListClusters(context.Background())
+	require.NoError(t, err)
+	_, err = client.ListClusters(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, 2, calls)
+}
+
+func TestNewRejectsAnUnusableClient(t *testing.T) {
+	_, err := cloudapi.New("", staticToken("t"))
+	require.Error(t, err, "a client with no cloud to talk to is not usable")
+
+	_, err = cloudapi.New("https://cloud.example", nil)
+	require.Error(t, err, "a client with no way to authenticate is not usable")
+}

--- a/pkg/cloudapi/cloudapitest/server.go
+++ b/pkg/cloudapi/cloudapitest/server.go
@@ -1,0 +1,71 @@
+// Package cloudapitest provides a stand-in for Miren Cloud's HTTP API, so
+// tests that need cloud to answer something can have it answer without a cloud.
+package cloudapitest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"miren.dev/runtime/pkg/cloudapi"
+)
+
+// Server is a fake Miren Cloud serving the endpoints cloudapi.Client calls. It
+// records which clusters were asked about, which is how a test checks that a
+// caller asked about the clusters it should have and left the rest alone.
+type Server struct {
+	*httptest.Server
+
+	mu    sync.Mutex
+	asked []string
+}
+
+// NewServer returns a fake cloud holding the given clusters, reporting online
+// for the cluster ids set to true in online. Close it when the test is done.
+//
+// Pass a non-OK status to make every request fail, which is how a test tells
+// "cloud said no" apart from "cloud would not answer".
+func NewServer(clusters []cloudapi.Cluster, online map[string]bool, status int) *Server {
+	fake := &Server{}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/users/clusters", func(w http.ResponseWriter, r *http.Request) {
+		if status != 0 && status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		writeJSON(w, map[string]any{"clusters": clusters})
+	})
+
+	mux.HandleFunc("/api/v1/clusters/{xid}/online", func(w http.ResponseWriter, r *http.Request) {
+		xid := r.PathValue("xid")
+
+		fake.mu.Lock()
+		fake.asked = append(fake.asked, xid)
+		fake.mu.Unlock()
+
+		if status != 0 && status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		writeJSON(w, map[string]any{"cluster_xid": xid, "online": online[xid]})
+	})
+
+	fake.Server = httptest.NewServer(mux)
+
+	return fake
+}
+
+// Asked returns the cluster ids whose presence was checked, in request order.
+func (s *Server) Asked() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.asked...)
+}
+
+func writeJSON(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}


### PR DESCRIPTION
You couldn't script `miren cluster add`. Giving it a cluster name without an address was refused ("both --cluster and --address must be specified, or neither"), so the only ways in were the interactive picker or passing `--address` yourself. Passing the address skips the useful part: trying each address the cluster advertises, asking Miren Cloud to pass commands through when none of them answer, and saving the cluster's certificate to check later connections against. MIR-1592 asked for a way to name a cluster and still get all that.

Now `--cluster prod` on its own runs the same logic the picker does. `--as` sets the local name the picker used to prompt for, and `--organization` separates two clusters that share a name.

A cluster that advertises no address and that Miren Cloud can't reach is greyed out in the picker. Naming it has no row to grey out, and the old code would have fallen back to trying `127.0.0.1:8443`. On a dev box that could save your local cluster's certificate under a remote cluster's name, so it's refused now.

`miren cluster available` is where the name comes from: the clusters Miren Cloud holds for your account, with `--format json`. Checking whether cloud can reach a cluster with no address costs a request each, so that sits behind `--check`.

`cluster add --format json` then reports the outcome. Success says what was written and how the cluster will be reached. Failure gives a code you can branch on and still exits non-zero. A name that doesn't exist and a cluster that's temporarily unreachable get different codes, because they need different responses. JSON mode won't open the picker or ask about overwriting either, even at a terminal. `ctx.Info` writes to stdout, so JSON commands now send progress to stderr, or the document doesn't parse.

Closes MIR-1592
