### PR TITLE
Stop deployment resyncs from reviving idle apps

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1253,7 +1253,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		eac,
 		controller.AdaptReconcileController[core_v1alpha.App](launcher),
 		time.Minute, // Resync every minute to ensure pools exist
-		1,           // Single worker to prevent race conditions
+		2,           // Parallelize apps; same-app work is serialized by the controller and launcher
 	)
 	c.cm.AddController(launcherController)
 
@@ -1265,7 +1265,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		eac,
 		launcher.AddonAssociationHandler(),
 		0, // No resync — driven entirely by watch events
-		1,
+		2, // Parallelize apps; the launcher's per-app lock serializes matching associations
 	)
 	c.cm.AddController(addonLauncherController)
 

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -205,34 +205,13 @@ func (l *Launcher) AddonAssociationHandler() controller.HandlerFunc {
 		l.Log.Info("addon association changed, reconciling app",
 			"association", assoc.ID, "status", assoc.Status, "app", assoc.App)
 
-		// Fetch the app and run the same reconcile logic
-		appResp, err := l.EAC.Get(ctx, assoc.App.String())
-		if err != nil {
-			if errors.Is(err, cond.ErrNotFound{}) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("failed to get app: %w", err)
-		}
-
-		var app core_v1alpha.App
-		app.Decode(appResp.Entity().Entity())
-
-		if app.ActiveVersion == "" {
-			return nil, nil
-		}
-
-		ready, err := l.addonsReady(ctx, app.ID)
-		if err != nil {
-			l.Log.Error("failed to check addon readiness", "app", app.ID, "error", err)
-			return nil, nil
-		}
-		if !ready {
-			l.Log.Info("addons still not ready, deferring", "app", app.ID)
-			return nil, nil
-		}
-
-		l.Log.Info("addons ready, triggering app reconciliation", "app", app.ID)
-		return nil, l.reconcileAppVersion(ctx, &app)
+		// Reconcile re-reads the app and checks all addon associations under the
+		// same per-app lock used by watch events and on-demand pool creation.
+		// Controller watch callbacks only enqueue events, so this handler cannot
+		// synchronously re-enter a launcher reconcile that already holds the lock.
+		// Calling reconcileAppVersion directly here used to let an addon event race
+		// the main deployment launcher for the same app.
+		return nil, l.Reconcile(ctx, &core_v1alpha.App{ID: assoc.App}, nil)
 	}
 }
 
@@ -455,9 +434,10 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 		// Steady-state reuse is a no-op; only log (below) when reuse actually
 		// mutates the pool.
 		needsUpdate := false
+		versionChanged := poolWithEntity.Pool.SandboxSpec.Version != ver.ID
 
 		// Update the pool's sandbox spec version to track the current AppVersion
-		if poolWithEntity.Pool.SandboxSpec.Version != ver.ID {
+		if versionChanged {
 			poolWithEntity.Pool.SandboxSpec.Version = ver.ID
 			needsUpdate = true
 		}
@@ -489,13 +469,12 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 		}
 
 		// A deploy should boot the new version so we can verify it, even when
-		// reusing a pool that drained to zero (an autoscale app gone idle).
-		// Floor a drained pool back to 1, the same way a fresh pool seeds; the
-		// autoscaler scales it down again afterward. Without this, a redeploy of
-		// a scaled-to-zero app would just point the pool at the new version
-		// without ever booting it, so we'd never know if it actually works.
+		// reusing a pool that drained to zero (an autoscale app gone idle). A
+		// steady-state resync of the same version must leave it drained; otherwise
+		// the minutely resync repeatedly cold-starts every idle app and blocks the
+		// launcher's worker while it waits for readiness.
 		bootForVerification := false
