### PR TITLE
Make BuildKit restart recover from lingering tasks

### DIFF
--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	buildkitclient "github.com/moby/buildkit/client"
@@ -19,6 +20,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/errdefs"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 	"miren.dev/runtime/pkg/imagerefs"
@@ -71,6 +73,12 @@ type Component struct {
 	hostsPath     string             // path to custom /etc/hosts file for the container
 	external      bool               // true if connecting to external daemon (no container management)
 	monitorCancel context.CancelFunc // cancels the task exit-monitor goroutine on intentional stop
+}
+
+type buildkitTask interface {
+	Wait(context.Context) (<-chan containerd.ExitStatus, error)
+	Kill(context.Context, syscall.Signal, ...containerd.KillOpts) error
+	Delete(context.Context, ...containerd.ProcessDeleteOpts) (*containerd.ExitStatus, error)
 }
 
 // NewComponent creates a new BuildKit component that manages an embedded daemon.
@@ -237,7 +245,9 @@ func (c *Component) Stop(ctx context.Context) error {
 	if c.container != nil {
 		task, err := c.container.Task(ctx, nil)
 		if err == nil {
-			c.stopTask(ctx, task)
+			if err := c.stopTask(ctx, task); err != nil {
+				c.Log.Error("failed to stop buildkit task during shutdown", "error", err)
+			}
 		} else {
 			c.Log.Warn("failed to get buildkit task for shutdown", "error", err)
 		}
@@ -507,7 +517,13 @@ func (c *Component) restartExistingContainer(ctx context.Context, container cont
 	// to this process.
 	if task, err := container.Task(ctx, nil); err == nil {
 		c.Log.Info("evicting stale buildkit task before restart")
-		c.stopTask(ctx, task)
+		if err := c.stopTask(ctx, task); err != nil {
+			c.container = nil
+			return fmt.Errorf("failed to evict stale buildkit task: %w", err)
+		}
+	} else if !errdefs.IsNotFound(err) {
+		c.container = nil
+		return fmt.Errorf("failed to inspect existing buildkit task: %w", err)
 	}
 
 	c.Log.Info("creating new task for existing buildkit container")
@@ -546,7 +562,9 @@ func (c *Component) startTaskAndMonitor(ctx context.Context, task containerd.Tas
 	}
 
 	if err := c.waitForReady(ctx); err != nil {
-		c.stopTask(ctx, task)
+		if stopErr := c.stopTask(ctx, task); stopErr != nil {
+			c.Log.Error("failed to stop buildkit task after readiness check failure", "error", stopErr)
+		}
 		return err
 	}
 
@@ -629,30 +647,47 @@ func (c *Component) waitForReady(ctx context.Context) error {
 	}
 }
 
-func (c *Component) stopTask(ctx context.Context, task containerd.Task) {
-	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+func (c *Component) stopTask(ctx context.Context, task buildkitTask) error {
+	return c.stopTaskWithGrace(ctx, task, 30*time.Second)
+}
+
+func (c *Component) stopTaskWithGrace(ctx context.Context, task buildkitTask, gracePeriod time.Duration) error {
+	shutdownBase := namespaces.WithNamespace(context.WithoutCancel(ctx), c.Namespace)
+	shutdownCtx, cancel := context.WithTimeout(shutdownBase, gracePeriod)
 	defer cancel()
+
+	// Register the wait before signalling so a fast exit cannot race past it.
+	status, waitErr := task.Wait(shutdownCtx)
+	if waitErr != nil {
+		c.Log.Warn("failed to wait for buildkit task, proceeding to delete", "error", waitErr)
+	}
 
 	// If SIGTERM can't be delivered we still fall through to Delete: a task we
 	// fail to reap here otherwise leaks and blocks the next NewTask on this
 	// container.
 	if err := task.Kill(shutdownCtx, unix.SIGTERM); err != nil {
-		c.Log.Error("failed to send SIGTERM to buildkit task", "error", err)
-	} else if status, err := task.Wait(shutdownCtx); err == nil {
+		c.Log.Warn("failed to send SIGTERM to buildkit task, proceeding to delete", "error", err)
+	} else if waitErr == nil {
 		select {
 		case es := <-status:
 			c.Log.Info("buildkit task exited", "code", es.ExitCode())
 
 		case <-shutdownCtx.Done():
 			c.Log.Warn("buildkit task did not exit gracefully, sending SIGKILL")
-			killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			killCtx, killCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), c.Namespace), 10*time.Second)
 			defer killCancel()
 
+			killStatus, killWaitErr := task.Wait(killCtx)
+			if killWaitErr != nil {
+				c.Log.Warn("failed to wait for buildkit task before SIGKILL, proceeding to delete", "error", killWaitErr)
+			}
 			if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
 				c.Log.Error("failed to send SIGKILL to buildkit task", "error", err)
-			} else {
-				if _, waitErr := task.Wait(killCtx); waitErr != nil {
-					c.Log.Error("buildkit task wait after SIGKILL failed", "error", waitErr)
+			} else if killWaitErr == nil {
+				select {
+				case <-killStatus:
+				case <-killCtx.Done():
+					c.Log.Warn("buildkit task did not exit after SIGKILL within timeout")
 				}
 			}
 		}
@@ -662,16 +697,15 @@ func (c *Component) stopTask(ctx context.Context, task containerd.Task) {
 	// container is left in a state where a fresh task can be created. Detach
 	// from the parent's cancellation so a cancelled/expired ctx can't skip
 	// cleanup, but carry over the containerd namespace (Delete requires it).
-	deleteBase := context.Background()
-	if ns, ok := namespaces.Namespace(ctx); ok {
-		deleteBase = namespaces.WithNamespace(deleteBase, ns)
-	}
-	deleteCtx, deleteCancel := context.WithTimeout(deleteBase, 10*time.Second)
+	deleteCtx, deleteCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), c.Namespace), 10*time.Second)
 	defer deleteCancel()
 
