### PR TITLE
Keep coordinator RPC alive through graceful shutdown

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -506,8 +506,10 @@ func (c *Coordinator) ExposeWorkServices() error {
 	return nil
 }
 
-// Stop stops the coordinator and all managed controllers
-func (c *Coordinator) Stop() {
+// Stop first quiesces coordinator-owned background work, then drains the RPC
+// server. The RPC lifetime is separate from the boot lifetime so graph
+// cancellation cannot cut off dependent components while they are draining.
+func (c *Coordinator) Stop(ctx context.Context) error {
 	if c.cm != nil {
 		c.cm.Stop()
 	}
@@ -540,6 +542,10 @@ func (c *Coordinator) Stop() {
 			c.Log.Error("failed to close debug server", "error", err)
 		}
 	}
+	if c.state != nil {
+		return c.state.Shutdown(ctx)
+	}
+	return nil
 }
 
 const (
@@ -908,7 +914,7 @@ func (c *Coordinator) workloadAuthenticator() rpc.Authenticator {
 	return workloadidentity.NewAuthenticator(c.WorkloadIssuer, c.Log)
 }
 
-func (c *Coordinator) Start(ctx context.Context) error {
+func (c *Coordinator) Start(ctx context.Context) (retErr error) {
 	c.Log.Info("starting coordinator", "address", c.Address, "etcd_endpoints", c.EtcdEndpoints, "prefix", c.Prefix)
 
 	err := c.LoadCA(ctx)
@@ -1025,12 +1031,22 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	rpcOpts = append(rpcOpts, c.runnerTelemetryOptions()...)
 
-	rs, err := rpc.NewState(ctx, rpcOpts...)
+	// The boot graph cancels ctx before it enters reverse dependency order.
+	// Keep RPC alive across that cancellation so dependents such as the OCI
+	// registry can finish their final coordinator calls before Stop drains it.
+	rs, err := rpc.NewState(context.WithoutCancel(ctx), rpcOpts...)
 	if err != nil {
 		c.Log.Error("failed to create RPC server", "error", err)
 		return err
 	}
 	c.state = rs
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		_ = c.state.Close()
+		c.state = nil
+	}()
 
 	server := rs.Server()
 

--- a/components/coordinate/coordinator_test.go
+++ b/components/coordinate/coordinator_test.go
@@ -1,10 +1,12 @@
 package coordinate_test
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -41,13 +43,20 @@ func TestCoordinatorParse(t *testing.T) {
 		NoAuth:        true,
 	}
 
-	// Create contexts
+	// Keep request contexts independent so cancelling the boot lifetime below
+	// models Graph.Stop without cancelling the client call too.
+	bootCtx, cancelBoot := context.WithCancel(t.Context())
 	ctx := t.Context()
 
 	// Start coordinator in background
 	coord := coordinate.NewCoordinator(log, coordCfg)
-	err := coord.Start(ctx)
+	err := coord.Start(bootCtx)
 	r.NoError(err)
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, coord.Stop(shutdownCtx))
+	})
 
 	// Create RPC client to interact with coordinator
 	rs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
