### PR TITLE
Suppress routine httpingress client disconnect panic logs

### DIFF
--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -479,15 +479,8 @@ func (h *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 func (h *Server) handleRequest(w http.ResponseWriter, req *http.Request) {
 	defer func() {
-		if r := recover(); r != nil {
-			h.Log.Error("panic in request handler",
-				"error", r,
-				"stack", string(debug.Stack()),
-				"method", req.Method,
-				"path", req.URL.Path,
-				"host", req.Host,
-			)
-			panic(r)
+		if recovered := recover(); recovered != nil {
+			h.handleRequestPanic(req, recovered)
 		}
 	}()
 
@@ -564,6 +557,28 @@ func (h *Server) handleRequest(w http.ResponseWriter, req *http.Request) {
 			h.Log.Error("Failed to record HTTP request", "error", err, "app", appName)
 		}
 	}
+}
+
+func (h *Server) handleRequestPanic(req *http.Request, recovered any) {
+	if recovered == nil {
+		return
+	}
+
+	// net/http uses this sentinel to abort a response that can no longer be
+	// completed and deliberately suppresses its own panic log. Do the same here
+	// to avoid scary panic output for a routine client disconnect.
+	recoveredErr, isError := recovered.(error)
+	if !isError || recoveredErr != http.ErrAbortHandler {
+		h.Log.Error("panic in request handler",
+			"error", recovered,
+			"stack", string(debug.Stack()),
+			"method", req.Method,
+			"path", req.URL.Path,
+			"host", req.Host,
+		)
+	}
+
+	panic(recovered)
 }
 
 func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, appName *string) {

--- a/servers/httpingress/httpingress_test.go
+++ b/servers/httpingress/httpingress_test.go
@@ -2,6 +2,7 @@ package httpingress
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"syscall"
 	"testing"
 	"time"
@@ -27,6 +29,70 @@ import (
 	"miren.dev/runtime/pkg/httputil"
 	"miren.dev/runtime/pkg/rpc"
 )
+
+func TestHandleRequestPanic(t *testing.T) {
+	tests := []struct {
+		name       string
+		panicValue any
+		wantLog    bool
+	}{
+		{
+			name:       "abort handler sentinel",
+			panicValue: http.ErrAbortHandler,
+			wantLog:    false,
+		},
+		{
+			name:       "different error with the same message",
+			panicValue: errors.New(http.ErrAbortHandler.Error()),
+			wantLog:    true,
+		},
+		{
+			name:       "uncomparable panic value",
+			panicValue: map[string]string{"unexpected": "panic"},
+			wantLog:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			h := &Server{Log: slog.New(slog.NewJSONHandler(&logs, nil))}
+			req := httptest.NewRequest(http.MethodGet, "https://example.com/test", nil)
+
+			var recovered any
+			func() {
+				defer func() {
+					recovered = recover()
+				}()
+				h.handleRequestPanic(req, tt.panicValue)
+			}()
+
+			if !reflect.DeepEqual(recovered, tt.panicValue) {
+				t.Fatalf("recovered panic = %v, want %v", recovered, tt.panicValue)
+			}
+
+			if !tt.wantLog {
+				if logs.Len() != 0 {
+					t.Fatalf("unexpected panic log: %s", logs.String())
+				}
+				return
+			}
+
+			for _, want := range [][]byte{
+				[]byte(`"level":"ERROR"`),
+				[]byte(`"msg":"panic in request handler"`),
+				[]byte(`"stack":`),
+				[]byte(`"method":"GET"`),
+				[]byte(`"path":"/test"`),
+				[]byte(`"host":"example.com"`),
+			} {
+				if !bytes.Contains(logs.Bytes(), want) {
+					t.Errorf("panic log missing %s: %s", want, logs.String())
+				}
+			}
+		})
+	}
+}
 
 func TestIngressConfigDefault(t *testing.T) {
 	// Test that zero timeout defaults to 60s


### PR DESCRIPTION
`ReverseProxy` uses `http.ErrAbortHandler` as normal control flow when a response stream can no longer continue. `net/http` suppresses its panic stack, but httpingress logged every recovered panic before passing it back, so routine client disconnects showed up as Error-level stack dumps.

This recognizes only the exact sentinel, skips our duplicate panic log, and re-panics so `net/http` still aborts the connection normally. Other panics keep their full diagnostics. All 145 httpingress tests pass.

Closes MIR-1705