-	if _, err := task.Delete(deleteCtx); err != nil {
+	if _, err := task.Delete(deleteCtx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
 		c.Log.Error("failed to delete buildkit task", "error", err)
+		return fmt.Errorf("delete buildkit task: %w", err)
 	}
+
+	return nil
 }
 
 func (c *Component) deleteContainerWithRetry(ctx context.Context) {

--- a/components/buildkit/task_test.go
+++ b/components/buildkit/task_test.go
@@ -1,0 +1,90 @@
+package buildkit
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"syscall"
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+type forcedStopTask struct {
+	graceExit      chan containerd.ExitStatus
+	killExit       chan containerd.ExitStatus
+	waitCalls      int
+	signals        []syscall.Signal
+	contextErrs    []error
+	deleteOptCount int
+	deleteErr      error
+}
+
+func newForcedStopTask() *forcedStopTask {
+	return &forcedStopTask{
+		graceExit: make(chan containerd.ExitStatus, 1),
+		killExit:  make(chan containerd.ExitStatus, 1),
+	}
+}
+
+func (t *forcedStopTask) Wait(ctx context.Context) (<-chan containerd.ExitStatus, error) {
+	t.contextErrs = append(t.contextErrs, ctx.Err())
+	t.waitCalls++
+	if t.waitCalls == 1 {
+		return t.graceExit, nil
+	}
+	return t.killExit, nil
+}
+
+func (t *forcedStopTask) Kill(ctx context.Context, signal syscall.Signal, _ ...containerd.KillOpts) error {
+	t.contextErrs = append(t.contextErrs, ctx.Err())
+	t.signals = append(t.signals, signal)
+	if signal == unix.SIGKILL {
+		t.killExit <- *containerd.NewExitStatus(137, time.Now(), nil)
+	}
+	return nil
+}
+
+func (t *forcedStopTask) Delete(ctx context.Context, opts ...containerd.ProcessDeleteOpts) (*containerd.ExitStatus, error) {
+	t.contextErrs = append(t.contextErrs, ctx.Err())
+	t.deleteOptCount = len(opts)
+	return nil, t.deleteErr
+}
+
+func TestStopTaskForceDeletesAfterGracePeriod(t *testing.T) {
+	task := newForcedStopTask()
+	component := &Component{
+		Log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Namespace: "miren-test",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, component.stopTaskWithGrace(ctx, task, time.Millisecond))
+	require.Equal(t, []syscall.Signal{unix.SIGTERM, unix.SIGKILL}, task.signals)
+	require.Equal(t, 2, task.waitCalls)
+	require.Empty(t, task.killExit, "task exit must be observed before deletion")
+	require.Equal(t, 1, task.deleteOptCount)
+	for _, contextErr := range task.contextErrs {
+		require.NoError(t, contextErr, "cleanup must detach from caller cancellation")
+	}
+}
+
+func TestStopTaskReturnsDeleteFailure(t *testing.T) {
+	task := newForcedStopTask()
+	task.graceExit <- *containerd.NewExitStatus(0, time.Now(), nil)
+	task.deleteErr = errors.New("task still exists")
+	component := &Component{
+		Log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Namespace: "miren-test",
+	}
+
+	err := component.stopTaskWithGrace(context.Background(), task, time.Second)
+	require.ErrorContains(t, err, "delete buildkit task: task still exists")
+	require.Equal(t, 1, task.deleteOptCount)
+}


### PR DESCRIPTION
The Depot POP canary exposed the ugly side of the short dev-server shutdown budget: Miren can be killed while BuildKit is still stopping, leaving containerd’s task behind for the next boot. We already try to evict that stale task, but the forced path sent SIGKILL without waiting for exit and then attempted a non-forced delete. If deletion lost that race, startup walked straight into `task miren-buildkit: already exists`.

Make eviction a real restart precondition. Task cleanup now registers waits before signaling, uses contexts independent of shutdown cancellation, force-deletes lingering processes, and returns deletion errors instead of attempting `NewTask` against uncertain state. Focused forced-stop coverage and the existing real-containerd restart suite pass.

Validated by the Depot POP canary in #1147. Closes MIR-1755.