### PR TITLE
Move pull request testing to Depot CI

### DIFF
--- a/.depot/workflows/test.yml
+++ b/.depot/workflows/test.yml
@@ -1,13 +1,27 @@
+# Depot runs this workflow for pull requests and the merge queue. Keep its job
+# behavior aligned with .github/workflows/test.yml, which release.yml calls for
+# main and tag builds. Standard GitHub runner labels are mapped to their Depot
+# equivalents below.
+
 name: Test
 
 on:
-  # PR and merge-queue runs live in .depot/workflows/test.yml. Keep this copy
-  # callable so release.yml can test main and tags inside GitHub Actions.
-  workflow_call:
-    # Called by release.yml for main/tag builds. No inputs: a called workflow
-    # inherits the caller's github context, so a bare checkout already lands on
-    # the commit that triggered the release, and there is no ref for a caller to
-    # aim somewhere else.
+  pull_request:
+    # Explicit list because naming `types` replaces the default set. `labeled`
+    # is what lets the ci:distributed opt-in below take effect on an open PR;
+    # the other three are the defaults we'd otherwise lose.
+    #
+    # A label change restarts the whole workflow, which looks wasteful enough
+    # to want gating the other jobs on `github.event.action != 'labeled'`.
+    # Don't. The concurrency group above cancels the run in flight, and a
+    # required status check resolves to the newest run of that name. A run
+    # that skipped lint/build/test would therefore replace real results with
+    # skipped ones, and a skipped check is generally treated as satisfying a
+    # required check. That trades one spare CI run for a PR that can merge
+    # without having been tested. Labels land on roughly 1 PR in 60 here, so
+    # the waste is theoretical and the hazard is not.
+    types: [opened, synchronize, reopened, labeled]
+  merge_group:
 
 # Cancel in-progress runs when a new run is triggered on the same branch/PR.
 concurrency:
@@ -87,7 +101,7 @@ jobs:
   # run on every PR but too important to leave to someone remembering a label.
   # Only consulted for pull_request; other events don't gate on it at all.
   changes:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     outputs:
       distributed: ${{ steps.filter.outputs.distributed }}
     steps:
@@ -128,7 +142,7 @@ jobs:
         fi
 
   test-groups:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -229,7 +243,7 @@ jobs:
       run: docker save runtime-shell -o /tmp/iso-image.tar
 
   blackbox-groups:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -465,26 +479,22 @@ jobs:
     # The distributed suite exercises the multi-node topology (a coordinator plus
     # a separate runner peer) with distributedrunners enabled. Setup is heavy
     # (iso peers, a binary build, the join dance) and it's the only place a
-    # second node exists, so a bug there is invisible until it's already on main
-    # blocking a release (exactly how MIR-1469 got in). It therefore runs on
-    # main/release builds rather than every PR push: release.yml (push to main
-    # and tags) calls this workflow via workflow_call, where github.event_name is
-    # the caller's event ('push'), so excluding 'pull_request' runs it there
-    # while skipping PRs. It would also run in a merge queue ('merge_group'). On
-    # a PR it runs when the diff touches code that can break the topology, or
-    # when someone labels the PR `ci:distributed`.
+    # second node exists, so a bug there can otherwise reach the merge queue
+    # unnoticed (exactly how MIR-1469 got in). It runs for every merge-group
+    # candidate. On a PR it runs when the diff touches code that can break the
+    # topology, or when someone labels the PR `ci:distributed`.
     #
     # `!cancelled()` rather than a plain condition keeps the non-PR clause
     # authoritative even if the `changes` job fails — a failed dependency would
-    # otherwise skip this on main and tags, quietly dropping the release coverage
-    # this whole gate exists to protect.
+    # otherwise skip this in the merge queue, quietly dropping the coverage this
+    # whole gate exists to protect.
     needs: [changes]
     if: >-
       !cancelled() && (
       github.event_name != 'pull_request' ||
       needs.changes.outputs.distributed == 'true' ||
       contains(github.event.pull_request.labels.*.name, 'ci:distributed') )
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -617,7 +627,7 @@ jobs:
   test:
     if: always()
     needs: [changes, test-runner, blackbox-groups, test-blackbox, test-blackbox-pop, blackbox-groups-distributed, test-blackbox-distributed]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
     - name: Check results
       run: |
@@ -661,15 +671,13 @@ jobs:
         if [[ "${{ needs.blackbox-groups-distributed.result }}" != "success" && "${{ needs.blackbox-groups-distributed.result }}" != "skipped" ]]; then
           exit 1
         fi
-        # Distributed suite is skipped on PRs (merge-queue / main only), so
-        # skipped is acceptable here; a real run (every shard) must pass.
+        # Distributed suite is skipped on ordinary PRs, so skipped is acceptable
+        # here; a scheduled PR or merge-queue run (every shard) must pass.
         if [[ "${{ needs.test-blackbox-distributed.result }}" != "success" && "${{ needs.test-blackbox-distributed.result }}" != "skipped" ]]; then
           exit 1
         fi
 
   build:
-    # Skip when called from release.yml - it has its own build jobs with signing
-    if: github.event_name != 'workflow_call'
     runs-on: depot-ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Depot’s native CI now supports tracefs and WireGuard, the two kernel capabilities that blocked #1037. The canary exercised both successfully and exposed a BuildKit restart race, which #1148 fixed.

This moves PR and merge-queue Test runs to `.depot/workflows/test.yml`, so they use Depot’s scheduler and sandboxes without a duplicate GitHub Actions run. The GitHub copy remains callable by `release.yml`; that mixed-platform workflow still needs GitHub’s macOS runners, while its Linux jobs continue to use Depot runners.

Related to MIR-1755