-		if poolWithEntity.Pool.DesiredInstances < 1 {
+		if versionChanged && poolWithEntity.Pool.DesiredInstances < 1 {
 			poolWithEntity.Pool.DesiredInstances = 1
 			l.Log.Info("flooring drained pool to one instance for deploy verification",
 				"service", serviceName,

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/addon/addon_v1alpha"
 	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
@@ -21,6 +22,7 @@ import (
 	apiserver "miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/network/network_v1alpha"
+	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/entity/types"
@@ -805,6 +807,92 @@ func TestAutoModePoolReusePreservesDesiredInstances(t *testing.T) {
 		"auto mode pool desired_instances should be preserved (not reset to 1)")
 	assert.Contains(t, pool.ReferencedByVersions, version.ID,
 		"pool should still reference the version")
+}
+
+// TestAutoModeDrainedPoolOnlyRevivesForNewVersion guards the distinction between
+// a minutely steady-state resync and a deploy. An idle pool must remain at zero
+// while it already points at the active version, but a new version reusing that
+// pool must boot once so the deploy is verified.
+func TestAutoModeDrainedPoolOnlyRevivesForNewVersion(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	newVersion := func(name string) *core_v1alpha.AppVersion {
+		t.Helper()
+		ver := &core_v1alpha.AppVersion{
+			App:      app.ID,
+			Version:  name,
+			ImageUrl: "web:latest",
+			Config: core_v1alpha.Config{
+				Port: 8080,
+				Services: []core_v1alpha.Services{
+					{
+						Name: "web",
+						ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+							Mode:                "auto",
+							RequestsPerInstance: 10,
+							ScaleDownDelay:      "15m",
+						},
+					},
+				},
+			},
+		}
+		verID, createErr := server.Client.Create(ctx, name, ver)
+		require.NoError(t, createErr)
+		ver.ID = verID
+		return ver
+	}
+
+	v1 := newVersion("v1")
+	app.ActiveVersion = v1.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	launcher := newTestLauncher(log, server.EAC)
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+	poolID := pools[0].ID
+
+	// Simulate the autoscaler draining the current version after its idle delay.
+	_, err = server.EAC.Patch(ctx, []entity.Attr{
+		entity.Ref(entity.DBId, poolID),
+		entity.Int64(compute_v1alpha.SandboxPoolDesiredInstancesId, 0),
+	}, 0)
+	require.NoError(t, err)
+
+	// A resync of the same active version must preserve scale-to-zero.
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+	pools = listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+	assert.Equal(t, poolID, pools[0].ID)
+	assert.Equal(t, int64(0), pools[0].DesiredInstances,
+		"steady-state resync must not revive an idle pool")
+	assert.Equal(t, v1.ID, pools[0].SandboxSpec.Version)
+
+	// A real deploy with the same sandbox spec reuses the pool, but it must boot
+	// the new version once for verification.
+	v2 := newVersion("v2")
+	app.ActiveVersion = v2.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	pools = listAllPools(t, ctx, server)
+	require.Len(t, pools, 1, "same spec should reuse the drained pool")
+	assert.Equal(t, poolID, pools[0].ID)
+	assert.Equal(t, int64(1), pools[0].DesiredInstances,
+		"new version should revive the pool for deploy verification")
+	assert.Equal(t, v2.ID, pools[0].SandboxSpec.Version)
+	assert.Contains(t, pools[0].ReferencedByVersions, v1.ID)
+	assert.Contains(t, pools[0].ReferencedByVersions, v2.ID)
 }
 
 // Helper functions
@@ -4137,6 +4225,81 @@ func TestCreatePoolForVersionSerializesWithReconcile(t *testing.T) {
 	// Exactly one pool — no duplicate creation.
 	pools := listAllPools(t, ctx, server)
 	assert.Len(t, pools, 1, "should create exactly one pool")
+}
+
+// TestAddonAssociationHandlerUsesPerAppLock proves addon-driven reconciliation
+// shares the main launcher's per-app lock. It also guards that locking one app
+// does not prevent another app from reconciling on the second worker.
+func TestAddonAssociationHandlerUsesPerAppLock(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	lockedApp := &core_v1alpha.App{Project: entity.Id("project-1")}
+	lockedAppID, err := server.Client.Create(ctx, "locked-app", lockedApp)
+	require.NoError(t, err)
+	lockedApp.ID = lockedAppID
+
+	otherApp := &core_v1alpha.App{Project: entity.Id("project-1")}
+	otherAppID, err := server.Client.Create(ctx, "other-app", otherApp)
+	require.NoError(t, err)
+	otherApp.ID = otherAppID
+
+	launcher := newTestLauncher(log, server.EAC)
+	val, _ := launcher.appMu.LoadOrStore(lockedApp.ID, &sync.Mutex{})
+	mu := val.(*sync.Mutex)
+	mu.Lock()
+
+	assoc := &addon_v1alpha.AddonAssociation{
+		ID:     entity.Id("addon-association/test"),
+		App:    lockedApp.ID,
+		Status: "active",
+	}
+	assocEntity := entity.New(
+		entity.DBId, assoc.ID,
+		assoc.Encode,
+	)
+
+	handlerDone := make(chan error, 1)
+	go func() {
+		_, handlerErr := launcher.AddonAssociationHandler()(ctx, controller.Event{
+			Type:   controller.EventUpdated,
+			Id:     assoc.ID,
+			Entity: assocEntity,
+		})
+		handlerDone <- handlerErr
+	}()
+
+	select {
+	case handlerErr := <-handlerDone:
+		mu.Unlock()
+		require.NoError(t, handlerErr)
+		t.Fatal("addon handler bypassed the app reconciliation lock")
+	case <-time.After(100 * time.Millisecond):
+		// The addon path is blocked on lockedApp as expected.
+	}
+
+	otherDone := make(chan error, 1)
+	go func() {
+		otherDone <- launcher.Reconcile(ctx, otherApp, nil)
+	}()
+	select {
+	case otherErr := <-otherDone:
+		require.NoError(t, otherErr)
+	case <-time.After(time.Second):
+		mu.Unlock()
+		t.Fatal("one app's reconciliation lock blocked another app")
+	}
+
+	mu.Unlock()
+	select {
+	case handlerErr := <-handlerDone:
+		require.NoError(t, handlerErr)
+	case <-time.After(time.Second):
+		t.Fatal("addon handler did not resume after the app lock was released")
+	}
 }
 
 // TestReapSkipsServicesWithoutEnsuredReplacement guards the gate that keeps


### PR DESCRIPTION
The deployment launcher treated any reused pool at `desired_instances=0` as a fresh deploy. Its minutely resync kept cold-starting idle autoscale apps and waiting for readiness while duplicate events piled up until the controller queue filled.

This keeps scale-to-zero pools drained unless the pool is actually moving to a new version, preserving deploy verification without manufacturing work on every resync. Addon-triggered reconciles now use the same per-app lock, which lets the launcher safely run two workers so one slow deploy does not stall unrelated apps.

The deployment and coordinator packages pass, the locking coverage is clean under the race detector, and the addon integration packages pass serially.

Part of MIR-1391
