### PR TITLE
Harden entity sync recovery and migration safety

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -463,10 +463,10 @@ func (c *Coordinator) NewDeploymentAttemptController() (*deploymentattemptsctrl.
 	return deploymentattemptsctrl.New(c.Log, c.store, c.eac), nil
 }
 
-// BackfillCloudExportMarker makes existing apps and app versions visible
-// through the shared export index. The deployment migration owns its kind's
-// marker so a downgraded writer cannot race generic backfill and expose an old
-// unsafe shape.
+// BackfillCloudExportMarker is the contract-wide safety net for exported kinds
+// that no specialized migration covers. The deployment-attempt controller has
+// already marked the apps, app versions, and deployments in its clean sweep;
+// excluding deployments here preserves its ownership of validating old shapes.
 func (c *Coordinator) BackfillCloudExportMarker(ctx context.Context) error {
 	if c.store == nil {
 		return errors.New("coordinator entity store is not ready")

--- a/controllers/deploymentattempts/controller.go
+++ b/controllers/deploymentattempts/controller.go
@@ -15,6 +15,7 @@ import (
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
+	entityexport "miren.dev/runtime/pkg/entity/export"
 )
 
 const (
@@ -116,10 +117,17 @@ func (c *Controller) Step(ctx context.Context) error {
 		return err
 	}
 	var migrateErrs []error
+	marker := core_v1alpha.CloudExportContract.MarkerID()
 	for _, ent := range entities {
+		if ent == nil {
+			continue
+		}
 		err := migrate(ctx, ent)
 		if err == nil && c.phase != phaseReconcile {
-			err = c.ensureCloudExportMarker(ctx, ent.Id())
+			attr, marked := ent.Get(marker)
+			if !marked || attr.Value.Kind() != entity.KindBool || !attr.Value.Bool() {
+				_, err = entityexport.EnsureMarker(ctx, c.Store, ent.Id(), marker)
+			}
 		}
 		if err != nil {
 			wrapped := fmt.Errorf("migrating %s in phase %s: %w", ent.Id(), c.phase, err)
@@ -232,22 +240,6 @@ func (c *Controller) migrateDeployment(ctx context.Context, ent *entity.Entity) 
 		attrs = append(attrs, entity.Time(core_v1alpha.DeploymentStartedAtId, started))
 	}
 	_, err := c.Store.PatchEntity(ctx, entity.New(attrs), entity.WithFromRevision(ent.GetRevision()))
-	return err
-}
-
-func (c *Controller) ensureCloudExportMarker(ctx context.Context, id entity.Id) error {
-	current, err := c.Store.GetEntity(ctx, id)
-	if err != nil {
-		return err
-	}
-	marker := core_v1alpha.CloudExportContract.MarkerID()
-	if attr, ok := current.Get(marker); ok && attr.Value.Kind() == entity.KindBool && attr.Value.Bool() {
-		return nil
-	}
-	_, err = c.Store.PatchEntity(ctx, entity.New(
-		entity.Ref(entity.DBId, id),
-		entity.Bool(marker, true),
-	), entity.WithFromRevision(current.GetRevision()))
 	return err
 }
 

--- a/controllers/deploymentattempts/controller_test.go
+++ b/controllers/deploymentattempts/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/deploylifecycle"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
@@ -22,6 +23,39 @@ import (
 type migrationFailStore struct {
 	entity.Store
 	fail entity.Id
+}
+
+type missingEntityStore struct {
+	entity.Store
+}
+
+func (s *missingEntityStore) GetEntities(context.Context, []entity.Id) ([]*entity.Entity, error) {
+	return []*entity.Entity{nil}, nil
+}
+
+type markerConflictStore struct {
+	entity.Store
+	patchCalls int
+}
+
+type countingGetStore struct {
+	entity.Store
+	getEntityCalls int
+}
+
+func (s *countingGetStore) GetEntity(ctx context.Context, id entity.Id) (*entity.Entity, error) {
+	s.getEntityCalls++
+	return s.Store.GetEntity(ctx, id)
+}
+
+func (s *markerConflictStore) PatchEntity(ctx context.Context, ent *entity.Entity, opts ...entity.EntityOption) (*entity.Entity, error) {
+	if _, ok := ent.Get(core_v1alpha.CloudExportContract.MarkerID()); ok {
+		s.patchCalls++
+		if s.patchCalls == 1 {
+			return nil, cond.Conflict("entity", ent.Id())
+		}
+	}
+	return s.Store.PatchEntity(ctx, ent, opts...)
 }
 
 func (s *migrationFailStore) ReplaceEntity(ctx context.Context, ent *entity.Entity, opts ...entity.EntityOption) (*entity.Entity, error) {
@@ -256,6 +290,55 @@ func TestCleanSweepMarksLegacyEntitiesForExport(t *testing.T) {
 	attr, ok := migrated.Get(marker)
 	require.True(t, ok)
 	assert.True(t, attr.Value.Bool())
+}
+
+func TestMigrationSkipsEntityRemovedAfterIndexRead(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	dep := &core_v1alpha.Deployment{ID: "deployment/disappeared", Status: "failed"}
+	_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, dep.ID), dep.Encode()))
+	require.NoError(t, err)
+
+	controller := New(slog.New(slog.NewTextHandler(io.Discard, nil)), &missingEntityStore{Store: inmem.Store}, inmem.EAC)
+	require.NoError(t, controller.Step(ctx))
+	require.Equal(t, phaseVersions, controller.phase)
+}
+
+func TestMigrationMarkerWriteRetriesRevisionConflict(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	app := &core_v1alpha.App{ID: "app/web"}
+	source := entity.New(entity.Ref(entity.DBId, app.ID), app.Encode())
+	source.Remove(core_v1alpha.CloudExportContract.MarkerID())
+	_, err := inmem.Store.CreateEntity(ctx, source)
+	require.NoError(t, err)
+
+	store := &markerConflictStore{Store: inmem.Store}
+	controller := New(slog.New(slog.NewTextHandler(io.Discard, nil)), store, inmem.EAC)
+	controller.phase = phaseApps
+	require.NoError(t, controller.Step(ctx))
+	require.Equal(t, 2, store.patchCalls)
+
+	stored, err := inmem.Store.GetEntity(ctx, app.ID)
+	require.NoError(t, err)
+	require.True(t, entity.MustGet(stored, core_v1alpha.CloudExportContract.MarkerID()).Value.Bool())
+}
+
+func TestMigrationSkipsMarkerReadForMarkedEntity(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	app := &core_v1alpha.App{ID: "app/already-marked"}
+	_, err := inmem.Store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, app.ID), app.Encode()))
+	require.NoError(t, err)
+
+	store := &countingGetStore{Store: inmem.Store}
+	controller := New(slog.New(slog.NewTextHandler(io.Discard, nil)), store, inmem.EAC)
+	controller.phase = phaseApps
+	require.NoError(t, controller.Step(ctx))
+	require.Zero(t, store.getEntityCalls)
 }
 
 func TestUnknownLegacyDeploymentKeepsExportGateClosed(t *testing.T) {

--- a/pkg/entity/export/backfill.go
+++ b/pkg/entity/export/backfill.go
@@ -79,7 +79,7 @@ func BackfillMarker(
 					stats.AlreadyMarked++
 					continue
 				}
-				marked, err := ensureMarker(ctx, store, source.Id(), contract.MarkerID())
+				marked, err := EnsureMarker(ctx, store, source.Id(), contract.MarkerID())
 				if err != nil {
 					return stats, fmt.Errorf("mark %s for cloud export: %w", source.Id(), err)
 				}
@@ -102,7 +102,9 @@ func BackfillMarker(
 	return stats, nil
 }
 
-func ensureMarker(ctx context.Context, store entity.Store, id, marker entity.Id) (bool, error) {
+// EnsureMarker adds marker to id, retrying if a concurrent writer changes the
+// entity between the read and patch. It reports whether this call added it.
+func EnsureMarker(ctx context.Context, store entity.Store, id, marker entity.Id) (bool, error) {
 	for {
 		if err := ctx.Err(); err != nil {
 			return false, err

--- a/pkg/entitysync/exporter.go
+++ b/pkg/entitysync/exporter.go
@@ -25,12 +25,15 @@ const snapshotBatchSize = 100
 const maxLiveBatchesBetweenSnapshotBatches = 8
 const sessionRetryDelay = time.Second
 const defaultMinimumResnapshotInterval = time.Hour
+const defaultAckTimeout = 30 * time.Second
+const defaultPreparationLogInterval = time.Minute
+const sourceEpochTimeout = 5 * time.Second
 
 var errCompacted = errors.New("entity sync cursor compacted")
 var errResnapshotDue = errors.New("entity sync anti-entropy snapshot due")
 
 type Link interface {
-	OfferCapability(uplink.CapabilityOffer)
+	OfferCapabilityFunc(string, []uint, uplink.CapabilityOfferFunc)
 	OnSession(func(context.Context, uplink.Session))
 	Handle(string, uplink.MessageHandler)
 	SendMessageBlocking(context.Context, string, any) error
@@ -40,17 +43,19 @@ type Exporter struct {
 	log                       *slog.Logger
 	store                     entity.Store
 	contract                  *entityexport.Contract
-	sourceEpoch               string
 	startGate                 <-chan struct{}
 	minimumResnapshotInterval time.Duration
+	ackTimeout                time.Duration
+	preparationLogInterval    time.Duration
 
 	mu     sync.Mutex
 	active *stream
 }
 
 type stream struct {
-	exporter *Exporter
-	ctx      context.Context
+	exporter    *Exporter
+	ctx         context.Context
+	sourceEpoch string
 
 	mu      sync.Mutex
 	waiters map[string]chan Ack
@@ -69,6 +74,8 @@ func NewExporter(log *slog.Logger, store entity.Store, contract *entityexport.Co
 	exporter := &Exporter{
 		log: log, store: store, contract: contract,
 		minimumResnapshotInterval: defaultMinimumResnapshotInterval,
+		ackTimeout:                defaultAckTimeout,
+		preparationLogInterval:    defaultPreparationLogInterval,
 	}
 	for _, option := range options {
 		option(exporter)
@@ -76,19 +83,14 @@ func NewExporter(log *slog.Logger, store entity.Store, contract *entityexport.Co
 	return exporter
 }
 
-func (t *Exporter) Register(ctx context.Context, link Link) error {
-	sourceEpoch, err := t.store.SourceEpoch(ctx)
-	if err != nil {
-		return err
-	}
-	if sourceEpoch == "" {
-		return errors.New("entity store returned an empty source epoch")
-	}
-	t.sourceEpoch = sourceEpoch
-	link.OfferCapability(uplink.CapabilityOffer{
-		Name:     uplink.CapabilityEntitySync,
-		Versions: []uint{Version1},
-		Offer:    marshalOffer(t.contract.Digest(), sourceEpoch),
+func (t *Exporter) Register(_ context.Context, link Link) error {
+	link.OfferCapabilityFunc(uplink.CapabilityEntitySync, []uint{Version1}, func(ctx context.Context) (json.RawMessage, bool) {
+		sourceEpoch, err := t.readSourceEpoch(ctx)
+		if err != nil {
+			t.log.Warn("entity sync source epoch unavailable; omitting capability", "error", err)
+			return nil, false
+		}
+		return marshalOffer(t.contract.Digest(), sourceEpoch), true
 	})
 	link.Handle(TypeAck, t.handleAck)
 	link.OnSession(func(ctx context.Context, session uplink.Session) {
@@ -113,23 +115,22 @@ func (t *Exporter) runSession(ctx context.Context, session uplink.Session, link 
 			"selected", config.ExportSchema, "local", t.contract.Digest())
 		return
 	}
-	if config.SourceEpoch != t.sourceEpoch {
-		t.log.Warn("cloud selected an unexpected entity source epoch",
-			"selected", config.SourceEpoch, "local", t.sourceEpoch)
+	resnapshotInterval, nextSnapshot := t.resnapshotSchedule(config)
+	if !t.waitForStartGate(ctx) {
 		return
 	}
-	resnapshotInterval, nextSnapshot := t.resnapshotSchedule(config)
-	if t.startGate != nil {
-		t.log.Info("entity sync waiting for source preparation")
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.startGate:
-			t.log.Info("entity sync source is ready")
-		}
+	sourceEpoch, err := t.readSourceEpoch(ctx)
+	if err != nil {
+		t.log.Warn("entity sync source epoch unavailable for selected session", "error", err)
+		return
+	}
+	if config.SourceEpoch != sourceEpoch {
+		t.log.Warn("cloud selected an unexpected entity source epoch",
+			"selected", config.SourceEpoch, "local", sourceEpoch)
+		return
 	}
 
-	s := &stream{exporter: t, ctx: ctx, waiters: make(map[string]chan Ack)}
+	s := &stream{exporter: t, ctx: ctx, sourceEpoch: sourceEpoch, waiters: make(map[string]chan Ack)}
 	t.mu.Lock()
 	t.active = s
 	t.mu.Unlock()
@@ -241,6 +242,9 @@ func durationSeconds(seconds int64) time.Duration {
 }
 
 func (s *stream) retry(ctx context.Context, message string, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
 	if err != nil {
 		s.exporter.log.Warn(message, "error", err, "retry_in", sessionRetryDelay)
 	}
@@ -252,6 +256,39 @@ func (s *stream) retry(ctx context.Context, message string, err error) bool {
 	case <-timer.C:
 		return true
 	}
+}
+
+func (t *Exporter) waitForStartGate(ctx context.Context) bool {
+	if t.startGate == nil {
+		return true
+	}
+	t.log.Info("entity sync waiting for source preparation")
+	ticker := time.NewTicker(t.preparationLogInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-t.startGate:
+			t.log.Info("entity sync source is ready")
+			return true
+		case <-ticker.C:
+			t.log.Warn("entity sync still waiting for source preparation")
+		}
+	}
+}
+
+func (t *Exporter) readSourceEpoch(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, sourceEpochTimeout)
+	defer cancel()
+	sourceEpoch, err := t.store.SourceEpoch(ctx)
+	if err != nil {
+		return "", err
+	}
+	if sourceEpoch == "" {
+		return "", errors.New("entity store returned an empty source epoch")
+	}
+	return sourceEpoch, nil
 }
 
 func (t *Exporter) marker() entity.Attr {
@@ -296,7 +333,7 @@ func (s *stream) snapshot(watchCtx context.Context, link Link) (int64, clientv3.
 	snapshotID := uuid.NewString()
 	if err := link.SendMessageBlocking(s.ctx, TypeSnapshotBegin, SnapshotBegin{
 		SnapshotID: snapshotID, SourceHead: head, ExportSchemaDigest: s.exporter.contract.Digest(),
-		SourceEpoch: s.exporter.sourceEpoch,
+		SourceEpoch: s.sourceEpoch,
 	}); err != nil {
 		return 0, nil, err
 	}
@@ -427,10 +464,15 @@ func (s *stream) sendWatchResponse(link Link, response clientv3.WatchResponse, c
 	if err := response.Err(); err != nil {
 		return cursor, fmt.Errorf("watch cloud export index: %w", err)
 	}
+	// During catch-up, etcd stamps the response header with the current store
+	// head, which can be newer than the events in this chunk. Match the client's
+	// own resume logic by advancing through the last delivered event; an empty
+	// progress notification still advances through its header.
 	to := response.Header.Revision
-	for _, event := range response.Events {
-		if event.Kv != nil && event.Kv.ModRevision > to {
-			to = event.Kv.ModRevision
+	if n := len(response.Events); n > 0 {
+		last := response.Events[n-1]
+		if last.Kv != nil && last.Kv.ModRevision > 0 {
+			to = last.Kv.ModRevision
 		}
 	}
 	if to <= cursor {
@@ -444,7 +486,7 @@ func (s *stream) sendWatchResponse(link Link, response clientv3.WatchResponse, c
 	ack, err := s.sendAndWait(link, TypeChangeBatch, ChangeBatch{
 		MessageID: messageID, FromRevision: cursor + 1, ToRevision: to,
 		ExportSchemaDigest: s.exporter.contract.Digest(),
-		Changes:            changes, SourceEpoch: s.exporter.sourceEpoch,
+		Changes:            changes, SourceEpoch: s.sourceEpoch,
 	}, messageID)
 	if err != nil {
 		return cursor, err
@@ -528,9 +570,11 @@ func (s *stream) sendAndWait(link Link, messageType string, payload any, message
 	if err := link.SendMessageBlocking(s.ctx, messageType, payload); err != nil {
 		return Ack{}, err
 	}
+	waitCtx, cancelWait := context.WithTimeout(s.ctx, s.exporter.ackTimeout)
+	defer cancelWait()
 	select {
-	case <-s.ctx.Done():
-		return Ack{}, s.ctx.Err()
+	case <-waitCtx.Done():
+		return Ack{}, fmt.Errorf("await %s ack: %w", messageType, waitCtx.Err())
 	case ack := <-waiter:
 		if ack.Error != "" {
 			return Ack{}, fmt.Errorf("cloud rejected %s: %s", messageType, ack.Error)

--- a/pkg/entitysync/exporter_test.go
+++ b/pkg/entitysync/exporter_test.go
@@ -1,11 +1,14 @@
 package entitysync
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -25,13 +28,56 @@ type sentMessage struct {
 }
 
 type fakeLink struct {
-	mu        sync.Mutex
-	offers    []uplink.CapabilityOffer
-	handlers  map[string]uplink.MessageHandler
-	sessions  []func(context.Context, uplink.Session)
-	messages  []sentMessage
-	onSend    func(string, any)
-	sendError func(string, any) error
+	mu            sync.Mutex
+	registrations []fakeCapabilityRegistration
+	handlers      map[string]uplink.MessageHandler
+	sessions      []func(context.Context, uplink.Session)
+	messages      []sentMessage
+	onSend        func(string, any)
+	sendError     func(string, any) error
+}
+
+type fakeCapabilityRegistration struct {
+	name     string
+	versions []uint
+	provide  uplink.CapabilityOfferFunc
+}
+
+type mutableEpochStore struct {
+	*entity.MockStore
+	mu    sync.Mutex
+	epoch string
+	err   error
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (s *mutableEpochStore) SourceEpoch(context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.epoch, s.err
+}
+
+func (s *mutableEpochStore) setEpoch(epoch string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.epoch = epoch
+	s.err = err
 }
 
 type controlledWatchStore struct {
@@ -137,8 +183,24 @@ func newFakeLink() *fakeLink {
 	return &fakeLink{handlers: make(map[string]uplink.MessageHandler)}
 }
 
-func (f *fakeLink) OfferCapability(offer uplink.CapabilityOffer) {
-	f.offers = append(f.offers, offer)
+func (f *fakeLink) OfferCapabilityFunc(name string, versions []uint, provide uplink.CapabilityOfferFunc) {
+	f.registrations = append(f.registrations, fakeCapabilityRegistration{
+		name: name, versions: versions, provide: provide,
+	})
+}
+
+func (f *fakeLink) sessionOffers(ctx context.Context) []uplink.CapabilityOffer {
+	var offers []uplink.CapabilityOffer
+	for _, registration := range f.registrations {
+		offer, ok := registration.provide(ctx)
+		if !ok {
+			continue
+		}
+		offers = append(offers, uplink.CapabilityOffer{
+			Name: registration.name, Versions: registration.versions, Offer: offer,
+		})
+	}
+	return offers
 }
 
 func (f *fakeLink) OnSession(fn func(context.Context, uplink.Session)) {
@@ -172,9 +234,7 @@ func (f *fakeLink) sent() []sentMessage {
 
 func testExporter(store entity.Store) *Exporter {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	tenant := NewExporter(log, store, core_v1alpha.CloudExportContract)
-	tenant.sourceEpoch = "mock-source-epoch"
-	return tenant
+	return NewExporter(log, store, core_v1alpha.CloudExportContract)
 }
 
 func TestRegisterOffersGeneratedContract(t *testing.T) {
@@ -182,15 +242,34 @@ func TestRegisterOffersGeneratedContract(t *testing.T) {
 	link := newFakeLink()
 	require.NoError(t, tenant.Register(t.Context(), link))
 
-	require.Len(t, link.offers, 1)
-	require.Equal(t, uplink.CapabilityEntitySync, link.offers[0].Name)
-	require.Equal(t, []uint{Version1}, link.offers[0].Versions)
+	offers := link.sessionOffers(t.Context())
+	require.Len(t, offers, 1)
+	require.Equal(t, uplink.CapabilityEntitySync, offers[0].Name)
+	require.Equal(t, []uint{Version1}, offers[0].Versions)
 	var offer Offer
-	require.NoError(t, json.Unmarshal(link.offers[0].Offer, &offer))
+	require.NoError(t, json.Unmarshal(offers[0].Offer, &offer))
 	require.Equal(t, []string{core_v1alpha.CloudExportContract.Digest()}, offer.ExportSchemas)
 	require.Equal(t, "mock-source-epoch", offer.SourceEpoch)
 	require.Contains(t, link.handlers, TypeAck)
 	require.Len(t, link.sessions, 1)
+}
+
+func TestCapabilityOfferRetriesEpochDiscoveryAndRefreshesAfterRestore(t *testing.T) {
+	store := &mutableEpochStore{MockStore: entity.NewMockStore()}
+	store.setEpoch("", errors.New("etcd unavailable"))
+	exporter := testExporter(store)
+	link := newFakeLink()
+	require.NoError(t, exporter.Register(t.Context(), link))
+
+	require.Empty(t, link.sessionOffers(t.Context()), "a failed epoch read omits only entity sync")
+	for _, epoch := range []string{"epoch-before-restore", "epoch-after-restore"} {
+		store.setEpoch(epoch, nil)
+		offers := link.sessionOffers(t.Context())
+		require.Len(t, offers, 1)
+		var offer Offer
+		require.NoError(t, json.Unmarshal(offers[0].Offer, &offer))
+		require.Equal(t, epoch, offer.SourceEpoch)
+	}
 }
 
 func TestSessionWaitsForSourcePreparation(t *testing.T) {
@@ -204,7 +283,6 @@ func TestSessionWaitsForSourcePreparation(t *testing.T) {
 		core_v1alpha.CloudExportContract,
 		WithStartGate(ready),
 	)
-	tenant.sourceEpoch = "mock-source-epoch"
 	link := newFakeLink()
 	link.onSend = func(typ string, payload any) {
 		if typ != TypeSnapshotComplete {
@@ -240,6 +318,67 @@ func TestSessionWaitsForSourcePreparation(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestSessionLogsWhileSourcePreparationRemainsBlocked(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var logs lockedBuffer
+	exporter := NewExporter(
+		slog.New(slog.NewTextHandler(&logs, nil)),
+		entity.NewMockStore(),
+		core_v1alpha.CloudExportContract,
+		WithStartGate(make(chan struct{})),
+	)
+	exporter.preparationLogInterval = 10 * time.Millisecond
+	link := newFakeLink()
+	config, err := json.Marshal(Config{
+		ExportSchema: core_v1alpha.CloudExportContract.Digest(),
+		SourceEpoch:  "mock-source-epoch",
+	})
+	require.NoError(t, err)
+
+	go exporter.runSession(ctx, uplink.Session{Capabilities: []uplink.CapabilitySelection{{
+		Name: uplink.CapabilityEntitySync, Version: Version1, Config: config,
+	}}}, link)
+	require.Eventually(t, func() bool {
+		return bytes.Contains([]byte(logs.String()), []byte("entity sync still waiting for source preparation"))
+	}, time.Second, time.Millisecond)
+}
+
+func TestSessionValidatesEpochAfterSourcePreparation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var logs lockedBuffer
+	store := &mutableEpochStore{MockStore: entity.NewMockStore(), epoch: "epoch-before-restore"}
+	ready := make(chan struct{})
+	exporter := NewExporter(
+		slog.New(slog.NewTextHandler(&logs, nil)),
+		store,
+		core_v1alpha.CloudExportContract,
+		WithStartGate(ready),
+	)
+	config, err := json.Marshal(Config{
+		ExportSchema:     core_v1alpha.CloudExportContract.Digest(),
+		SourceEpoch:      "epoch-before-restore",
+		SnapshotRequired: true,
+	})
+	require.NoError(t, err)
+	link := newFakeLink()
+
+	go exporter.runSession(ctx, uplink.Session{Capabilities: []uplink.CapabilitySelection{{
+		Name: uplink.CapabilityEntitySync, Version: Version1, Config: config,
+	}}}, link)
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "entity sync waiting for source preparation")
+	}, time.Second, time.Millisecond)
+
+	store.setEpoch("epoch-after-restore", nil)
+	close(ready)
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "cloud selected an unexpected entity source epoch")
+	}, time.Second, time.Millisecond)
+	require.Empty(t, link.sent(), "the restored source must not be sent under the negotiated old epoch")
+}
+
 func TestSnapshotFiltersEntities(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -263,7 +402,7 @@ func TestSnapshotFiltersEntities(t *testing.T) {
 	store.AddEntity(deployment.Id(), deployment)
 
 	tenant := testExporter(store)
-	s := &stream{exporter: tenant, ctx: ctx, waiters: make(map[string]chan Ack)}
+	s := &stream{exporter: tenant, ctx: ctx, sourceEpoch: "mock-source-epoch", waiters: make(map[string]chan Ack)}
 	tenant.active = s
 	link := newFakeLink()
 	link.onSend = func(typ string, payload any) {
@@ -317,7 +456,7 @@ func TestSnapshotReadsAndSendsOnePinnedPageAtATime(t *testing.T) {
 	}
 
 	exporter := testExporter(store)
-	stream := &stream{exporter: exporter, ctx: ctx, waiters: make(map[string]chan Ack)}
+	stream := &stream{exporter: exporter, ctx: ctx, sourceEpoch: "mock-source-epoch", waiters: make(map[string]chan Ack)}
 	exporter.active = stream
 	link := newFakeLink()
 	var readsAtSend []int
@@ -354,7 +493,7 @@ func TestSnapshotSkipsStaleMarkerIndexEntry(t *testing.T) {
 	defer cancel()
 	store := &staleIndexStore{MockStore: entity.NewMockStore(), stale: "app/missing"}
 	tenant := testExporter(store)
-	s := &stream{exporter: tenant, ctx: ctx, waiters: make(map[string]chan Ack)}
+	s := &stream{exporter: tenant, ctx: ctx, sourceEpoch: "mock-source-epoch", waiters: make(map[string]chan Ack)}
 	tenant.active = s
 	link := newFakeLink()
 	link.onSend = func(typ string, payload any) {
@@ -386,7 +525,7 @@ func TestLiveChangePreemptsArchiveSnapshot(t *testing.T) {
 	store.AddEntity(deployment.Id(), deployment)
 
 	tenant := testExporter(store)
-	s := &stream{exporter: tenant, ctx: ctx, waiters: make(map[string]chan Ack)}
+	s := &stream{exporter: tenant, ctx: ctx, sourceEpoch: "mock-source-epoch", waiters: make(map[string]chan Ack)}
 	tenant.active = s
 	link := newFakeLink()
 	link.onSend = func(typ string, payload any) {
@@ -771,4 +910,139 @@ func TestSessionSnapshotsWhenCursorIsAheadOfSource(t *testing.T) {
 		return len(link.sent()) >= 2
 	}, time.Second, time.Millisecond)
 	require.Equal(t, []int64{11}, store.WatchFromRevsCopy(), "a regressed source snapshots instead of watching beyond its head")
+}
+
+func TestWatchBatchStopsAtLastDeliveredEvent(t *testing.T) {
+	store := entity.NewMockStore()
+	marker := core_v1alpha.CloudExportContract.MarkerID()
+	for _, id := range []entity.Id{"deployment/a", "deployment/b"} {
+		store.AddEntity(id, entity.New(
+			entity.Ref(entity.DBId, id),
+			(&core_v1alpha.Deployment{ID: id, AppName: "web"}).Encode(),
+			entity.Bool(marker, true),
+		))
+	}
+	exporter := testExporter(store)
+	stream := &stream{
+		exporter: exporter, ctx: t.Context(), sourceEpoch: "mock-source-epoch",
+		waiters: make(map[string]chan Ack),
+	}
+	exporter.active = stream
+	link := newFakeLink()
+	link.onSend = func(typ string, payload any) {
+		if typ == TypeChangeBatch {
+			batch := payload.(ChangeBatch)
+			stream.deliver(Ack{MessageID: batch.MessageID, Cursor: batch.ToRevision})
+		}
+	}
+
+	cursor, err := stream.sendWatchResponse(link, clientv3.WatchResponse{
+		Header: etcdserverpb.ResponseHeader{Revision: 100},
+		Events: []*clientv3.Event{
+			{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Value: []byte("deployment/a"), ModRevision: 10}},
+			{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Value: []byte("deployment/b"), ModRevision: 20}},
+		},
+	}, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(20), cursor)
+	require.Len(t, link.sent(), 1)
+	require.Equal(t, int64(20), link.sent()[0].payload.(ChangeBatch).ToRevision)
+}
+
+func TestTailDeliversEveryCatchUpChunkBeforeStoreHead(t *testing.T) {
+	store := entity.NewMockStore()
+	marker := core_v1alpha.CloudExportContract.MarkerID()
+	for _, id := range []entity.Id{"deployment/a", "deployment/b"} {
+		store.AddEntity(id, entity.New(
+			entity.Ref(entity.DBId, id),
+			(&core_v1alpha.Deployment{ID: id, AppName: "web"}).Encode(),
+			entity.Bool(marker, true),
+		))
+	}
+	exporter := testExporter(store)
+	stream := &stream{
+		exporter: exporter, ctx: t.Context(), sourceEpoch: "mock-source-epoch",
+		waiters: make(map[string]chan Ack),
+	}
+	exporter.active = stream
+	link := newFakeLink()
+	link.onSend = func(typ string, payload any) {
+		if typ == TypeChangeBatch {
+			batch := payload.(ChangeBatch)
+			stream.deliver(Ack{MessageID: batch.MessageID, Cursor: batch.ToRevision})
+		}
+	}
+	watcher := make(chan clientv3.WatchResponse, 2)
+	watcher <- clientv3.WatchResponse{
+		Header: etcdserverpb.ResponseHeader{Revision: 100},
+		Events: []*clientv3.Event{{
+			Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Value: []byte("deployment/a"), ModRevision: 10},
+		}},
+	}
+	watcher <- clientv3.WatchResponse{
+		Header: etcdserverpb.ResponseHeader{Revision: 100},
+		Events: []*clientv3.Event{{
+			Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Value: []byte("deployment/b"), ModRevision: 20},
+		}},
+	}
+	close(watcher)
+
+	cursor, err := stream.tail(link, watcher, 0, time.Time{})
+	require.ErrorContains(t, err, "watch closed")
+	require.Equal(t, int64(20), cursor)
+	messages := link.sent()
+	require.Len(t, messages, 2)
+	require.Equal(t, int64(10), messages[0].payload.(ChangeBatch).ToRevision)
+	require.Equal(t, int64(20), messages[1].payload.(ChangeBatch).ToRevision)
+}
+
+func TestSendAndWaitTimesOutWithoutAcknowledgment(t *testing.T) {
+	exporter := testExporter(entity.NewMockStore())
+	exporter.ackTimeout = 10 * time.Millisecond
+	stream := &stream{exporter: exporter, ctx: t.Context(), waiters: make(map[string]chan Ack)}
+
+	_, err := stream.sendAndWait(newFakeLink(), TypeChangeBatch, struct{}{}, "message-1")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, "await entity.change.batch ack")
+}
+
+func TestSendAndWaitPreservesCancellationAndRejection(t *testing.T) {
+	t.Run("session cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		exporter := testExporter(entity.NewMockStore())
+		exporter.ackTimeout = time.Hour
+		stream := &stream{exporter: exporter, ctx: ctx, waiters: make(map[string]chan Ack)}
+
+		_, err := stream.sendAndWait(newFakeLink(), TypeChangeBatch, struct{}{}, "message-1")
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("cloud rejection", func(t *testing.T) {
+		exporter := testExporter(entity.NewMockStore())
+		exporter.ackTimeout = time.Hour
+		stream := &stream{exporter: exporter, ctx: t.Context(), waiters: make(map[string]chan Ack)}
+		link := newFakeLink()
+		link.onSend = func(string, any) {
+			stream.deliver(Ack{MessageID: "message-1", Error: "not accepted"})
+		}
+
+		_, err := stream.sendAndWait(link, TypeChangeBatch, struct{}{}, "message-1")
+		require.ErrorContains(t, err, "cloud rejected entity.change.batch: not accepted")
+	})
+}
+
+func TestRetryDoesNotWarnAfterSessionCancellation(t *testing.T) {
+	var logs lockedBuffer
+	exporter := NewExporter(
+		slog.New(slog.NewTextHandler(&logs, nil)),
+		entity.NewMockStore(),
+		core_v1alpha.CloudExportContract,
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	stream := &stream{exporter: exporter, ctx: ctx}
+
+	require.False(t, stream.retry(ctx, "start entity sync session", context.Canceled))
+	require.NotContains(t, logs.String(), "start entity sync session")
 }

--- a/pkg/uplink/client.go
+++ b/pkg/uplink/client.go
@@ -67,7 +67,7 @@ type Client struct {
 	mu           sync.Mutex
 	onConnect    []func(ctx context.Context)
 	onSession    []func(ctx context.Context, session Session)
-	capabilities []CapabilityOffer
+	capabilities []capabilityRegistration
 	session      *sessionConfig
 
 	// NewClient enables this for production's pre-handshake path. Keeping it
@@ -82,6 +82,17 @@ type Client struct {
 
 type sessionConfig struct {
 	runtimeVersion string
+}
+
+// CapabilityOfferFunc builds the connection-specific payload for an offered
+// capability. Returning false omits the capability from that connection.
+type CapabilityOfferFunc func(context.Context) (json.RawMessage, bool)
+
+type capabilityRegistration struct {
+	name     string
+	versions []uint
+	offer    json.RawMessage
+	provide  CapabilityOfferFunc
 }
 
 // ClientOption changes how a Client establishes its connections.
@@ -212,14 +223,31 @@ func (c *Client) OnConnect(fn func(ctx context.Context)) {
 // OfferCapability adds a protocol family to the next session hello. Offers
 // are snapshotted for each connection, so tenants should register before Run.
 func (c *Client) OfferCapability(offer CapabilityOffer) {
+	c.registerCapability(capabilityRegistration{
+		name: offer.Name, versions: offer.Versions, offer: offer.Offer,
+	})
+}
+
+// OfferCapabilityFunc adds a capability whose offer payload is rebuilt before
+// each connection's session handshake. Returning false omits only that
+// capability from the connection, so temporary source failures do not prevent
+// other tenants from negotiating.
+func (c *Client) OfferCapabilityFunc(name string, versions []uint, provide CapabilityOfferFunc) {
+	if provide == nil {
+		panic(fmt.Sprintf("uplink capability %q has no offer provider", name))
+	}
+	c.registerCapability(capabilityRegistration{name: name, versions: versions, provide: provide})
+}
+
+func (c *Client) registerCapability(capability capabilityRegistration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, existing := range c.capabilities {
-		if existing.Name == offer.Name {
-			panic(fmt.Sprintf("uplink capability %q offered more than once", offer.Name))
+		if existing.name == capability.name {
+			panic(fmt.Sprintf("uplink capability %q offered more than once", capability.name))
 		}
 	}
-	c.capabilities = append(c.capabilities, offer)
+	c.capabilities = append(c.capabilities, capability)
 }
 
 // OnSession registers a callback invoked after cloud's welcome has been
@@ -241,17 +269,29 @@ func (c *Client) connectCallbacks() []func(ctx context.Context) {
 	return slices.Clone(c.onConnect)
 }
 
-func (c *Client) sessionSnapshot() ([]CapabilityOffer, []func(context.Context, Session)) {
+func (c *Client) sessionSnapshot(ctx context.Context) ([]CapabilityOffer, []func(context.Context, Session)) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	capabilities := slices.Clone(c.capabilities)
+	callbacks := slices.Clone(c.onSession)
+	c.mu.Unlock()
 
-	offers := make([]CapabilityOffer, len(c.capabilities))
-	for i, offer := range c.capabilities {
-		offers[i] = offer
-		offers[i].Versions = slices.Clone(offer.Versions)
-		offers[i].Offer = slices.Clone(offer.Offer)
+	offers := make([]CapabilityOffer, 0, len(capabilities))
+	for _, capability := range capabilities {
+		offer := capability.offer
+		if capability.provide != nil {
+			var ok bool
+			offer, ok = capability.provide(ctx)
+			if !ok {
+				continue
+			}
+		}
+		offers = append(offers, CapabilityOffer{
+			Name:     capability.name,
+			Versions: slices.Clone(capability.versions),
+			Offer:    slices.Clone(offer),
+		})
 	}
-	return offers, slices.Clone(c.onSession)
+	return offers, callbacks
 }
 
 // Handle registers a handler for an inbound message type, which is how a
@@ -477,7 +517,7 @@ func (c *Client) runOnce(ctx context.Context) error {
 }
 
 func (c *Client) establishSession(ctx context.Context, conn *websocket.Conn) (Session, []func(context.Context, Session), error) {
-	offers, callbacks := c.sessionSnapshot()
+	offers, callbacks := c.sessionSnapshot(ctx)
 	hello := SessionHello{
 		HandshakeVersions: []uint{HandshakeVersion1},
 		RuntimeVersion:    c.session.runtimeVersion,

--- a/pkg/uplink/client_test.go
+++ b/pkg/uplink/client_test.go
@@ -139,6 +139,30 @@ func TestOfferCapabilityPanicsOnDuplicateName(t *testing.T) {
 	client.OfferCapability(CapabilityOffer{Name: CapabilityPopConnect, Versions: []uint{2}})
 }
 
+func TestOfferCapabilityFuncRefreshesAndCanOmitAnOffer(t *testing.T) {
+	client := newTestClient("http://unused", "test-token", NewMessageRouter())
+	include := false
+	payload := json.RawMessage(`{"epoch":"one"}`)
+	client.OfferCapabilityFunc(CapabilityEntitySync, []uint{1}, func(context.Context) (json.RawMessage, bool) {
+		return payload, include
+	})
+
+	offers, _ := client.sessionSnapshot(t.Context())
+	if len(offers) != 0 {
+		t.Fatalf("omitted capability offers = %+v, want none", offers)
+	}
+	include = true
+	offers, _ = client.sessionSnapshot(t.Context())
+	if len(offers) != 1 || string(offers[0].Offer) != string(payload) {
+		t.Fatalf("capability offers = %+v, want refreshed entity-sync offer", offers)
+	}
+	payload = json.RawMessage(`{"epoch":"two"}`)
+	offers, _ = client.sessionSnapshot(t.Context())
+	if string(offers[0].Offer) != string(payload) {
+		t.Fatalf("capability offer = %s, want %s", offers[0].Offer, payload)
+	}
+}
+
 func TestLegacyClientSendsBootstrapBeforeTenantMessages(t *testing.T) {
 	received := make(chan []Envelope, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Runtime’s entity-sync path is safe to lag behind local serving, but several recovery edges could make that lag silent, sticky, or lossy. A failed source-epoch read lasted for the process lifetime, an unanswered batch stalled a session indefinitely, and catch-up responses could acknowledge the store head before delivering every chunk. Normal index churn could also force another full sweep or panic the migration loop.

This refreshes the epoch offer for each uplink session, bounds acknowledgment waits so the existing retry loop can resume from the last cursor, and advances catch-up cursors through the last delivered event rather than the response header. The preparation gate now logs periodically, marker writes share the conflict-retrying path, stale index rows are skipped, and normal shutdown cancellation stays quiet.

This follows up on the non-blocking review notes from #1117 and folds in the catch-up cursor bug reported by Detail in #1135. Focused packages, the repository compile sweep, and the changed concurrency paths under the race detector pass. The coordinate package also passes in `hack/it`.

Part of MIR-1651
Closes MIR-1739