### PR TITLE
Bound WebTransport reconnects to the caller context

### DIFF
--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -136,7 +136,7 @@ func (c *NetworkClient) setupTransport() {
 	c.qc = DefaultQUICConfig
 	c.qc.HandshakeIdleTimeout = handshakeTimeoutFor(c.remote)
 	c.htr.QUICConfig = &c.qc
-	c.htr.Dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+	dial := func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config, early bool) (*quic.Conn, error) {
 		uaddr, err := resolveUDPAddr(ctx, "udp", addr)
 		if err != nil {
 			return nil, err
@@ -144,17 +144,33 @@ func (c *NetworkClient) setupTransport() {
 
 		setTLSConfigServerName(tlsCfg, uaddr, addr)
 
-		conn, err := c.transport.DialEarly(ctx, uaddr, tlsCfg, cfg)
+		var conn *quic.Conn
+		if early {
+			conn, err = c.transport.DialEarly(ctx, uaddr, tlsCfg, cfg)
+		} else {
+			conn, err = c.transport.Dial(ctx, uaddr, tlsCfg, cfg)
+		}
 		if err != nil {
 			return nil, err
 		}
 		c.trackConn(conn)
 		return conn, nil
 	}
+	c.htr.Dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+		return dial(ctx, addr, tlsCfg, cfg, true)
+	}
 
 	c.ws.TLSClientConfig = c.tlsCfg
 	c.ws.QUICConfig = &c.qc
-	c.ws.DialAddr = c.htr.Dial
+	// webtransport.Dialer waits for HTTP/3 settings on its own lifetime
+	// context after DialAddr returns. An early connection can therefore leave
+	// Dial blocked forever when the handshake subsequently fails, even after
+	// the request context is canceled. Complete the handshake here so failed
+	// reconnects remain bounded by the caller's context. Ordinary HTTP/3 RPCs
+	// keep their 0-RTT path above.
+	c.ws.DialAddr = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+		return dial(ctx, addr, tlsCfg, cfg, false)
+	}
 }
 
 func setTLSConfigServerName(tlsConf *tls.Config, addr net.Addr, host string) {

--- a/pkg/rpc/client_internal_test.go
+++ b/pkg/rpc/client_internal_test.go
@@ -1,0 +1,58 @@
+package rpc
+
+import (
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebTransportDialHonorsContextWhenServerDoesNotAnswer(t *testing.T) {
+	r := require.New(t)
+
+	// Keep a UDP socket open without reading from it. This behaves like a
+	// coordinator whose address is routable but whose QUIC server is down: the
+	// client gets no ICMP rejection and no handshake response.
+	blackhole, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	r.NoError(err)
+	t.Cleanup(func() { _ = blackhole.Close() })
+
+	packetConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	r.NoError(err)
+
+	state := &State{StateCommon: &StateCommon{log: slog.Default()}}
+	client := &NetworkClient{
+		State:     state,
+		transport: &quic.Transport{Conn: packetConn},
+		tlsCfg:    &tls.Config{InsecureSkipVerify: true}, // test-only endpoint
+		remote:    blackhole.LocalAddr().String(),
+	}
+	client.setupTransport()
+	t.Cleanup(func() {
+		_ = client.ws.Close()
+		_ = client.htr.Close()
+		_ = client.transport.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := client.ws.Dial(ctx, "https://"+client.remote+"/", nil)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		r.Error(err)
+		r.ErrorIs(err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("WebTransport dial remained blocked after its context expired")
+	}
+}


### PR DESCRIPTION
Streaming RPCs could stop reconnecting permanently if the remote server disappeared while QUIC was handshaking. WebTransport was handed an early connection, then webtransport-go waited for HTTP/3 settings on its own lifetime context, so the caller’s cancellation never reached the wait and watch retry loops never got an error.

Complete the QUIC handshake before handing WebTransport the connection. Regular HTTP/3 calls keep their 0-RTT path. A blackholed UDP regression covers the failed-handshake case and proves the dial returns when the caller context expires.

Closes MIR-1717