@@ -89,6 +98,17 @@ func TestCoordinatorParse(t *testing.T) {
 	enttest.EqualAttr(t, ent, entity.Id("dev.miren.core/metadata.name"), "nginx")
 	enttest.EqualAttr(t, ent, entity.Id("entity/kind"), types.Id("dev.miren.compute/kind.sandbox"))
 	enttest.EqualAttr(t, ent, entity.Id("entity/kind"), types.Id("dev.miren.core/kind.metadata"))
+
+	// Graph.Stop cancels the boot lifetime before it starts reverse-order stop
+	// hooks. The coordinator must remain available during that gap so dependent
+	// drains can make their final RPCs over an already-warmed connection.
+	cancelBoot()
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		_, err := eac.Parse(ctx, data)
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond)
+	}
 
 	/*
 		r.Equal(attrs[2].ID, entity.Id("dev.miren.sandbox/port"))

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -58,6 +58,11 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 	coord := coordinate.NewCoordinator(testDeps.Log, coordCfg)
 	err := coord.Start(ctx)
 	r.NoError(err)
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		r.NoError(coord.Stop(shutdownCtx))
+	}()
 
 	rcfg, err := coord.ServiceConfig()
 	r.NoError(err)

--- a/components/server/boot_coordinator.go
+++ b/components/server/boot_coordinator.go
@@ -113,9 +113,9 @@ func (b *coordinatorBoot) start(ctx context.Context, ipDiscovery ipDiscoveryBoot
 	return b.result, nil
 }
 
-func (b *coordinatorBoot) stop(context.Context) error {
+func (b *coordinatorBoot) stop(ctx context.Context) error {
 	if b.result.coordinator != nil {
-		b.result.coordinator.Stop()
+		return b.result.coordinator.Stop(ctx)
 	}
 	return nil
 }

--- a/pkg/rpc/message_tcp.go
+++ b/pkg/rpc/message_tcp.go
@@ -105,8 +105,9 @@ func (s *State) startTCPListener(ctx context.Context, addr string) error {
 	s.msgLn = ln
 
 	go func() {
-		<-ctx.Done()
-		_ = ln.Close()
+		if s.contextOwnsShutdown(ctx) {
+			_ = ln.Close()
+		}
 	}()
 
 	s.log.Info("starting tcp message listener", "addr", ln.Addr().String())

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -1185,6 +1185,10 @@ func (s *Server) runCallStream(ctx context.Context, cs *controlStream, mm Method
 	ctx = contextWithServerLifetime(ctx, s.state.top)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	if s.state.top != nil {
+		stop := context.AfterFunc(s.state.top, cancel)
+		defer stop()
+	}
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -15,6 +16,7 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/quic-go/quic-go"
@@ -115,15 +117,20 @@ func (s *StateCommon) audit() *slog.Logger {
 type State struct {
 	*StateCommon
 
+	cancel         context.CancelFunc
 	transport      *quic.Transport
 	localTransport *quic.Transport
 
 	defaultEndpoint string
 
-	server *Server
-	hs     *http3.Server
-	ws     *webtransport.Server
-	li     *quic.EarlyListener
+	server    *Server
+	hs        *http3.Server
+	ws        *webtransport.Server
+	li        *quic.EarlyListener
+	localHS   *http3.Server
+	localLI   *quic.EarlyListener
+	localLn   net.Listener
+	localPath string
 
 	httpSrv *http.Server
 	tcpLn   net.Listener
@@ -138,6 +145,13 @@ type State struct {
 	msgContact string
 
 	localMP *packet.PacketConnMultiplex
+
+	// explicitStop tells the context-owned cleanup goroutines that an explicit
+	// Shutdown or Close has taken ownership of teardown. In particular, this
+	// keeps a coordinator-owned lifetime cancellation from racing a second
+	// HTTP/3 Shutdown after the ordered boot stop has already drained it.
+	explicitStop     chan struct{}
+	explicitStopOnce sync.Once
 }
 
 // contactAddr returns the address embedded in capabilities this server mints,
@@ -479,10 +493,11 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 	if err := server.mountHTTPHandlers(so.httpHandlers); err != nil {
 		return nil, err
 	}
+	stateCtx, cancelState := context.WithCancel(ctx)
 
 	s := &State{
 		StateCommon: &StateCommon{
-			top:           ctx,
+			top:           stateCtx,
 			log:           so.log,
 			auditLog:      newAuditLogger(so.log),
 			certAuth:      newCertAuthDeduper(),
@@ -494,54 +509,62 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 			authorizer:    so.authorizer,
 		},
 
+		cancel:          cancelState,
 		defaultEndpoint: so.endpoint,
 		server:          server,
 		transport:       &quic.Transport{Conn: udpConn},
+		explicitStop:    make(chan struct{}),
 	}
 
 	s.qc = DefaultQUICConfig
 
-	err = s.startListener(ctx, &so)
+	err = s.startListener(stateCtx, &so)
 	if err != nil {
+		_ = s.Close()
 		return nil, err
 	}
 
-	err = s.setupLocal(ctx)
+	err = s.setupLocal(stateCtx)
 	if err != nil {
+		_ = s.Close()
 		return nil, err
 	}
 
 	if so.serverLocalAddr != "" {
-		err := s.startLocalListener(ctx, so.serverLocalAddr)
+		err := s.startLocalListener(stateCtx, so.serverLocalAddr)
 		if err != nil {
+			_ = s.Close()
 			return nil, err
 		}
 	}
 
 	if so.wsBindAddr != "" {
-		err := s.startWSListener(ctx, so.wsBindAddr)
+		err := s.startWSListener(stateCtx, so.wsBindAddr)
 		if err != nil {
+			_ = s.Close()
 			return nil, err
 		}
 	}
 
 	if so.tcpBindAddr != "" {
-		err := s.startTCPListener(ctx, so.tcpBindAddr)
+		err := s.startTCPListener(stateCtx, so.tcpBindAddr)
 		if err != nil {
+			_ = s.Close()
 			return nil, err
 		}
 	}
 
 	if so.restBindAddr != "" {
-		err := s.startRESTListener(ctx, so.restBindAddr)
+		err := s.startRESTListener(stateCtx, so.restBindAddr)
 		if err != nil {
+			_ = s.Close()
 			return nil, err
 		}
 	}
 
 	if so.memServerName != "" {
 		s.msgContact = "mem://" + so.memServerName
-		defaultMemRegistry.register(ctx, so.memServerName, s)
+		defaultMemRegistry.register(stateCtx, so.memServerName, s)
 	}
 
 	return s, nil
@@ -675,8 +698,9 @@ func (s *State) startListener(ctx context.Context, so *stateOptions) error {
 	s.server.ws = s.ws
 
 	go func() {
-		<-ctx.Done()
-		s.hs.Shutdown(context.Background())
+		if s.contextOwnsShutdown(ctx) {
+			_ = s.hs.Shutdown(context.Background())
+		}
 	}()
 
 	// Trigger webtransport server initialization by calling Serve with a stub PacketConn.
@@ -689,33 +713,144 @@ func (s *State) startListener(ctx context.Context, so *stateOptions) error {
 	return nil
 }
 
-func (s *State) Close() error {
-	s.li.Close()
+// Shutdown gracefully stops every network server owned by this State. Unlike
+// cancellation of the context passed to NewState, callers can place Shutdown
+// precisely in an ordered component teardown and give in-flight requests a
+// bounded drain window.
+func (s *State) Shutdown(ctx context.Context) error {
+	s.disableContextShutdown()
+	// Stop server-owned background work and streaming RPCs before asking the
+	// network servers to drain. Unary request contexts remain transport-owned,
+	// so in-flight calls can still finish during the graceful shutdown window.
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.localLn != nil {
+		_ = s.localLn.Close()
+	}
+
+	var (
+		errs []error
+		mu   sync.Mutex
+		wg   sync.WaitGroup
+	)
+	shutdown := func(fn func(context.Context) error) {
+		if fn == nil {
+			return
+		}
+		wg.Go(func() {
+			if err := fn(ctx); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+		})
+	}
+
 	if s.hs != nil {
-		s.hs.Close()
+		shutdown(s.hs.Shutdown)
+	}
+	if s.localHS != nil {
+		shutdown(s.localHS.Shutdown)
+	}
+	if s.httpSrv != nil {
+		shutdown(s.httpSrv.Shutdown)
+	}
+	if s.restSrv != nil {
+		shutdown(s.restSrv.Shutdown)
+	}
+	if s.msgLn != nil {
+		_ = s.msgLn.Close()
+	}
+
+	wg.Wait()
+	if s.li != nil {
+		_ = s.li.Close()
+	}
+	if s.localLI != nil {
+		_ = s.localLI.Close()
+	}
+	if s.localPath != "" {
+		_ = os.Remove(s.localPath)
+	}
+	if s.transport != nil && s.transport.Conn != nil {
+		_ = s.transport.Conn.Close()
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *State) Close() error {
+	s.disableContextShutdown()
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.li != nil {
+		_ = s.li.Close()
+	}
+	if s.hs != nil {
+		_ = s.hs.Close()
+	}
+
+	if s.localLI != nil {
+		_ = s.localLI.Close()
+	}
+	if s.localLn != nil {
+		_ = s.localLn.Close()
+	}
+	if s.localHS != nil {
+		_ = s.localHS.Close()
+	}
+	if s.localPath != "" {
+		_ = os.Remove(s.localPath)
 	}
 
 	if s.httpSrv != nil {
-		s.httpSrv.Close()
+		_ = s.httpSrv.Close()
 	}
 
 	if s.tcpLn != nil {
-		s.tcpLn.Close()
+		_ = s.tcpLn.Close()
 	}
 
 	if s.msgLn != nil {
-		s.msgLn.Close()
+		_ = s.msgLn.Close()
 	}
 
 	if s.restSrv != nil {
-		s.restSrv.Close()
+		_ = s.restSrv.Close()
 	}
 
 	if s.restLn != nil {
-		s.restLn.Close()
+		_ = s.restLn.Close()
 	}
 
 	return s.transport.Conn.Close()
+}
+
+func (s *State) disableContextShutdown() {
+	s.explicitStopOnce.Do(func() {
+		if s.explicitStop != nil {
+			close(s.explicitStop)
+		}
+	})
+}
+
+func (s *State) contextOwnsShutdown(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		// If explicit shutdown and context cancellation become ready together,
+		// the select above may choose either. Re-check ownership so cancellation
+		// never starts a duplicate shutdown after an explicit caller took it.
+		select {
+		case <-s.explicitStop:
+			return false
+		default:
+			return true
+		}
+	case <-s.explicitStop:
+		return false
+	}
 }
 
 func (s *State) Client(name string) (*NetworkClient, error) {

--- a/pkg/rpc/state_local.go
+++ b/pkg/rpc/state_local.go
@@ -104,6 +104,7 @@ func (s *State) startLocalListener(ctx context.Context, addr string) error {
 	if err != nil {
 		return err
 	}
+	s.localLn = li
 	os.Chmod(addr, 0777)
 
 	go func() {
@@ -151,11 +152,16 @@ func (s *State) startLocalListener(ctx context.Context, addr string) error {
 	}
 
 	subS.hs = serv
+	s.localHS = serv
+	s.localLI = ec
+	s.localPath = addr
 
 	go func() {
-		<-ctx.Done()
-		os.Remove(addr)
-		serv.Shutdown(context.Background())
+		if s.contextOwnsShutdown(ctx) {
+			_ = li.Close()
+			_ = os.Remove(addr)
+			_ = serv.Shutdown(context.Background())
+		}
 	}()
 
 	s.log.Debug("starting local listener", "addr", addr)

--- a/pkg/rpc/state_rest.go
+++ b/pkg/rpc/state_rest.go
@@ -50,8 +50,9 @@ func (s *State) startRESTListener(ctx context.Context, addr string) error {
 	s.restLn = tcpLn
 
 	go func() {
-		<-ctx.Done()
-		_ = srv.Shutdown(context.Background())
+		if s.contextOwnsShutdown(ctx) {
+			_ = srv.Shutdown(context.Background())
+		}
 	}()
 
 	s.log.Info("starting rest/tcp listener", "addr", tcpLn.Addr().String())

--- a/pkg/rpc/state_shutdown_test.go
+++ b/pkg/rpc/state_shutdown_test.go
@@ -1,0 +1,179 @@
+package rpc_test
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/example"
+	"miren.dev/runtime/pkg/rpc/stream"
+)
+
+type shutdownBlockingStream struct {
+	started chan struct{}
+}
+
+func (s *shutdownBlockingStream) Emit(ctx context.Context, _ *example.EmitTempsEmit) error {
+	close(s.started)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestStateShutdownDrainsActiveHTTP3Request(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	state, err := rpc.NewState(t.Context(),
+		rpc.WithSkipVerify,
+		rpc.WithHTTPHandler("GET /drain", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			close(requestStarted)
+			<-releaseRequest
+			_, _ = io.WriteString(w, "drained")
+		})),
+	)
+	require.NoError(t, err)
+
+	transport := &http3.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	t.Cleanup(func() { _ = transport.Close() })
+	client := &http.Client{Transport: transport}
+
+	type response struct {
+		body string
+		err  error
+	}
+	responseDone := make(chan response, 1)
+	go func() {
+		resp, err := client.Get("https://" + state.LoopbackAddr() + "/drain")
+		if err != nil {
+			responseDone <- response{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		responseDone <- response{body: string(body), err: err}
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request did not reach the server")
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), time.Second)
+	defer cancelShutdown()
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- state.Shutdown(shutdownCtx) }()
+
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("shutdown returned before the active request completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseRequest)
+	result := <-responseDone
+	require.NoError(t, result.err)
+	require.Equal(t, "drained", result.body)
+	require.NoError(t, <-shutdownDone)
+}
+
+func TestStateContextCancellationStillStopsHTTP3(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	state, err := rpc.NewState(ctx,
+		rpc.WithSkipVerify,
+		rpc.WithHTTPHandler("GET /probe", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = state.Close() })
+	url := "https://" + state.LoopbackAddr() + "/probe"
+
+	warmTransport := &http3.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	warmClient := &http.Client{Transport: warmTransport}
+	resp, err := warmClient.Get(url)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.NoError(t, warmTransport.Close())
+
+	cancel()
+	require.Eventually(t, func() bool {
+		transport := &http3.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		defer transport.Close()
+		requestCtx, cancelRequest := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancelRequest()
+		req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, url, nil)
+		if err != nil {
+			return false
+		}
+		resp, err := transport.RoundTrip(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		return err != nil
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestStateShutdownCancelsActiveHTTP3CallStreamsBeforeDrain(t *testing.T) {
+	streamHandler := &shutdownBlockingStream{started: make(chan struct{})}
+	serverState, err := rpc.NewState(t.Context(), rpc.WithSkipVerify)
+	require.NoError(t, err)
+	serverState.Server().ExposeValue("stream", example.AdaptEmitTemps(streamHandler))
+
+	clientState, err := rpc.NewState(t.Context(), rpc.WithSkipVerify)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientState.Close() })
+	client, err := clientState.Connect(serverState.LoopbackAddr(), "stream")
+	require.NoError(t, err)
+
+	callDone := make(chan error, 1)
+	go func() {
+		_, err := example.NewEmitTempsClient(client).Emit(t.Context(), stream.StreamRecv(func(float32) error {
+			return nil
+		}))
+		callDone <- err
+	}()
+
+	select {
+	case <-streamHandler.started:
+	case <-time.After(time.Second):
+		t.Fatal("streaming RPC did not reach the server")
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), time.Second)
+	defer cancelShutdown()
+	require.NoError(t, serverState.Shutdown(shutdownCtx))
+
+	select {
+	case err := <-callDone:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("streaming RPC remained active after shutdown")
+	}
+}
+
+func TestStateShutdownUnregistersMemServer(t *testing.T) {
+	name := "shutdown-" + t.Name()
+	serverState, err := rpc.NewState(t.Context(), rpc.WithSkipVerify, rpc.WithMemServer(name))
+	require.NoError(t, err)
+	serverState.Server().ExposeValue("meter", example.AdaptMeter(&exampleMeter{temp: 42}))
+
+	clientState, err := rpc.NewState(t.Context(), rpc.WithSkipVerify)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientState.Close() })
+	_, err = clientState.Connect("mem://"+name, "meter")
+	require.NoError(t, err)
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), time.Second)
+	defer cancelShutdown()
+	require.NoError(t, serverState.Shutdown(shutdownCtx))
+	require.Eventually(t, func() bool {
+		_, err := clientState.Connect("mem://"+name, "meter")
+		return err != nil
+	}, time.Second, time.Millisecond)
+}

--- a/pkg/rpc/state_ws.go
+++ b/pkg/rpc/state_ws.go
@@ -42,8 +42,9 @@ func (s *State) startWSListener(ctx context.Context, addr string) error {
 	s.tcpLn = tcpLn
 
 	go func() {
-		<-ctx.Done()
-		_ = srv.Shutdown(context.Background())
+		if s.contextOwnsShutdown(ctx) {
+			_ = srv.Shutdown(context.Background())
+		}
 	}()
 
 	s.log.Info("starting websocket/tcp listener", "addr", tcpLn.Addr().String())

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -85,6 +85,18 @@ func TestServer(t *testing.T) error {
 		ctxCancel()
 		return err
 	}
+	// Cleanup runs in reverse registration order. Register the coordinator now
+	// so the HTTP and OCI servers below drain before coordinator RPC shuts down.
+	t.Cleanup(func() {
+		log.Info("Stopping coordinator and controllers")
+		ctxCancel()
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := co.Stop(shutdownCtx); err != nil {
+			log.Error("failed to stop coordinator", "error", err)
+		}
+	})
 
 	// Create subnet from test deps
 	subnet := testDeps.Subnet
@@ -241,15 +253,6 @@ func TestServer(t *testing.T) error {
 	hm.SetHost("cluster.local", regAddr)
 
 	log.Info("Starting test server", "address", optsAddress, "runner_id", optsRunnerId)
-
-	// Register cleanup for running components
-	t.Cleanup(func() {
-		log.Info("Stopping coordinator and controllers")
-		co.Stop()
-
-		log.Info("Canceling context to stop all components")
-		ctxCancel()
-	})
 
 	// Wait in a separate goroutine for any errors from the errgroup
 	eg.Go(func() error {

--- a/pkg/testutils/reg.go
+++ b/pkg/testutils/reg.go
@@ -265,6 +265,11 @@ func NewTestDeps() (*TestDeps, func()) {
 
 	cleanup := func() {
 		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := coord.Stop(shutdownCtx); err != nil {
+			log.Error("failed to stop test coordinator", "error", err)
+		}
+		shutdownCancel()
 
 		if netServ != nil {
 			netServ.ShutdownAll()


### PR DESCRIPTION
The boot graph cancels the coordinator context before dependent components stop. That could send HTTP/3 GOAWAY while the OCI registry was making its final entity RPC for a manifest push, turning an otherwise clean shutdown into a 500.

This gives RPC state an explicit bounded shutdown and invokes it from the coordinator’s ordered stop hook. Server-owned streaming calls are canceled before the drain so long-lived watches from distributed runners cannot consume the deadline, while unary requests remain free to finish. Context-driven cleanup remains in place for standalone RPC state users.

The affected RPC, coordinator, server, registry, and runner suites pass after rebasing onto current main. The RPC package also passes under the race detector.

Closes MIR-1748