### PR TITLE
Add miren top for cluster-wide resource usage

### DIFF
--- a/api/compute/compute.go
+++ b/api/compute/compute.go
@@ -16,3 +16,55 @@ func SandboxActive(status compute_v1alpha.SandboxStatus) bool {
 func SandboxDead(status compute_v1alpha.SandboxStatus) bool {
 	return status == compute_v1alpha.STOPPED || status == compute_v1alpha.DEAD
 }
+
+// Kind classifies what a sandbox is for.
+type Kind string
+
+const (
+	// KindApp is a sandbox running a deployed application service.
+	KindApp Kind = "app"
+	// KindAddon is managed infrastructure an app depends on, such as a
+	// dedicated database, or a shared server no single app owns.
+	KindAddon Kind = "addon"
+	// KindRun is a one-off task run.
+	KindRun Kind = "run"
+	// KindOther is a sandbox none of the above describe.
+	KindOther Kind = "other"
+)
+
+// SandboxKind separates a user's own services from the platform running
+// underneath them, so a usage report can tell a web process from the database
+// sitting behind it.
+//
+// This lives here rather than beside either caller because two of them need the
+// same answer: the sandbox controller stamps it onto every metric series, and
+// the usage service filters rows by it. When they were separate implementations
+// they disagreed, which meant a --kind filter could select rows whose metrics
+// said something else.
+//
+// The classification is read back out of attributes the sandbox already
+// carries rather than stored on it: appspec stamps miren.stage=app-run on
+// deployed services and the run controller stamps miren.stage=run, while the
+// addon framework passes the addon's own labels through as log attributes and
+// sets no stage.
+func SandboxKind(sb *compute_v1alpha.Sandbox) Kind {
+	var stage string
+
+	for _, lbl := range sb.Spec.LogAttribute {
+		switch lbl.Key {
+		case "addon":
+			return KindAddon
+		case "miren.stage":
+			stage = lbl.Value
+		}
+	}
+
+	switch stage {
+	case "run":
+		return KindRun
+	case "app-run":
+		return KindApp
+	}
+
+	return KindOther
+}

--- a/api/compute/compute_test.go
+++ b/api/compute/compute_test.go
@@ -3,7 +3,10 @@ package compute
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/pkg/entity/types"
 )
 
 func TestSandboxStatusCoverage(t *testing.T) {
@@ -29,4 +32,31 @@ func TestSandboxStatusCoverage(t *testing.T) {
 			t.Errorf("status %q is both Active and Dead", s)
 		}
 	}
+}
+
+// SandboxKind separates a user's own services from the platform underneath
+// them. It lives in this package because the sandbox controller and the usage
+// service both need the same answer; when they each had their own copy the two
+// disagreed, so a --kind filter could select rows whose metrics said otherwise.
+func TestSandboxKind(t *testing.T) {
+	withAttrs := func(kv ...string) *compute_v1alpha.Sandbox {
+		sb := &compute_v1alpha.Sandbox{}
+		sb.Spec.LogAttribute = types.LabelSet(kv...)
+		return sb
+	}
+
+	r := require.New(t)
+
+	r.Equal(KindApp, SandboxKind(withAttrs("miren.stage", "app-run", "miren.service", "web")),
+		"appspec stamps app-run on every deployed service")
+	r.Equal(KindRun, SandboxKind(withAttrs("miren.stage", "run", "miren.task", "migrate")),
+		"the run controller stamps run on one-off tasks")
+
+	// Addon servers set no stage at all, so the addon label is the only signal
+	// that a sandbox is infrastructure rather than someone's app.
+	r.Equal(KindAddon, SandboxKind(withAttrs("addon", "postgresql", "app", "myapp")),
+		"an addon is infrastructure even though it carries an app label")
+
+	r.Equal(KindOther, SandboxKind(withAttrs()),
+		"an unclassifiable sandbox is reported as such rather than assumed to be an app")
 }

--- a/api/usage/rpc.yml
+++ b/api/usage/rpc.yml
@@ -1,0 +1,881 @@
+apiVersion: miren.dev/rpc/v1
+kind: IDL
+
+# Cluster-wide resource usage for sandboxes and nodes.
+#
+# This is deliberately separate from api/metric, which is a node-local,
+# cgroup-shaped probe exposed on every runner. This one is cluster-scoped and
+# query-shaped, and lives only on the coordinator. Different audience, different
+# auth surface.
+#
+# Two conventions run through everything below.
+#
+# Values are in base units and never pre-formatted: CPU in cores (which may
+# exceed 1.0 for a multi-core sandbox), memory in bytes, rates per second.
+# Rendering "178%" or "3.2 GiB" is the caller's job, because a billing job and a
+# dashboard want the number, not the string.
+#
+# Missing data is reported, not faked. A sandbox with no samples in the window
+# comes back with zeroed usage and stale=true rather than being dropped, and a
+# node whose capacity is unknown reports zero capacity rather than a plausible
+# guess. Operators reach for this when something is already broken, so a partial
+# answer that says which part is missing beats a clean answer that quietly
+# omits the broken host.
+
+imports:
+  standard:
+    path: ../../pkg/rpc/standard/standard.yml
+    import: miren.dev/runtime/pkg/rpc/standard
+
+types:
+  - type: UsageWindow
+    doc: |
+      The time span a measurement covers, as the server resolved it. Every
+      response carries one so a caller that asked for a default can tell what it
+      actually got, and so a chart can label its axis without guessing.
+    fields:
+      - name: start
+        type: standard.Timestamp
+        index: 0
+      - name: end
+        type: standard.Timestamp
+        index: 1
+      - name: aggregate
+        type: string
+        index: 2
+        doc: How the window was collapsed to one number - avg, max, min or last
+      - name: step_seconds
+        type: int64
+        index: 3
+        doc: Resolution of any returned series; 0 when no series was requested
+
+  - type: SandboxRef
+    doc: |
+      Identity of one sandbox. Both ids and names are present throughout: an
+      automated caller joins on the id, which is stable, while a human-facing
+      one prints the name, which is not.
+    fields:
+      - name: sandbox
+        type: string
+        index: 0
+        doc: Sandbox entity id
+      - name: sandbox_short_id
+        type: string
+        index: 1
+      - name: app
+        type: string
+        index: 2
+        doc: App name; empty for sandboxes that belong to no app
+      - name: app_id
+        type: string
+        index: 3
+      - name: service
+        type: string
+        index: 4
+        doc: Service name within the app, such as web or worker
+      - name: pool
+        type: string
+        index: 5
+        doc: Sandbox pool entity id; the unit a replacement happens within
+      - name: version
+        type: string
+        index: 6
+      - name: version_short_id
+        type: string
+        index: 7
+      - name: node
+        type: string
+        index: 8
+        doc: Node entity id the sandbox is scheduled on
+      - name: node_name
+        type: string
+        index: 9
+      - name: runner_id
+        type: string
+        index: 10
+      - name: kind
+        type: string
+        index: 11
+        doc: |
+          What sort of sandbox this is: app for a deployed service, addon for
+          managed infrastructure such as a database, run for a one-off task, or
+          other when it cannot be classified. This is what separates a user's
+          own load from the platform running underneath it.
+      - name: status
+        type: string
+        index: 12
+      - name: started_at
+        type: standard.Timestamp
+        index: 13
+
+  - type: CpuUsage
+    doc: |
+      CPU measured in cores, not percent: a sandbox using two full cores reads
+      2.0 whether the host has 4 cores or 64. percent_of_node is the same figure
+      expressed against the host it runs on, which is the number that says
+      whether it matters.
+
+      Throttling and configured limits are deliberately absent. Miren sets no
+      per-sandbox CPU ceiling today, so both would be a constant zero, and a
+      zero here would read as "never throttled" rather than "never measured".
+      They belong here when limits do.
+    fields:
+      - name: cores
+        type: float64
+        index: 0
+      - name: percent_of_node
+        type: float64
+        index: 1
+        doc: Zero when the node's core count is unknown, not when usage is zero
+
+  - type: MemoryUsage
+    doc: |
+      percent_of_node, not percent_of_limit: Miren sets no per-sandbox memory
+      ceiling, so the host is the only meaningful denominator.
+
+      Peak, swap and OOM-kill counts are not here. The collector reads them from
+      the cgroup but does not publish them, so the service has nothing to report
+      and a zero would be a measurement nobody took.
+    fields:
+      - name: bytes
+        type: int64
+        index: 0
+      - name: percent_of_node
+        type: float64
+        index: 1
+
+  - type: SandboxUsage
+    doc: One row of a top-style listing.
+    fields:
+      - name: ref
+        type: SandboxRef
+        index: 0
+      - name: cpu
+        type: CpuUsage
+        index: 1
+      - name: memory
+        type: MemoryUsage
+        index: 2
+      - name: measured_at
+        type: standard.Timestamp
+        index: 3
+      - name: stale
+        type: bool
+        index: 4
+        doc: |
+          True when no samples landed in the window. The row is still returned,
+          with zeroed usage, because a sandbox that stopped reporting is itself
+          the finding - dropping it would make a broken metrics pipeline look
+          like an idle cluster.
+
+  - type: ResourceTotals
+    doc: A rolled-up slice of resource use, in the same units as a single sandbox.
+    fields:
+      - name: cpu_cores
+        type: float64
+        index: 0
+      - name: cpu_percent
+        type: float64
+        index: 1
+      - name: memory_bytes
+        type: int64
+        index: 2
+      - name: memory_percent
+        type: float64
+        index: 3
+
+  - type: NodeCapacity
+    doc: What a host physically has. Zero means unknown, not absent.
+    fields:
+      - name: cpu_cores
+        type: float64
+        index: 0
+      - name: memory_bytes
+        type: int64
+        index: 1
+      - name: storage_bytes
+        type: int64
+        index: 2
+
+  - type: NodeUsage
+    doc: |
+      One host, split four ways. total is the whole machine; sandboxes is the
+      sum of everything running in a sandbox cgroup; system is the remainder,
+      which is the container runtime, the image builder, the registry, the log
+      pipeline and miren itself. That remainder is the answer to "the node is
+      hot but no app is" and is why all four are reported rather than just the
+      two that were measured directly.
+
+      system is floored at zero. Page-cache accounting means the parts do not
+      reconcile exactly, and a negative number would be worse than a rounded one.
+    fields:
+      - name: node
+        type: string
+        index: 0
+        doc: Node entity id
+      - name: node_name
+        type: string
+        index: 1
+      - name: runner_id
+        type: string
+        index: 2
+      - name: role
+        type: string
+        index: 3
+        doc: coordinator or runner
+      - name: status
+        type: string
+        index: 4
+      - name: scheduling
+        type: string
+        index: 5
+        doc: Empty or schedulable when accepting work, cordoned when parked
+      - name: capacity
+        type: NodeCapacity
+        index: 6
+      - name: total
+        type: ResourceTotals
+        index: 7
+      - name: sandboxes
+        type: ResourceTotals
+        index: 8
+      - name: system
+        type: ResourceTotals
+        index: 9
+      - name: load1
+        type: float64
+        index: 10
+      - name: load5
+        type: float64
+        index: 11
+      - name: load15
+        type: float64
+        index: 12
+      - name: storage_used_bytes
+        type: int64
+        index: 13
+      - name: sandbox_count
+        type: int64
+        index: 14
+      - name: running_sandbox_count
+        type: int64
+        index: 15
+      - name: measured_at
+        type: standard.Timestamp
+        index: 16
+      - name: stale
+        type: bool
+        index: 17
+        doc: |
+          True when this host reported no samples in the window. A runner that
+          has stopped reporting still gets a row, because its silence is the
+          finding.
+
+  - type: AppUsage
+    doc: |
+      One app's total resource use, summed across every sandbox that belongs to
+      it, split into the app's own services and the addons it depends on.
+
+      The split is the point. A dedicated database exists because the app asked
+      for it, so a capacity or cost question wants it counted; a "what is my code
+      doing" question does not. Reporting both means one number answers either,
+      and "2.1 cores, 1.6 of it Postgres" is a far more actionable sentence than
+      "2.1 cores".
+    fields:
+      - name: app
+        type: string
+        index: 0
+        doc: App name, which is how metrics label it
+      - name: app_id
+        type: string
+        index: 1
+        doc: App entity id; empty for an app seen only in metrics
+      - name: total
+        type: ResourceTotals
+        index: 2
+        doc: services plus addons
+      - name: services
+        type: ResourceTotals
+        index: 3
+        doc: The app's own deployed sandboxes
+      - name: addons
+        type: ResourceTotals
+        index: 4
+        doc: Managed infrastructure this app owns, such as a dedicated database
+      - name: sandbox_count
+        type: int64
+        index: 5
+      - name: service_count
+        type: int64
+        index: 6
+      - name: addon_count
+        type: int64
+        index: 7
+      - name: stale
+        type: bool
+        index: 8
+        doc: |
+          True when no sandbox of this app reported a sample in the window. The
+          app still gets a row: an app that has stopped reporting is a finding,
+          and dropping it would make a broken telemetry pipeline look like an
+          idle cluster.
+
+  - type: Selector
+    doc: |
+      What to include in a listing. Every field is optional, and an empty field
+      means unconstrained.
+
+      Grouping these into one type is not decoration. As loose parameters they
+      were six adjacent strings on the generated client, where transposing app
+      and service compiled cleanly and silently returned the wrong rows.
+    fields:
+      - name: app
+        type: string
+        index: 0
+      - name: service
+        type: string
+        index: 1
+      - name: node
+        type: string
+        index: 2
+        doc: Node entity id, runner id, or node name - whichever the caller has
+      - name: kind
+        type: string
+        index: 3
+        doc: app, addon, run or other
+      - name: status
+        type: string
+        index: 4
+      - name: include_system
+        type: bool
+        index: 5
+        doc: |
+          Include addon and platform sandboxes. Off by default so a listing
+          answers "what are my apps doing".
+
+          Setting kind explicitly overrides this: asking for kind=addon is a
+          direct request and is honoured whether or not include_system is set.
+      - name: include_addons
+        type: bool
+        index: 6
+        doc: |
+          App rollups only. Whether an app's dedicated addons count toward its
+          total. Unset means yes -- a database exists because the app asked for
+          it -- and the addons block reports zero rather than being hidden when
+          this is false.
+
+  - type: Window
+    doc: |
+      The span to measure over, and how to collapse it to one number.
+
+      start and end are absolute so there is exactly one way to express a
+      window. An unset start means the server default of one minute back from
+      end; an unset end means now.
+    fields:
+      - name: start
+        type: standard.Timestamp
+        index: 0
+      - name: end
+        type: standard.Timestamp
+        index: 1
+      - name: aggregate
+        type: string
+        index: 2
+        doc: |
+          avg (default), max, min or last. max is what finds a spike that has
+          already passed, which a live view cannot. An unrecognized value falls
+          back to avg rather than failing the call.
+
+  - type: Ordering
+    doc: How to sort and truncate a listing. Sorting happens server-side, because
+      a limit is only meaningful against a known order.
+    fields:
+      - name: sort
+        type: string
+        index: 0
+        doc: |
+          Sandboxes: cpu, memory, app, service or node.
+          Nodes: cpu, memory, load, sandboxes or name.
+          Apps: cpu, memory, sandboxes or name.
+      - name: order
+        type: string
+        index: 1
+        doc: desc (default) or asc
+      - name: limit
+        type: int32
+        index: 2
+        doc: 0 means no limit
+
+  - type: DetailOptions
+    doc: What to include alongside one sandbox's current usage.
+    fields:
+      - name: include_series
+        type: bool
+        index: 0
+      - name: include_containers
+        type: bool
+        index: 1
+        doc: |
+          Per-container breakdown. The stored series sum a sandbox's containers
+          before they are written, so this needs the live per-node probe and is
+          not yet served from the metrics store.
+      - name: step_seconds
+        type: int64
+        index: 2
+        doc: Resolution of any returned series; 0 derives one from the window
+
+  - type: ContainerUsage
+    doc: |
+      Per-container breakdown within one sandbox. A sandbox is usually one app
+      container plus a pause container, but a sandbox with sidecars can have
+      several, and the top-level figures sum across all of them.
+    fields:
+      - name: name
+        type: string
+        index: 0
+        doc: Container name; empty for the sandbox's pause container
+      - name: cpu
+        type: CpuUsage
+        index: 1
+      - name: memory
+        type: MemoryUsage
+        index: 2
+
+  - type: UsagePoint
+    fields:
+      - name: at
+        type: standard.Timestamp
+        index: 0
+      - name: value
+        type: float64
+        index: 1
+
+  - type: UsageSeries
+    doc: One metric over time, for charting a sandbox's recent history.
+    fields:
+      - name: metric
+        type: string
+        index: 0
+        doc: cpu_cores or memory_bytes
+      - name: points
+        type: list
+        element: "*UsagePoint"
+        index: 1
+
+  - type: SandboxExit
+    doc: Why a sandbox stopped, when it has.
+    fields:
+      - name: code
+        type: int32
+        index: 0
+      - name: at
+        type: standard.Timestamp
+        index: 1
+      - name: container
+        type: string
+        index: 2
+        doc: Which container exited first and so took the sandbox down
+
+  - type: CrashLoopState
+    doc: |
+      The pool's view of repeated failure, which is where a crash loop is
+      visible: Miren replaces a failed sandbox rather than restarting it, so no
+      single sandbox accumulates a restart count. consecutive_crashes resets on
+      a successful start, so a non-zero value means this service is failing
+      right now rather than having failed once last week.
+    fields:
+      - name: consecutive_crashes
+        type: int32
+        index: 0
+      - name: last_crash_at
+        type: standard.Timestamp
+        index: 1
+      - name: cooldown_until
+        type: standard.Timestamp
+        index: 2
+        doc: When set and in the future, the pool is deliberately not restarting
+
+interfaces:
+  - name: ResourceUsage
+    doc: |
+      Cluster-wide resource usage. Exposed only on the coordinator, which is the
+      only place that holds a view of every node.
+
+      This interface carries two shapes of the same four questions, because the
+      two callers want opposite things.
+
+      The verb-prefixed methods -- listSandboxes, getSandbox, listNodes,
+      listApps -- are the RPC surface. They take grouped types, so a Go caller
+      names what it is passing and the compiler catches a transposition.
+
+      The http-prefixed methods are the same six questions asked over plain
+      HTTP GET. They take flat scalars, because a query string names every
+      argument at the call site and a nested object cannot bind to one at all,
+      and they accept a duration string (since=1h) rather than timestamps,
+      because that is what a URL should look like. A Go caller should reach for
+      the RPC form instead; these exist for the URL.
+
+      Both shapes run the same implementation. If they ever disagree that is a
+      bug, not a feature.
+    http:
+      prefix: /api/v1
+    methods:
+      # NOTE: parameter and result lists are positionally encoded on the wire,
+      # so they are append-only. Never insert or reorder an entry; a new field
+      # goes on the end or it breaks every deployed client.
+
+      # --- RPC surface: grouped types, no HTTP binding ---
+
+      - name: listSandboxes
+        doc: One row per live sandbox, cluster-wide.
+        parameters:
+          - name: selector
+            type: Selector
+          - name: window
+            type: Window
+          - name: ordering
+            type: Ordering
+        results:
+          - name: sandboxes
+            type: list
+            element: SandboxUsage
+          - name: window
+            type: UsageWindow
+          - name: cluster
+            type: ResourceTotals
+            doc: Sum across every matching row, before any limit was applied
+          - name: total_count
+            type: int32
+            doc: Rows matching the selector, which exceeds len(sandboxes) when limited
+          - name: collected_at
+            type: standard.Timestamp
+          - name: warnings
+            type: list
+            element: string
+            doc: |
+              Problems that degraded the answer without invalidating it, such as
+              a node that reported nothing. Populated instead of failing the
+              call, because a partial answer naming its own gaps is more use to
+              someone debugging than an error.
+
+      - name: getSandbox
+        doc: One sandbox in detail, optionally with its recent history.
+        parameters:
+          - name: sandbox
+            type: string
+          - name: window
+            type: Window
+          - name: options
+            type: DetailOptions
+        results:
+          - name: usage
+            type: SandboxUsage
+          - name: containers
+            type: list
+            element: ContainerUsage
+          - name: series
+            type: list
+            element: UsageSeries
+          - name: exit
+            type: SandboxExit
+          - name: crash_loop
+            type: CrashLoopState
+          - name: image
+            type: string
+          - name: restart_policy
+            type: string
+          - name: window
+            type: UsageWindow
+          - name: warnings
+            type: list
+            element: string
+
+      - name: listNodes
+        doc: |
+          One row per host, each split into sandbox and system use. This is the
+          first question of an investigation - which machine is hot - and the
+          split answers the second, whether it is an app's fault.
+        parameters:
+          - name: selector
+            type: Selector
+          - name: window
+            type: Window
+          - name: ordering
+            type: Ordering
+        results:
+          - name: nodes
+            type: list
+            element: NodeUsage
+          - name: cluster
+            type: ResourceTotals
+          - name: capacity
+            type: NodeCapacity
+            doc: Sum of every reporting node's capacity
+          - name: window
+            type: UsageWindow
+          - name: collected_at
+            type: standard.Timestamp
+          - name: warnings
+            type: list
+            element: string
+
+      - name: listApps
+        doc: |
+          One row per app, summed across all of its sandboxes. This answers
+          "what is app X costing me" without the caller having to add up rows
+          itself, and without it having to know that an app's database is a
+          separate sandbox.
+        parameters:
+          - name: selector
+            type: Selector
+          - name: window
+            type: Window
+          - name: ordering
+            type: Ordering
+        results:
+          - name: apps
+            type: list
+            element: AppUsage
+          - name: cluster
+            type: ResourceTotals
+          - name: total_count
+            type: int32
+          - name: window
+            type: UsageWindow
+          - name: collected_at
+            type: standard.Timestamp
+          - name: warnings
+            type: list
+            element: string
+
+      # --- REST surface: flat scalars, GET bindings ---
+      #
+      # since and until are duration strings here ("30s", "5m", "1h") rather
+      # than timestamps: a URL should read as a URL. Everything else is a
+      # scalar because only scalars bind to a query parameter.
+
+      - name: httpListSandboxes
+        rest_only: true
+        doc: |
+          GET /api/v1/usage/sandboxes?app=web&sort=cpu&limit=20
+
+          The HTTP form of listSandboxes.
+        http:
+          get: /usage/sandboxes
+        parameters:
+          - name: app
+            type: string
+          - name: service
+            type: string
+          - name: node
+            type: string
+          - name: kind
+            type: string
+          - name: status
+            type: string
+          - name: include_system
+            type: bool
+          - name: since
+            type: string
+            doc: How far back to measure, as a duration ("1h"). Defaults to 1m.
+          - name: until
+            type: string
+            doc: How long ago the window ends, as a duration ("10m"). Defaults to now.
+          - name: aggregate
+            type: string
+          - name: sort
+            type: string
+          - name: order
+            type: string
+          - name: limit
+            type: int32
+        results:
+          - name: sandboxes
+            type: list
+            element: SandboxUsage
+          - name: window
+            type: UsageWindow
+          - name: cluster
+            type: ResourceTotals
+          - name: total_count
+            type: int32
+          - name: collected_at
+            type: standard.Timestamp
+          - name: warnings
+            type: list
+            element: string
+
+      - name: httpGetSandbox
+        rest_only: true
+        doc: GET /api/v1/usage/sandboxes/{sandbox}
+        http:
+          get: /usage/sandboxes/{sandbox}
+        parameters:
+          - name: sandbox
+            type: string
+          - name: since
+            type: string
+          - name: until
+            type: string
+          - name: aggregate
+            type: string
+          - name: series
+            type: bool
+            doc: Include CPU and memory history
+          - name: containers
+            type: bool
+          - name: step
+            type: string
+            doc: Series resolution as a duration ("30s"); derived from the window when empty
+        results:
+          - name: usage
+            type: SandboxUsage
+          - name: containers
+            type: list
+            element: ContainerUsage
+          - name: series
+            type: list
+            element: UsageSeries
+          - name: exit
+            type: SandboxExit
+          - name: crash_loop
+            type: CrashLoopState
+          - name: image
+            type: string
+          - name: restart_policy
+            type: string
+          - name: window
+            type: UsageWindow
+          - name: warnings
+            type: list
+            element: string
+
+      - name: httpListNodes
+        rest_only: true
+        doc: GET /api/v1/usage/nodes?sort=cpu
+        http:
+          get: /usage/nodes
+        parameters:
+          - name: since
+            type: string
+          - name: until
+            type: string
+          - name: aggregate
+            type: string
+          - name: sort
+            type: string
+          - name: order
+            type: string
+          - name: limit
+            type: int32
+        results:
+          - name: nodes
+            type: list
+            element: NodeUsage
+          - name: cluster
+            type: ResourceTotals
+          - name: capacity
+            type: NodeCapacity
+          - name: window
+            type: UsageWindow
+          - name: collected_at
+            type: standard.Timestamp
+          - name: warnings
+            type: list
+            element: string
+
+      - name: httpGetNode
+        rest_only: true
+        doc: |
+          GET /api/v1/usage/nodes/{node}
+
+          One host, addressed by entity id, runner id, or name.
+        http:
+          get: /usage/nodes/{node}
+        parameters:
+          - name: node
+            type: string
+          - name: since
+            type: string
+          - name: until
+            type: string
+          - name: aggregate
+            type: string
+        results:
+          - name: usage
+            type: NodeUsage
+          - name: window
+            type: UsageWindow
+          - name: warnings
+            type: list
+            element: string
+
+      - name: httpListApps
+        rest_only: true
+        doc: GET /api/v1/usage/apps?sort=cpu
+        http:
+          get: /usage/apps
+        parameters:
+          - name: since
+            type: string
+          - name: until
+            type: string
+          - name: aggregate
+            type: string
+          - name: sort
+            type: string
+          - name: order
+            type: string
+          - name: limit
+            type: int32
+          - name: addons
+            type: bool
+            doc: |
+              Count each app's dedicated addons toward its total. Absent means
+              yes; pass addons=false for the app's own code alone.
+          - name: node
+            type: string
+            doc: Count only the sandboxes on this node, for a per-host breakdown
+        results:
+          - name: apps
+            type: list
+            element: AppUsage
+          - name: cluster
+            type: ResourceTotals
+          - name: total_count
+            type: int32
+          - name: window
+            type: UsageWindow
+          - name: collected_at
+            type: standard.Timestamp
+          - name: warnings
+            type: list
+            element: string
+
+      - name: httpGetApp
+        rest_only: true
+        doc: |
+          GET /api/v1/usage/apps/{app}
+
+          One app's total, split into its own services and the addons it owns.
+        http:
+          get: /usage/apps/{app}
+        parameters:
+          - name: app
+            type: string
+          - name: since
+            type: string
+          - name: until
+            type: string
+          - name: aggregate
+            type: string
+          - name: addons
+            type: bool
+        results:
+          - name: usage
+            type: AppUsage
+          - name: window
+            type: UsageWindow
+          - name: warnings
+            type: list
+            element: string

--- a/api/usage/rpc.yml
+++ b/api/usage/rpc.yml
@@ -394,9 +394,12 @@ types:
         type: string
         index: 0
         doc: |
-          Sandboxes: cpu, memory, app, service or node.
+          Sandboxes: cpu, memory, name, app, service or node.
           Nodes: cpu, memory, load, sandboxes or name.
           Apps: cpu, memory, sandboxes or name.
+
+          A usage key sorts busiest first and a name sorts A to Z unless order
+          says otherwise.
       - name: order
         type: string
         index: 1

--- a/api/usage/usage.go
+++ b/api/usage/usage.go
@@ -1,0 +1,4 @@
+package usage
+
+//go:generate mkdir -p usage_v1alpha
+//go:generate go run ../../pkg/rpc/cmd/rpcgen -pkg usage_v1alpha -input rpc.yml -output usage_v1alpha/rpc.gen.go

--- a/api/usage/usage_v1alpha/rpc.gen.go
+++ b/api/usage/usage_v1alpha/rpc.gen.go
@@ -1,0 +1,4084 @@
+package usage_v1alpha
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+
+	"github.com/fxamacker/cbor/v2"
+	rpc "miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+type usageWindowData struct {
+	Start       *standard.Timestamp `cbor:"0,keyasint,omitempty" json:"start,omitempty"`
+	End         *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"end,omitempty"`
+	Aggregate   *string             `cbor:"2,keyasint,omitempty" json:"aggregate,omitempty"`
+	StepSeconds *int64              `cbor:"3,keyasint,omitempty" json:"step_seconds,omitempty"`
+}
+
+type UsageWindow struct {
+	data usageWindowData
+}
+
+func (v *UsageWindow) HasStart() bool {
+	return v.data.Start != nil
+}
+
+func (v *UsageWindow) Start() *standard.Timestamp {
+	return v.data.Start
+}
+
+func (v *UsageWindow) SetStart(start *standard.Timestamp) {
+	v.data.Start = start
+}
+
+func (v *UsageWindow) HasEnd() bool {
+	return v.data.End != nil
+}
+
+func (v *UsageWindow) End() *standard.Timestamp {
+	return v.data.End
+}
+
+func (v *UsageWindow) SetEnd(end *standard.Timestamp) {
+	v.data.End = end
+}
+
+func (v *UsageWindow) HasAggregate() bool {
+	return v.data.Aggregate != nil
+}
+
+func (v *UsageWindow) Aggregate() string {
+	if v.data.Aggregate == nil {
+		return ""
+	}
+	return *v.data.Aggregate
+}
+
+func (v *UsageWindow) SetAggregate(aggregate string) {
+	v.data.Aggregate = &aggregate
+}
+
+func (v *UsageWindow) HasStepSeconds() bool {
+	return v.data.StepSeconds != nil
+}
+
+func (v *UsageWindow) StepSeconds() int64 {
+	if v.data.StepSeconds == nil {
+		return 0
+	}
+	return *v.data.StepSeconds
+}
+
+func (v *UsageWindow) SetStepSeconds(step_seconds int64) {
+	v.data.StepSeconds = &step_seconds
+}
+
+func (v *UsageWindow) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *UsageWindow) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *UsageWindow) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *UsageWindow) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type sandboxRefData struct {
+	Sandbox        *string             `cbor:"0,keyasint,omitempty" json:"sandbox,omitempty"`
+	SandboxShortId *string             `cbor:"1,keyasint,omitempty" json:"sandbox_short_id,omitempty"`
+	App            *string             `cbor:"2,keyasint,omitempty" json:"app,omitempty"`
+	AppId          *string             `cbor:"3,keyasint,omitempty" json:"app_id,omitempty"`
+	Service        *string             `cbor:"4,keyasint,omitempty" json:"service,omitempty"`
+	Pool           *string             `cbor:"5,keyasint,omitempty" json:"pool,omitempty"`
+	Version        *string             `cbor:"6,keyasint,omitempty" json:"version,omitempty"`
+	VersionShortId *string             `cbor:"7,keyasint,omitempty" json:"version_short_id,omitempty"`
+	Node           *string             `cbor:"8,keyasint,omitempty" json:"node,omitempty"`
+	NodeName       *string             `cbor:"9,keyasint,omitempty" json:"node_name,omitempty"`
+	RunnerId       *string             `cbor:"10,keyasint,omitempty" json:"runner_id,omitempty"`
+	Kind           *string             `cbor:"11,keyasint,omitempty" json:"kind,omitempty"`
+	Status         *string             `cbor:"12,keyasint,omitempty" json:"status,omitempty"`
+	StartedAt      *standard.Timestamp `cbor:"13,keyasint,omitempty" json:"started_at,omitempty"`
+}
+
+type SandboxRef struct {
+	data sandboxRefData
+}
+
+func (v *SandboxRef) HasSandbox() bool {
+	return v.data.Sandbox != nil
+}
+
+func (v *SandboxRef) Sandbox() string {
+	if v.data.Sandbox == nil {
+		return ""
+	}
+	return *v.data.Sandbox
+}
+
+func (v *SandboxRef) SetSandbox(sandbox string) {
+	v.data.Sandbox = &sandbox
+}
+
+func (v *SandboxRef) HasSandboxShortId() bool {
+	return v.data.SandboxShortId != nil
+}
+
+func (v *SandboxRef) SandboxShortId() string {
+	if v.data.SandboxShortId == nil {
+		return ""
+	}
+	return *v.data.SandboxShortId
+}
+
+func (v *SandboxRef) SetSandboxShortId(sandbox_short_id string) {
+	v.data.SandboxShortId = &sandbox_short_id
+}
+
+func (v *SandboxRef) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *SandboxRef) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *SandboxRef) SetApp(app string) {
+	v.data.App = &app
+}
+
+func (v *SandboxRef) HasAppId() bool {
+	return v.data.AppId != nil
+}
+
+func (v *SandboxRef) AppId() string {
+	if v.data.AppId == nil {
+		return ""
+	}
+	return *v.data.AppId
+}
+
+func (v *SandboxRef) SetAppId(app_id string) {
+	v.data.AppId = &app_id
+}
+
+func (v *SandboxRef) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *SandboxRef) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *SandboxRef) SetService(service string) {
+	v.data.Service = &service
+}
+
+func (v *SandboxRef) HasPool() bool {
+	return v.data.Pool != nil
+}
+
+func (v *SandboxRef) Pool() string {
+	if v.data.Pool == nil {
+		return ""
+	}
+	return *v.data.Pool
+}
+
+func (v *SandboxRef) SetPool(pool string) {
+	v.data.Pool = &pool
+}
+
+func (v *SandboxRef) HasVersion() bool {
+	return v.data.Version != nil
+}
+
+func (v *SandboxRef) Version() string {
+	if v.data.Version == nil {
+		return ""
+	}
+	return *v.data.Version
+}
+
+func (v *SandboxRef) SetVersion(version string) {
+	v.data.Version = &version
+}
+
+func (v *SandboxRef) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *SandboxRef) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
+}
+
+func (v *SandboxRef) SetVersionShortId(version_short_id string) {
+	v.data.VersionShortId = &version_short_id
+}
+
+func (v *SandboxRef) HasNode() bool {
+	return v.data.Node != nil
+}
+
+func (v *SandboxRef) Node() string {
+	if v.data.Node == nil {
+		return ""
+	}
+	return *v.data.Node
+}
+
+func (v *SandboxRef) SetNode(node string) {
+	v.data.Node = &node
+}
+
+func (v *SandboxRef) HasNodeName() bool {
+	return v.data.NodeName != nil
+}
+
+func (v *SandboxRef) NodeName() string {
+	if v.data.NodeName == nil {
+		return ""
+	}
+	return *v.data.NodeName
+}
+
+func (v *SandboxRef) SetNodeName(node_name string) {
+	v.data.NodeName = &node_name
+}
+
+func (v *SandboxRef) HasRunnerId() bool {
+	return v.data.RunnerId != nil
+}
+
+func (v *SandboxRef) RunnerId() string {
+	if v.data.RunnerId == nil {
+		return ""
+	}
+	return *v.data.RunnerId
+}
+
+func (v *SandboxRef) SetRunnerId(runner_id string) {
+	v.data.RunnerId = &runner_id
+}
+
+func (v *SandboxRef) HasKind() bool {
+	return v.data.Kind != nil
+}
+
+func (v *SandboxRef) Kind() string {
+	if v.data.Kind == nil {
+		return ""
+	}
+	return *v.data.Kind
+}
+
+func (v *SandboxRef) SetKind(kind string) {
+	v.data.Kind = &kind
+}
+
+func (v *SandboxRef) HasStatus() bool {
+	return v.data.Status != nil
+}
+
+func (v *SandboxRef) Status() string {
+	if v.data.Status == nil {
+		return ""
+	}
+	return *v.data.Status
+}
+
+func (v *SandboxRef) SetStatus(status string) {
+	v.data.Status = &status
+}
+
+func (v *SandboxRef) HasStartedAt() bool {
+	return v.data.StartedAt != nil
+}
+
+func (v *SandboxRef) StartedAt() *standard.Timestamp {
+	return v.data.StartedAt
+}
+
+func (v *SandboxRef) SetStartedAt(started_at *standard.Timestamp) {
+	v.data.StartedAt = started_at
+}
+
+func (v *SandboxRef) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SandboxRef) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SandboxRef) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SandboxRef) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type cpuUsageData struct {
+	Cores         *float64 `cbor:"0,keyasint,omitempty" json:"cores,omitempty"`
+	PercentOfNode *float64 `cbor:"1,keyasint,omitempty" json:"percent_of_node,omitempty"`
+}
+
+type CpuUsage struct {
+	data cpuUsageData
+}
+
+func (v *CpuUsage) HasCores() bool {
+	return v.data.Cores != nil
+}
+
+func (v *CpuUsage) Cores() float64 {
+	if v.data.Cores == nil {
+		return 0
+	}
+	return *v.data.Cores
+}
+
+func (v *CpuUsage) SetCores(cores float64) {
+	v.data.Cores = &cores
+}
+
+func (v *CpuUsage) HasPercentOfNode() bool {
+	return v.data.PercentOfNode != nil
+}
+
+func (v *CpuUsage) PercentOfNode() float64 {
+	if v.data.PercentOfNode == nil {
+		return 0
+	}
+	return *v.data.PercentOfNode
+}
+
+func (v *CpuUsage) SetPercentOfNode(percent_of_node float64) {
+	v.data.PercentOfNode = &percent_of_node
+}
+
+func (v *CpuUsage) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CpuUsage) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CpuUsage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CpuUsage) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type memoryUsageData struct {
+	Bytes         *int64   `cbor:"0,keyasint,omitempty" json:"bytes,omitempty"`
+	PercentOfNode *float64 `cbor:"1,keyasint,omitempty" json:"percent_of_node,omitempty"`
+}
+
+type MemoryUsage struct {
+	data memoryUsageData
+}
+
+func (v *MemoryUsage) HasBytes() bool {
+	return v.data.Bytes != nil
+}
+
+func (v *MemoryUsage) Bytes() int64 {
+	if v.data.Bytes == nil {
+		return 0
+	}
+	return *v.data.Bytes
+}
+
+func (v *MemoryUsage) SetBytes(bytes int64) {
+	v.data.Bytes = &bytes
+}
+
+func (v *MemoryUsage) HasPercentOfNode() bool {
+	return v.data.PercentOfNode != nil
+}
+
+func (v *MemoryUsage) PercentOfNode() float64 {
+	if v.data.PercentOfNode == nil {
+		return 0
+	}
+	return *v.data.PercentOfNode
+}
+
+func (v *MemoryUsage) SetPercentOfNode(percent_of_node float64) {
+	v.data.PercentOfNode = &percent_of_node
+}
+
+func (v *MemoryUsage) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *MemoryUsage) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *MemoryUsage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *MemoryUsage) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type sandboxUsageData struct {
+	Ref        *SandboxRef         `cbor:"0,keyasint,omitempty" json:"ref,omitempty"`
+	Cpu        *CpuUsage           `cbor:"1,keyasint,omitempty" json:"cpu,omitempty"`
+	Memory     *MemoryUsage        `cbor:"2,keyasint,omitempty" json:"memory,omitempty"`
+	MeasuredAt *standard.Timestamp `cbor:"3,keyasint,omitempty" json:"measured_at,omitempty"`
+	Stale      *bool               `cbor:"4,keyasint,omitempty" json:"stale,omitempty"`
+}
+
+type SandboxUsage struct {
+	data sandboxUsageData
+}
+
+func (v *SandboxUsage) HasRef() bool {
+	return v.data.Ref != nil
+}
+
+func (v *SandboxUsage) Ref() *SandboxRef {
+	return v.data.Ref
+}
+
+func (v *SandboxUsage) SetRef(ref *SandboxRef) {
+	v.data.Ref = ref
+}
+
+func (v *SandboxUsage) HasCpu() bool {
+	return v.data.Cpu != nil
+}
+
+func (v *SandboxUsage) Cpu() *CpuUsage {
+	return v.data.Cpu
+}
+
+func (v *SandboxUsage) SetCpu(cpu *CpuUsage) {
+	v.data.Cpu = cpu
+}
+
+func (v *SandboxUsage) HasMemory() bool {
+	return v.data.Memory != nil
+}
+
+func (v *SandboxUsage) Memory() *MemoryUsage {
+	return v.data.Memory
+}
+
+func (v *SandboxUsage) SetMemory(memory *MemoryUsage) {
+	v.data.Memory = memory
+}
+
+func (v *SandboxUsage) HasMeasuredAt() bool {
+	return v.data.MeasuredAt != nil
+}
+
+func (v *SandboxUsage) MeasuredAt() *standard.Timestamp {
+	return v.data.MeasuredAt
+}
+
+func (v *SandboxUsage) SetMeasuredAt(measured_at *standard.Timestamp) {
+	v.data.MeasuredAt = measured_at
+}
+
+func (v *SandboxUsage) HasStale() bool {
+	return v.data.Stale != nil
+}
+
+func (v *SandboxUsage) Stale() bool {
+	if v.data.Stale == nil {
+		return false
+	}
+	return *v.data.Stale
+}
+
+func (v *SandboxUsage) SetStale(stale bool) {
+	v.data.Stale = &stale
+}
+
+func (v *SandboxUsage) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SandboxUsage) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SandboxUsage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SandboxUsage) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceTotalsData struct {
+	CpuCores      *float64 `cbor:"0,keyasint,omitempty" json:"cpu_cores,omitempty"`
+	CpuPercent    *float64 `cbor:"1,keyasint,omitempty" json:"cpu_percent,omitempty"`
+	MemoryBytes   *int64   `cbor:"2,keyasint,omitempty" json:"memory_bytes,omitempty"`
+	MemoryPercent *float64 `cbor:"3,keyasint,omitempty" json:"memory_percent,omitempty"`
+}
+
+type ResourceTotals struct {
+	data resourceTotalsData
+}
+
+func (v *ResourceTotals) HasCpuCores() bool {
+	return v.data.CpuCores != nil
+}
+
+func (v *ResourceTotals) CpuCores() float64 {
+	if v.data.CpuCores == nil {
+		return 0
+	}
+	return *v.data.CpuCores
+}
+
+func (v *ResourceTotals) SetCpuCores(cpu_cores float64) {
+	v.data.CpuCores = &cpu_cores
+}
+
+func (v *ResourceTotals) HasCpuPercent() bool {
+	return v.data.CpuPercent != nil
+}
+
+func (v *ResourceTotals) CpuPercent() float64 {
+	if v.data.CpuPercent == nil {
+		return 0
+	}
+	return *v.data.CpuPercent
+}
+
+func (v *ResourceTotals) SetCpuPercent(cpu_percent float64) {
+	v.data.CpuPercent = &cpu_percent
+}
+
+func (v *ResourceTotals) HasMemoryBytes() bool {
+	return v.data.MemoryBytes != nil
+}
+
+func (v *ResourceTotals) MemoryBytes() int64 {
+	if v.data.MemoryBytes == nil {
+		return 0
+	}
+	return *v.data.MemoryBytes
+}
+
+func (v *ResourceTotals) SetMemoryBytes(memory_bytes int64) {
+	v.data.MemoryBytes = &memory_bytes
+}
+
+func (v *ResourceTotals) HasMemoryPercent() bool {
+	return v.data.MemoryPercent != nil
+}
+
+func (v *ResourceTotals) MemoryPercent() float64 {
+	if v.data.MemoryPercent == nil {
+		return 0
+	}
+	return *v.data.MemoryPercent
+}
+
+func (v *ResourceTotals) SetMemoryPercent(memory_percent float64) {
+	v.data.MemoryPercent = &memory_percent
+}
+
+func (v *ResourceTotals) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceTotals) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceTotals) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceTotals) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type nodeCapacityData struct {
+	CpuCores     *float64 `cbor:"0,keyasint,omitempty" json:"cpu_cores,omitempty"`
+	MemoryBytes  *int64   `cbor:"1,keyasint,omitempty" json:"memory_bytes,omitempty"`
+	StorageBytes *int64   `cbor:"2,keyasint,omitempty" json:"storage_bytes,omitempty"`
+}
+
+type NodeCapacity struct {
+	data nodeCapacityData
+}
+
+func (v *NodeCapacity) HasCpuCores() bool {
+	return v.data.CpuCores != nil
+}
+
+func (v *NodeCapacity) CpuCores() float64 {
+	if v.data.CpuCores == nil {
+		return 0
+	}
+	return *v.data.CpuCores
+}
+
+func (v *NodeCapacity) SetCpuCores(cpu_cores float64) {
+	v.data.CpuCores = &cpu_cores
+}
+
+func (v *NodeCapacity) HasMemoryBytes() bool {
+	return v.data.MemoryBytes != nil
+}
+
+func (v *NodeCapacity) MemoryBytes() int64 {
+	if v.data.MemoryBytes == nil {
+		return 0
+	}
+	return *v.data.MemoryBytes
+}
+
+func (v *NodeCapacity) SetMemoryBytes(memory_bytes int64) {
+	v.data.MemoryBytes = &memory_bytes
+}
+
+func (v *NodeCapacity) HasStorageBytes() bool {
+	return v.data.StorageBytes != nil
+}
+
+func (v *NodeCapacity) StorageBytes() int64 {
+	if v.data.StorageBytes == nil {
+		return 0
+	}
+	return *v.data.StorageBytes
+}
+
+func (v *NodeCapacity) SetStorageBytes(storage_bytes int64) {
+	v.data.StorageBytes = &storage_bytes
+}
+
+func (v *NodeCapacity) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *NodeCapacity) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *NodeCapacity) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *NodeCapacity) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type nodeUsageData struct {
+	Node                *string             `cbor:"0,keyasint,omitempty" json:"node,omitempty"`
+	NodeName            *string             `cbor:"1,keyasint,omitempty" json:"node_name,omitempty"`
+	RunnerId            *string             `cbor:"2,keyasint,omitempty" json:"runner_id,omitempty"`
+	Role                *string             `cbor:"3,keyasint,omitempty" json:"role,omitempty"`
+	Status              *string             `cbor:"4,keyasint,omitempty" json:"status,omitempty"`
+	Scheduling          *string             `cbor:"5,keyasint,omitempty" json:"scheduling,omitempty"`
+	Capacity            *NodeCapacity       `cbor:"6,keyasint,omitempty" json:"capacity,omitempty"`
+	Total               *ResourceTotals     `cbor:"7,keyasint,omitempty" json:"total,omitempty"`
+	Sandboxes           *ResourceTotals     `cbor:"8,keyasint,omitempty" json:"sandboxes,omitempty"`
+	System              *ResourceTotals     `cbor:"9,keyasint,omitempty" json:"system,omitempty"`
+	Load1               *float64            `cbor:"10,keyasint,omitempty" json:"load1,omitempty"`
+	Load5               *float64            `cbor:"11,keyasint,omitempty" json:"load5,omitempty"`
+	Load15              *float64            `cbor:"12,keyasint,omitempty" json:"load15,omitempty"`
+	StorageUsedBytes    *int64              `cbor:"13,keyasint,omitempty" json:"storage_used_bytes,omitempty"`
+	SandboxCount        *int64              `cbor:"14,keyasint,omitempty" json:"sandbox_count,omitempty"`
+	RunningSandboxCount *int64              `cbor:"15,keyasint,omitempty" json:"running_sandbox_count,omitempty"`
+	MeasuredAt          *standard.Timestamp `cbor:"16,keyasint,omitempty" json:"measured_at,omitempty"`
+	Stale               *bool               `cbor:"17,keyasint,omitempty" json:"stale,omitempty"`
+}
+
+type NodeUsage struct {
+	data nodeUsageData
+}
+
+func (v *NodeUsage) HasNode() bool {
+	return v.data.Node != nil
+}
+
+func (v *NodeUsage) Node() string {
+	if v.data.Node == nil {
+		return ""
+	}
+	return *v.data.Node
+}
+
+func (v *NodeUsage) SetNode(node string) {
+	v.data.Node = &node
+}
+
+func (v *NodeUsage) HasNodeName() bool {
+	return v.data.NodeName != nil
+}
+
+func (v *NodeUsage) NodeName() string {
+	if v.data.NodeName == nil {
+		return ""
+	}
+	return *v.data.NodeName
+}
+
+func (v *NodeUsage) SetNodeName(node_name string) {
+	v.data.NodeName = &node_name
+}
+
+func (v *NodeUsage) HasRunnerId() bool {
+	return v.data.RunnerId != nil
+}
+
+func (v *NodeUsage) RunnerId() string {
+	if v.data.RunnerId == nil {
+		return ""
+	}
+	return *v.data.RunnerId
+}
+
+func (v *NodeUsage) SetRunnerId(runner_id string) {
+	v.data.RunnerId = &runner_id
+}
+
+func (v *NodeUsage) HasRole() bool {
+	return v.data.Role != nil
+}
+
+func (v *NodeUsage) Role() string {
+	if v.data.Role == nil {
+		return ""
+	}
+	return *v.data.Role
+}
+
+func (v *NodeUsage) SetRole(role string) {
+	v.data.Role = &role
+}
+
+func (v *NodeUsage) HasStatus() bool {
+	return v.data.Status != nil
+}
+
+func (v *NodeUsage) Status() string {
+	if v.data.Status == nil {
+		return ""
+	}
+	return *v.data.Status
+}
+
+func (v *NodeUsage) SetStatus(status string) {
+	v.data.Status = &status
+}
+
+func (v *NodeUsage) HasScheduling() bool {
+	return v.data.Scheduling != nil
+}
+
+func (v *NodeUsage) Scheduling() string {
+	if v.data.Scheduling == nil {
+		return ""
+	}
+	return *v.data.Scheduling
+}
+
+func (v *NodeUsage) SetScheduling(scheduling string) {
+	v.data.Scheduling = &scheduling
+}
+
+func (v *NodeUsage) HasCapacity() bool {
+	return v.data.Capacity != nil
+}
+
+func (v *NodeUsage) Capacity() *NodeCapacity {
+	return v.data.Capacity
+}
+
+func (v *NodeUsage) SetCapacity(capacity *NodeCapacity) {
+	v.data.Capacity = capacity
+}
+
+func (v *NodeUsage) HasTotal() bool {
+	return v.data.Total != nil
+}
+
+func (v *NodeUsage) Total() *ResourceTotals {
+	return v.data.Total
+}
+
+func (v *NodeUsage) SetTotal(total *ResourceTotals) {
+	v.data.Total = total
+}
+
+func (v *NodeUsage) HasSandboxes() bool {
+	return v.data.Sandboxes != nil
+}
+
+func (v *NodeUsage) Sandboxes() *ResourceTotals {
+	return v.data.Sandboxes
+}
+
+func (v *NodeUsage) SetSandboxes(sandboxes *ResourceTotals) {
+	v.data.Sandboxes = sandboxes
+}
+
+func (v *NodeUsage) HasSystem() bool {
+	return v.data.System != nil
+}
+
+func (v *NodeUsage) System() *ResourceTotals {
+	return v.data.System
+}
+
+func (v *NodeUsage) SetSystem(system *ResourceTotals) {
+	v.data.System = system
+}
+
+func (v *NodeUsage) HasLoad1() bool {
+	return v.data.Load1 != nil
+}
+
+func (v *NodeUsage) Load1() float64 {
+	if v.data.Load1 == nil {
+		return 0
+	}
+	return *v.data.Load1
+}
+
+func (v *NodeUsage) SetLoad1(load1 float64) {
+	v.data.Load1 = &load1
+}
+
+func (v *NodeUsage) HasLoad5() bool {
+	return v.data.Load5 != nil
+}
+
+func (v *NodeUsage) Load5() float64 {
+	if v.data.Load5 == nil {
+		return 0
+	}
+	return *v.data.Load5
+}
+
+func (v *NodeUsage) SetLoad5(load5 float64) {
+	v.data.Load5 = &load5
+}
+
+func (v *NodeUsage) HasLoad15() bool {
+	return v.data.Load15 != nil
+}
+
+func (v *NodeUsage) Load15() float64 {
+	if v.data.Load15 == nil {
+		return 0
+	}
+	return *v.data.Load15
+}
+
+func (v *NodeUsage) SetLoad15(load15 float64) {
+	v.data.Load15 = &load15
+}
+
+func (v *NodeUsage) HasStorageUsedBytes() bool {
+	return v.data.StorageUsedBytes != nil
+}
+
+func (v *NodeUsage) StorageUsedBytes() int64 {
+	if v.data.StorageUsedBytes == nil {
+		return 0
+	}
+	return *v.data.StorageUsedBytes
+}
+
+func (v *NodeUsage) SetStorageUsedBytes(storage_used_bytes int64) {
+	v.data.StorageUsedBytes = &storage_used_bytes
+}
+
+func (v *NodeUsage) HasSandboxCount() bool {
+	return v.data.SandboxCount != nil
+}
+
+func (v *NodeUsage) SandboxCount() int64 {
+	if v.data.SandboxCount == nil {
+		return 0
+	}
+	return *v.data.SandboxCount
+}
+
+func (v *NodeUsage) SetSandboxCount(sandbox_count int64) {
+	v.data.SandboxCount = &sandbox_count
+}
+
+func (v *NodeUsage) HasRunningSandboxCount() bool {
+	return v.data.RunningSandboxCount != nil
+}
+
+func (v *NodeUsage) RunningSandboxCount() int64 {
+	if v.data.RunningSandboxCount == nil {
+		return 0
+	}
+	return *v.data.RunningSandboxCount
+}
+
+func (v *NodeUsage) SetRunningSandboxCount(running_sandbox_count int64) {
+	v.data.RunningSandboxCount = &running_sandbox_count
+}
+
+func (v *NodeUsage) HasMeasuredAt() bool {
+	return v.data.MeasuredAt != nil
+}
+
+func (v *NodeUsage) MeasuredAt() *standard.Timestamp {
+	return v.data.MeasuredAt
+}
+
+func (v *NodeUsage) SetMeasuredAt(measured_at *standard.Timestamp) {
+	v.data.MeasuredAt = measured_at
+}
+
+func (v *NodeUsage) HasStale() bool {
+	return v.data.Stale != nil
+}
+
+func (v *NodeUsage) Stale() bool {
+	if v.data.Stale == nil {
+		return false
+	}
+	return *v.data.Stale
+}
+
+func (v *NodeUsage) SetStale(stale bool) {
+	v.data.Stale = &stale
+}
+
+func (v *NodeUsage) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *NodeUsage) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *NodeUsage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *NodeUsage) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type appUsageData struct {
+	App          *string         `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	AppId        *string         `cbor:"1,keyasint,omitempty" json:"app_id,omitempty"`
+	Total        *ResourceTotals `cbor:"2,keyasint,omitempty" json:"total,omitempty"`
+	Services     *ResourceTotals `cbor:"3,keyasint,omitempty" json:"services,omitempty"`
+	Addons       *ResourceTotals `cbor:"4,keyasint,omitempty" json:"addons,omitempty"`
+	SandboxCount *int64          `cbor:"5,keyasint,omitempty" json:"sandbox_count,omitempty"`
+	ServiceCount *int64          `cbor:"6,keyasint,omitempty" json:"service_count,omitempty"`
+	AddonCount   *int64          `cbor:"7,keyasint,omitempty" json:"addon_count,omitempty"`
+	Stale        *bool           `cbor:"8,keyasint,omitempty" json:"stale,omitempty"`
+}
+
+type AppUsage struct {
+	data appUsageData
+}
+
+func (v *AppUsage) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *AppUsage) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *AppUsage) SetApp(app string) {
+	v.data.App = &app
+}
+
+func (v *AppUsage) HasAppId() bool {
+	return v.data.AppId != nil
+}
+
+func (v *AppUsage) AppId() string {
+	if v.data.AppId == nil {
+		return ""
+	}
+	return *v.data.AppId
+}
+
+func (v *AppUsage) SetAppId(app_id string) {
+	v.data.AppId = &app_id
+}
+
+func (v *AppUsage) HasTotal() bool {
+	return v.data.Total != nil
+}
+
+func (v *AppUsage) Total() *ResourceTotals {
+	return v.data.Total
+}
+
+func (v *AppUsage) SetTotal(total *ResourceTotals) {
+	v.data.Total = total
+}
+
+func (v *AppUsage) HasServices() bool {
+	return v.data.Services != nil
+}
+
+func (v *AppUsage) Services() *ResourceTotals {
+	return v.data.Services
+}
+
+func (v *AppUsage) SetServices(services *ResourceTotals) {
+	v.data.Services = services
+}
+
+func (v *AppUsage) HasAddons() bool {
+	return v.data.Addons != nil
+}
+
+func (v *AppUsage) Addons() *ResourceTotals {
+	return v.data.Addons
+}
+
+func (v *AppUsage) SetAddons(addons *ResourceTotals) {
+	v.data.Addons = addons
+}
+
+func (v *AppUsage) HasSandboxCount() bool {
+	return v.data.SandboxCount != nil
+}
+
+func (v *AppUsage) SandboxCount() int64 {
+	if v.data.SandboxCount == nil {
+		return 0
+	}
+	return *v.data.SandboxCount
+}
+
+func (v *AppUsage) SetSandboxCount(sandbox_count int64) {
+	v.data.SandboxCount = &sandbox_count
+}
+
+func (v *AppUsage) HasServiceCount() bool {
+	return v.data.ServiceCount != nil
+}
+
+func (v *AppUsage) ServiceCount() int64 {
+	if v.data.ServiceCount == nil {
+		return 0
+	}
+	return *v.data.ServiceCount
+}
+
+func (v *AppUsage) SetServiceCount(service_count int64) {
+	v.data.ServiceCount = &service_count
+}
+
+func (v *AppUsage) HasAddonCount() bool {
+	return v.data.AddonCount != nil
+}
+
+func (v *AppUsage) AddonCount() int64 {
+	if v.data.AddonCount == nil {
+		return 0
+	}
+	return *v.data.AddonCount
+}
+
+func (v *AppUsage) SetAddonCount(addon_count int64) {
+	v.data.AddonCount = &addon_count
+}
+
+func (v *AppUsage) HasStale() bool {
+	return v.data.Stale != nil
+}
+
+func (v *AppUsage) Stale() bool {
+	if v.data.Stale == nil {
+		return false
+	}
+	return *v.data.Stale
+}
+
+func (v *AppUsage) SetStale(stale bool) {
+	v.data.Stale = &stale
+}
+
+func (v *AppUsage) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *AppUsage) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *AppUsage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *AppUsage) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type selectorData struct {
+	App           *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	Service       *string `cbor:"1,keyasint,omitempty" json:"service,omitempty"`
+	Node          *string `cbor:"2,keyasint,omitempty" json:"node,omitempty"`
+	Kind          *string `cbor:"3,keyasint,omitempty" json:"kind,omitempty"`
+	Status        *string `cbor:"4,keyasint,omitempty" json:"status,omitempty"`
+	IncludeSystem *bool   `cbor:"5,keyasint,omitempty" json:"include_system,omitempty"`
+	IncludeAddons *bool   `cbor:"6,keyasint,omitempty" json:"include_addons,omitempty"`
+}
+
+type Selector struct {
+	data selectorData
+}
+
+func (v *Selector) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *Selector) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *Selector) SetApp(app string) {
+	v.data.App = &app
+}
+
+func (v *Selector) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *Selector) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *Selector) SetService(service string) {
+	v.data.Service = &service
+}
+
+func (v *Selector) HasNode() bool {
+	return v.data.Node != nil
+}
+
+func (v *Selector) Node() string {
+	if v.data.Node == nil {
+		return ""
+	}
+	return *v.data.Node
+}
+
+func (v *Selector) SetNode(node string) {
+	v.data.Node = &node
+}
+
+func (v *Selector) HasKind() bool {
+	return v.data.Kind != nil
+}
+
+func (v *Selector) Kind() string {
+	if v.data.Kind == nil {
+		return ""
+	}
+	return *v.data.Kind
+}
+
+func (v *Selector) SetKind(kind string) {
+	v.data.Kind = &kind
+}
+
+func (v *Selector) HasStatus() bool {
+	return v.data.Status != nil
+}
+
+func (v *Selector) Status() string {
+	if v.data.Status == nil {
+		return ""
+	}
+	return *v.data.Status
+}
+
+func (v *Selector) SetStatus(status string) {
+	v.data.Status = &status
+}
+
+func (v *Selector) HasIncludeSystem() bool {
+	return v.data.IncludeSystem != nil
+}
+
+func (v *Selector) IncludeSystem() bool {
+	if v.data.IncludeSystem == nil {
+		return false
+	}
+	return *v.data.IncludeSystem
+}
+
+func (v *Selector) SetIncludeSystem(include_system bool) {
+	v.data.IncludeSystem = &include_system
+}
+
+func (v *Selector) HasIncludeAddons() bool {
+	return v.data.IncludeAddons != nil
+}
+
+func (v *Selector) IncludeAddons() bool {
+	if v.data.IncludeAddons == nil {
+		return false
+	}
+	return *v.data.IncludeAddons
+}
+
+func (v *Selector) SetIncludeAddons(include_addons bool) {
+	v.data.IncludeAddons = &include_addons
+}
+
+func (v *Selector) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *Selector) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *Selector) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *Selector) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type windowData struct {
+	Start     *standard.Timestamp `cbor:"0,keyasint,omitempty" json:"start,omitempty"`
+	End       *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"end,omitempty"`
+	Aggregate *string             `cbor:"2,keyasint,omitempty" json:"aggregate,omitempty"`
+}
+
+type Window struct {
+	data windowData
+}
+
+func (v *Window) HasStart() bool {
+	return v.data.Start != nil
+}
+
+func (v *Window) Start() *standard.Timestamp {
+	return v.data.Start
+}
+
+func (v *Window) SetStart(start *standard.Timestamp) {
+	v.data.Start = start
+}
+
+func (v *Window) HasEnd() bool {
+	return v.data.End != nil
+}
+
+func (v *Window) End() *standard.Timestamp {
+	return v.data.End
+}
+
+func (v *Window) SetEnd(end *standard.Timestamp) {
+	v.data.End = end
+}
+
+func (v *Window) HasAggregate() bool {
+	return v.data.Aggregate != nil
+}
+
+func (v *Window) Aggregate() string {
+	if v.data.Aggregate == nil {
+		return ""
+	}
+	return *v.data.Aggregate
+}
+
+func (v *Window) SetAggregate(aggregate string) {
+	v.data.Aggregate = &aggregate
+}
+
+func (v *Window) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *Window) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *Window) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *Window) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type orderingData struct {
+	Sort  *string `cbor:"0,keyasint,omitempty" json:"sort,omitempty"`
+	Order *string `cbor:"1,keyasint,omitempty" json:"order,omitempty"`
+	Limit *int32  `cbor:"2,keyasint,omitempty" json:"limit,omitempty"`
+}
+
+type Ordering struct {
+	data orderingData
+}
+
+func (v *Ordering) HasSort() bool {
+	return v.data.Sort != nil
+}
+
+func (v *Ordering) Sort() string {
+	if v.data.Sort == nil {
+		return ""
+	}
+	return *v.data.Sort
+}
+
+func (v *Ordering) SetSort(sort string) {
+	v.data.Sort = &sort
+}
+
+func (v *Ordering) HasOrder() bool {
+	return v.data.Order != nil
+}
+
+func (v *Ordering) Order() string {
+	if v.data.Order == nil {
+		return ""
+	}
+	return *v.data.Order
+}
+
+func (v *Ordering) SetOrder(order string) {
+	v.data.Order = &order
+}
+
+func (v *Ordering) HasLimit() bool {
+	return v.data.Limit != nil
+}
+
+func (v *Ordering) Limit() int32 {
+	if v.data.Limit == nil {
+		return 0
+	}
+	return *v.data.Limit
+}
+
+func (v *Ordering) SetLimit(limit int32) {
+	v.data.Limit = &limit
+}
+
+func (v *Ordering) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *Ordering) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *Ordering) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *Ordering) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type detailOptionsData struct {
+	IncludeSeries     *bool  `cbor:"0,keyasint,omitempty" json:"include_series,omitempty"`
+	IncludeContainers *bool  `cbor:"1,keyasint,omitempty" json:"include_containers,omitempty"`
+	StepSeconds       *int64 `cbor:"2,keyasint,omitempty" json:"step_seconds,omitempty"`
+}
+
+type DetailOptions struct {
+	data detailOptionsData
+}
+
+func (v *DetailOptions) HasIncludeSeries() bool {
+	return v.data.IncludeSeries != nil
+}
+
+func (v *DetailOptions) IncludeSeries() bool {
+	if v.data.IncludeSeries == nil {
+		return false
+	}
+	return *v.data.IncludeSeries
+}
+
+func (v *DetailOptions) SetIncludeSeries(include_series bool) {
+	v.data.IncludeSeries = &include_series
+}
+
+func (v *DetailOptions) HasIncludeContainers() bool {
+	return v.data.IncludeContainers != nil
+}
+
+func (v *DetailOptions) IncludeContainers() bool {
+	if v.data.IncludeContainers == nil {
+		return false
+	}
+	return *v.data.IncludeContainers
+}
+
+func (v *DetailOptions) SetIncludeContainers(include_containers bool) {
+	v.data.IncludeContainers = &include_containers
+}
+
+func (v *DetailOptions) HasStepSeconds() bool {
+	return v.data.StepSeconds != nil
+}
+
+func (v *DetailOptions) StepSeconds() int64 {
+	if v.data.StepSeconds == nil {
+		return 0
+	}
+	return *v.data.StepSeconds
+}
+
+func (v *DetailOptions) SetStepSeconds(step_seconds int64) {
+	v.data.StepSeconds = &step_seconds
+}
+
+func (v *DetailOptions) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *DetailOptions) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *DetailOptions) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *DetailOptions) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type containerUsageData struct {
+	Name   *string      `cbor:"0,keyasint,omitempty" json:"name,omitempty"`
+	Cpu    *CpuUsage    `cbor:"1,keyasint,omitempty" json:"cpu,omitempty"`
+	Memory *MemoryUsage `cbor:"2,keyasint,omitempty" json:"memory,omitempty"`
+}
+
+type ContainerUsage struct {
+	data containerUsageData
+}
+
+func (v *ContainerUsage) HasName() bool {
+	return v.data.Name != nil
+}
+
+func (v *ContainerUsage) Name() string {
+	if v.data.Name == nil {
+		return ""
+	}
+	return *v.data.Name
+}
+
+func (v *ContainerUsage) SetName(name string) {
+	v.data.Name = &name
+}
+
+func (v *ContainerUsage) HasCpu() bool {
+	return v.data.Cpu != nil
+}
+
+func (v *ContainerUsage) Cpu() *CpuUsage {
+	return v.data.Cpu
+}
+
+func (v *ContainerUsage) SetCpu(cpu *CpuUsage) {
+	v.data.Cpu = cpu
+}
+
+func (v *ContainerUsage) HasMemory() bool {
+	return v.data.Memory != nil
+}
+
+func (v *ContainerUsage) Memory() *MemoryUsage {
+	return v.data.Memory
+}
+
+func (v *ContainerUsage) SetMemory(memory *MemoryUsage) {
+	v.data.Memory = memory
+}
+
+func (v *ContainerUsage) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ContainerUsage) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ContainerUsage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ContainerUsage) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type usagePointData struct {
+	At    *standard.Timestamp `cbor:"0,keyasint,omitempty" json:"at,omitempty"`
+	Value *float64            `cbor:"1,keyasint,omitempty" json:"value,omitempty"`
+}
+
+type UsagePoint struct {
+	data usagePointData
+}
+
+func (v *UsagePoint) HasAt() bool {
+	return v.data.At != nil
+}
+
+func (v *UsagePoint) At() *standard.Timestamp {
+	return v.data.At
+}
+
+func (v *UsagePoint) SetAt(at *standard.Timestamp) {
+	v.data.At = at
+}
+
+func (v *UsagePoint) HasValue() bool {
+	return v.data.Value != nil
+}
+
+func (v *UsagePoint) Value() float64 {
+	if v.data.Value == nil {
+		return 0
+	}
+	return *v.data.Value
+}
+
+func (v *UsagePoint) SetValue(value float64) {
+	v.data.Value = &value
+}
+
+func (v *UsagePoint) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *UsagePoint) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *UsagePoint) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *UsagePoint) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type usageSeriesData struct {
+	Metric *string        `cbor:"0,keyasint,omitempty" json:"metric,omitempty"`
+	Points *[]*UsagePoint `cbor:"1,keyasint,omitempty" json:"points,omitempty"`
+}
+
+type UsageSeries struct {
+	data usageSeriesData
+}
+
+func (v *UsageSeries) HasMetric() bool {
+	return v.data.Metric != nil
+}
+
+func (v *UsageSeries) Metric() string {
+	if v.data.Metric == nil {
+		return ""
+	}
+	return *v.data.Metric
+}
+
+func (v *UsageSeries) SetMetric(metric string) {
+	v.data.Metric = &metric
+}
+
+func (v *UsageSeries) HasPoints() bool {
+	return v.data.Points != nil
+}
+
+func (v *UsageSeries) Points() []*UsagePoint {
+	if v.data.Points == nil {
+		return nil
+	}
+	return *v.data.Points
+}
+
+func (v *UsageSeries) SetPoints(points []*UsagePoint) {
+	x := slices.Clone(points)
+	v.data.Points = &x
+}
+
+func (v *UsageSeries) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *UsageSeries) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *UsageSeries) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *UsageSeries) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type sandboxExitData struct {
+	Code      *int32              `cbor:"0,keyasint,omitempty" json:"code,omitempty"`
+	At        *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"at,omitempty"`
+	Container *string             `cbor:"2,keyasint,omitempty" json:"container,omitempty"`
+}
+
+type SandboxExit struct {
+	data sandboxExitData
+}
+
+func (v *SandboxExit) HasCode() bool {
+	return v.data.Code != nil
+}
+
+func (v *SandboxExit) Code() int32 {
+	if v.data.Code == nil {
+		return 0
+	}
+	return *v.data.Code
+}
+
+func (v *SandboxExit) SetCode(code int32) {
+	v.data.Code = &code
+}
+
+func (v *SandboxExit) HasAt() bool {
+	return v.data.At != nil
+}
+
+func (v *SandboxExit) At() *standard.Timestamp {
+	return v.data.At
+}
+
+func (v *SandboxExit) SetAt(at *standard.Timestamp) {
+	v.data.At = at
+}
+
+func (v *SandboxExit) HasContainer() bool {
+	return v.data.Container != nil
+}
+
+func (v *SandboxExit) Container() string {
+	if v.data.Container == nil {
+		return ""
+	}
+	return *v.data.Container
+}
+
+func (v *SandboxExit) SetContainer(container string) {
+	v.data.Container = &container
+}
+
+func (v *SandboxExit) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SandboxExit) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SandboxExit) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SandboxExit) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type crashLoopStateData struct {
+	ConsecutiveCrashes *int32              `cbor:"0,keyasint,omitempty" json:"consecutive_crashes,omitempty"`
+	LastCrashAt        *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"last_crash_at,omitempty"`
+	CooldownUntil      *standard.Timestamp `cbor:"2,keyasint,omitempty" json:"cooldown_until,omitempty"`
+}
+
+type CrashLoopState struct {
+	data crashLoopStateData
+}
+
+func (v *CrashLoopState) HasConsecutiveCrashes() bool {
+	return v.data.ConsecutiveCrashes != nil
+}
+
+func (v *CrashLoopState) ConsecutiveCrashes() int32 {
+	if v.data.ConsecutiveCrashes == nil {
+		return 0
+	}
+	return *v.data.ConsecutiveCrashes
+}
+
+func (v *CrashLoopState) SetConsecutiveCrashes(consecutive_crashes int32) {
+	v.data.ConsecutiveCrashes = &consecutive_crashes
+}
+
+func (v *CrashLoopState) HasLastCrashAt() bool {
+	return v.data.LastCrashAt != nil
+}
+
+func (v *CrashLoopState) LastCrashAt() *standard.Timestamp {
+	return v.data.LastCrashAt
+}
+
+func (v *CrashLoopState) SetLastCrashAt(last_crash_at *standard.Timestamp) {
+	v.data.LastCrashAt = last_crash_at
+}
+
+func (v *CrashLoopState) HasCooldownUntil() bool {
+	return v.data.CooldownUntil != nil
+}
+
+func (v *CrashLoopState) CooldownUntil() *standard.Timestamp {
+	return v.data.CooldownUntil
+}
+
+func (v *CrashLoopState) SetCooldownUntil(cooldown_until *standard.Timestamp) {
+	v.data.CooldownUntil = cooldown_until
+}
+
+func (v *CrashLoopState) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CrashLoopState) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CrashLoopState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CrashLoopState) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageListSandboxesArgsData struct {
+	Selector *Selector `cbor:"0,keyasint,omitempty" json:"selector,omitempty"`
+	Window   *Window   `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Ordering *Ordering `cbor:"2,keyasint,omitempty" json:"ordering,omitempty"`
+}
+
+type ResourceUsageListSandboxesArgs struct {
+	call rpc.Call
+	data resourceUsageListSandboxesArgsData
+}
+
+func (v *ResourceUsageListSandboxesArgs) HasSelector() bool {
+	return v.data.Selector != nil
+}
+
+func (v *ResourceUsageListSandboxesArgs) Selector() *Selector {
+	return v.data.Selector
+}
+
+func (v *ResourceUsageListSandboxesArgs) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageListSandboxesArgs) Window() *Window {
+	return v.data.Window
+}
+
+func (v *ResourceUsageListSandboxesArgs) HasOrdering() bool {
+	return v.data.Ordering != nil
+}
+
+func (v *ResourceUsageListSandboxesArgs) Ordering() *Ordering {
+	return v.data.Ordering
+}
+
+func (v *ResourceUsageListSandboxesArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageListSandboxesArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageListSandboxesArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageListSandboxesArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageListSandboxesResultsData struct {
+	Sandboxes   *[]*SandboxUsage    `cbor:"0,keyasint,omitempty" json:"sandboxes,omitempty"`
+	Window      *UsageWindow        `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Cluster     *ResourceTotals     `cbor:"2,keyasint,omitempty" json:"cluster,omitempty"`
+	TotalCount  *int32              `cbor:"3,keyasint,omitempty" json:"total_count,omitempty"`
+	CollectedAt *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"collected_at,omitempty"`
+	Warnings    *[]string           `cbor:"5,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageListSandboxesResults struct {
+	call rpc.Call
+	data resourceUsageListSandboxesResultsData
+}
+
+func (v *ResourceUsageListSandboxesResults) SetSandboxes(sandboxes []*SandboxUsage) {
+	x := slices.Clone(sandboxes)
+	v.data.Sandboxes = &x
+}
+
+func (v *ResourceUsageListSandboxesResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageListSandboxesResults) SetCluster(cluster *ResourceTotals) {
+	v.data.Cluster = cluster
+}
+
+func (v *ResourceUsageListSandboxesResults) SetTotalCount(total_count int32) {
+	v.data.TotalCount = &total_count
+}
+
+func (v *ResourceUsageListSandboxesResults) SetCollectedAt(collected_at *standard.Timestamp) {
+	v.data.CollectedAt = collected_at
+}
+
+func (v *ResourceUsageListSandboxesResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageListSandboxesResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageListSandboxesResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageListSandboxesResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageListSandboxesResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageGetSandboxArgsData struct {
+	Sandbox *string        `cbor:"0,keyasint,omitempty" json:"sandbox,omitempty"`
+	Window  *Window        `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Options *DetailOptions `cbor:"2,keyasint,omitempty" json:"options,omitempty"`
+}
+
+type ResourceUsageGetSandboxArgs struct {
+	call rpc.Call
+	data resourceUsageGetSandboxArgsData
+}
+
+func (v *ResourceUsageGetSandboxArgs) HasSandbox() bool {
+	return v.data.Sandbox != nil
+}
+
+func (v *ResourceUsageGetSandboxArgs) Sandbox() string {
+	if v.data.Sandbox == nil {
+		return ""
+	}
+	return *v.data.Sandbox
+}
+
+func (v *ResourceUsageGetSandboxArgs) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageGetSandboxArgs) Window() *Window {
+	return v.data.Window
+}
+
+func (v *ResourceUsageGetSandboxArgs) HasOptions() bool {
+	return v.data.Options != nil
+}
+
+func (v *ResourceUsageGetSandboxArgs) Options() *DetailOptions {
+	return v.data.Options
+}
+
+func (v *ResourceUsageGetSandboxArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageGetSandboxArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageGetSandboxArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageGetSandboxArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageGetSandboxResultsData struct {
+	Usage         *SandboxUsage      `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
+	Containers    *[]*ContainerUsage `cbor:"1,keyasint,omitempty" json:"containers,omitempty"`
+	Series        *[]*UsageSeries    `cbor:"2,keyasint,omitempty" json:"series,omitempty"`
+	Exit          *SandboxExit       `cbor:"3,keyasint,omitempty" json:"exit,omitempty"`
+	CrashLoop     *CrashLoopState    `cbor:"4,keyasint,omitempty" json:"crash_loop,omitempty"`
+	Image         *string            `cbor:"5,keyasint,omitempty" json:"image,omitempty"`
+	RestartPolicy *string            `cbor:"6,keyasint,omitempty" json:"restart_policy,omitempty"`
+	Window        *UsageWindow       `cbor:"7,keyasint,omitempty" json:"window,omitempty"`
+	Warnings      *[]string          `cbor:"8,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageGetSandboxResults struct {
+	call rpc.Call
+	data resourceUsageGetSandboxResultsData
+}
+
+func (v *ResourceUsageGetSandboxResults) SetUsage(usage *SandboxUsage) {
+	v.data.Usage = usage
+}
+
+func (v *ResourceUsageGetSandboxResults) SetContainers(containers []*ContainerUsage) {
+	x := slices.Clone(containers)
+	v.data.Containers = &x
+}
+
+func (v *ResourceUsageGetSandboxResults) SetSeries(series []*UsageSeries) {
+	x := slices.Clone(series)
+	v.data.Series = &x
+}
+
+func (v *ResourceUsageGetSandboxResults) SetExit(exit *SandboxExit) {
+	v.data.Exit = exit
+}
+
+func (v *ResourceUsageGetSandboxResults) SetCrashLoop(crash_loop *CrashLoopState) {
+	v.data.CrashLoop = crash_loop
+}
+
+func (v *ResourceUsageGetSandboxResults) SetImage(image string) {
+	v.data.Image = &image
+}
+
+func (v *ResourceUsageGetSandboxResults) SetRestartPolicy(restart_policy string) {
+	v.data.RestartPolicy = &restart_policy
+}
+
+func (v *ResourceUsageGetSandboxResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageGetSandboxResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageGetSandboxResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageGetSandboxResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageGetSandboxResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageGetSandboxResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageListNodesArgsData struct {
+	Selector *Selector `cbor:"0,keyasint,omitempty" json:"selector,omitempty"`
+	Window   *Window   `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Ordering *Ordering `cbor:"2,keyasint,omitempty" json:"ordering,omitempty"`
+}
+
+type ResourceUsageListNodesArgs struct {
+	call rpc.Call
+	data resourceUsageListNodesArgsData
+}
+
+func (v *ResourceUsageListNodesArgs) HasSelector() bool {
+	return v.data.Selector != nil
+}
+
+func (v *ResourceUsageListNodesArgs) Selector() *Selector {
+	return v.data.Selector
+}
+
+func (v *ResourceUsageListNodesArgs) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageListNodesArgs) Window() *Window {
+	return v.data.Window
+}
+
+func (v *ResourceUsageListNodesArgs) HasOrdering() bool {
+	return v.data.Ordering != nil
+}
+
+func (v *ResourceUsageListNodesArgs) Ordering() *Ordering {
+	return v.data.Ordering
+}
+
+func (v *ResourceUsageListNodesArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageListNodesArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageListNodesArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageListNodesArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageListNodesResultsData struct {
+	Nodes       *[]*NodeUsage       `cbor:"0,keyasint,omitempty" json:"nodes,omitempty"`
+	Cluster     *ResourceTotals     `cbor:"1,keyasint,omitempty" json:"cluster,omitempty"`
+	Capacity    *NodeCapacity       `cbor:"2,keyasint,omitempty" json:"capacity,omitempty"`
+	Window      *UsageWindow        `cbor:"3,keyasint,omitempty" json:"window,omitempty"`
+	CollectedAt *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"collected_at,omitempty"`
+	Warnings    *[]string           `cbor:"5,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageListNodesResults struct {
+	call rpc.Call
+	data resourceUsageListNodesResultsData
+}
+
+func (v *ResourceUsageListNodesResults) SetNodes(nodes []*NodeUsage) {
+	x := slices.Clone(nodes)
+	v.data.Nodes = &x
+}
+
+func (v *ResourceUsageListNodesResults) SetCluster(cluster *ResourceTotals) {
+	v.data.Cluster = cluster
+}
+
+func (v *ResourceUsageListNodesResults) SetCapacity(capacity *NodeCapacity) {
+	v.data.Capacity = capacity
+}
+
+func (v *ResourceUsageListNodesResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageListNodesResults) SetCollectedAt(collected_at *standard.Timestamp) {
+	v.data.CollectedAt = collected_at
+}
+
+func (v *ResourceUsageListNodesResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageListNodesResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageListNodesResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageListNodesResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageListNodesResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageListAppsArgsData struct {
+	Selector *Selector `cbor:"0,keyasint,omitempty" json:"selector,omitempty"`
+	Window   *Window   `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Ordering *Ordering `cbor:"2,keyasint,omitempty" json:"ordering,omitempty"`
+}
+
+type ResourceUsageListAppsArgs struct {
+	call rpc.Call
+	data resourceUsageListAppsArgsData
+}
+
+func (v *ResourceUsageListAppsArgs) HasSelector() bool {
+	return v.data.Selector != nil
+}
+
+func (v *ResourceUsageListAppsArgs) Selector() *Selector {
+	return v.data.Selector
+}
+
+func (v *ResourceUsageListAppsArgs) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageListAppsArgs) Window() *Window {
+	return v.data.Window
+}
+
+func (v *ResourceUsageListAppsArgs) HasOrdering() bool {
+	return v.data.Ordering != nil
+}
+
+func (v *ResourceUsageListAppsArgs) Ordering() *Ordering {
+	return v.data.Ordering
+}
+
+func (v *ResourceUsageListAppsArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageListAppsArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageListAppsArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageListAppsArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageListAppsResultsData struct {
+	Apps        *[]*AppUsage        `cbor:"0,keyasint,omitempty" json:"apps,omitempty"`
+	Cluster     *ResourceTotals     `cbor:"1,keyasint,omitempty" json:"cluster,omitempty"`
+	TotalCount  *int32              `cbor:"2,keyasint,omitempty" json:"total_count,omitempty"`
+	Window      *UsageWindow        `cbor:"3,keyasint,omitempty" json:"window,omitempty"`
+	CollectedAt *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"collected_at,omitempty"`
+	Warnings    *[]string           `cbor:"5,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageListAppsResults struct {
+	call rpc.Call
+	data resourceUsageListAppsResultsData
+}
+
+func (v *ResourceUsageListAppsResults) SetApps(apps []*AppUsage) {
+	x := slices.Clone(apps)
+	v.data.Apps = &x
+}
+
+func (v *ResourceUsageListAppsResults) SetCluster(cluster *ResourceTotals) {
+	v.data.Cluster = cluster
+}
+
+func (v *ResourceUsageListAppsResults) SetTotalCount(total_count int32) {
+	v.data.TotalCount = &total_count
+}
+
+func (v *ResourceUsageListAppsResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageListAppsResults) SetCollectedAt(collected_at *standard.Timestamp) {
+	v.data.CollectedAt = collected_at
+}
+
+func (v *ResourceUsageListAppsResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageListAppsResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageListAppsResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageListAppsResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageListAppsResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpListSandboxesArgsData struct {
+	App           *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	Service       *string `cbor:"1,keyasint,omitempty" json:"service,omitempty"`
+	Node          *string `cbor:"2,keyasint,omitempty" json:"node,omitempty"`
+	Kind          *string `cbor:"3,keyasint,omitempty" json:"kind,omitempty"`
+	Status        *string `cbor:"4,keyasint,omitempty" json:"status,omitempty"`
+	IncludeSystem *bool   `cbor:"5,keyasint,omitempty" json:"include_system,omitempty"`
+	Since         *string `cbor:"6,keyasint,omitempty" json:"since,omitempty"`
+	Until         *string `cbor:"7,keyasint,omitempty" json:"until,omitempty"`
+	Aggregate     *string `cbor:"8,keyasint,omitempty" json:"aggregate,omitempty"`
+	Sort          *string `cbor:"9,keyasint,omitempty" json:"sort,omitempty"`
+	Order         *string `cbor:"10,keyasint,omitempty" json:"order,omitempty"`
+	Limit         *int32  `cbor:"11,keyasint,omitempty" json:"limit,omitempty"`
+}
+
+type ResourceUsageHttpListSandboxesArgs struct {
+	call rpc.Call
+	data resourceUsageHttpListSandboxesArgsData
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasNode() bool {
+	return v.data.Node != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Node() string {
+	if v.data.Node == nil {
+		return ""
+	}
+	return *v.data.Node
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasKind() bool {
+	return v.data.Kind != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Kind() string {
+	if v.data.Kind == nil {
+		return ""
+	}
+	return *v.data.Kind
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasStatus() bool {
+	return v.data.Status != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Status() string {
+	if v.data.Status == nil {
+		return ""
+	}
+	return *v.data.Status
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasIncludeSystem() bool {
+	return v.data.IncludeSystem != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) IncludeSystem() bool {
+	if v.data.IncludeSystem == nil {
+		return false
+	}
+	return *v.data.IncludeSystem
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasSince() bool {
+	return v.data.Since != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Since() string {
+	if v.data.Since == nil {
+		return ""
+	}
+	return *v.data.Since
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasUntil() bool {
+	return v.data.Until != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Until() string {
+	if v.data.Until == nil {
+		return ""
+	}
+	return *v.data.Until
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasAggregate() bool {
+	return v.data.Aggregate != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Aggregate() string {
+	if v.data.Aggregate == nil {
+		return ""
+	}
+	return *v.data.Aggregate
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasSort() bool {
+	return v.data.Sort != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Sort() string {
+	if v.data.Sort == nil {
+		return ""
+	}
+	return *v.data.Sort
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasOrder() bool {
+	return v.data.Order != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Order() string {
+	if v.data.Order == nil {
+		return ""
+	}
+	return *v.data.Order
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) HasLimit() bool {
+	return v.data.Limit != nil
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) Limit() int32 {
+	if v.data.Limit == nil {
+		return 0
+	}
+	return *v.data.Limit
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListSandboxesArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpListSandboxesResultsData struct {
+	Sandboxes   *[]*SandboxUsage    `cbor:"0,keyasint,omitempty" json:"sandboxes,omitempty"`
+	Window      *UsageWindow        `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Cluster     *ResourceTotals     `cbor:"2,keyasint,omitempty" json:"cluster,omitempty"`
+	TotalCount  *int32              `cbor:"3,keyasint,omitempty" json:"total_count,omitempty"`
+	CollectedAt *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"collected_at,omitempty"`
+	Warnings    *[]string           `cbor:"5,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageHttpListSandboxesResults struct {
+	call rpc.Call
+	data resourceUsageHttpListSandboxesResultsData
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) SetSandboxes(sandboxes []*SandboxUsage) {
+	x := slices.Clone(sandboxes)
+	v.data.Sandboxes = &x
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) SetCluster(cluster *ResourceTotals) {
+	v.data.Cluster = cluster
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) SetTotalCount(total_count int32) {
+	v.data.TotalCount = &total_count
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) SetCollectedAt(collected_at *standard.Timestamp) {
+	v.data.CollectedAt = collected_at
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListSandboxesResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpGetSandboxArgsData struct {
+	Sandbox    *string `cbor:"0,keyasint,omitempty" json:"sandbox,omitempty"`
+	Since      *string `cbor:"1,keyasint,omitempty" json:"since,omitempty"`
+	Until      *string `cbor:"2,keyasint,omitempty" json:"until,omitempty"`
+	Aggregate  *string `cbor:"3,keyasint,omitempty" json:"aggregate,omitempty"`
+	Series     *bool   `cbor:"4,keyasint,omitempty" json:"series,omitempty"`
+	Containers *bool   `cbor:"5,keyasint,omitempty" json:"containers,omitempty"`
+	Step       *string `cbor:"6,keyasint,omitempty" json:"step,omitempty"`
+}
+
+type ResourceUsageHttpGetSandboxArgs struct {
+	call rpc.Call
+	data resourceUsageHttpGetSandboxArgsData
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) HasSandbox() bool {
+	return v.data.Sandbox != nil
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) Sandbox() string {
+	if v.data.Sandbox == nil {
+		return ""
+	}
+	return *v.data.Sandbox
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) HasSince() bool {
+	return v.data.Since != nil
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) Since() string {
+	if v.data.Since == nil {
+		return ""
+	}
+	return *v.data.Since
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) HasUntil() bool {
+	return v.data.Until != nil
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) Until() string {
+	if v.data.Until == nil {
+		return ""
+	}
+	return *v.data.Until
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) HasAggregate() bool {
+	return v.data.Aggregate != nil
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) Aggregate() string {
+	if v.data.Aggregate == nil {
+		return ""
+	}
+	return *v.data.Aggregate
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) HasSeries() bool {
+	return v.data.Series != nil
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) Series() bool {
+	if v.data.Series == nil {
+		return false
+	}
+	return *v.data.Series
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) HasContainers() bool {
+	return v.data.Containers != nil
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) Containers() bool {
+	if v.data.Containers == nil {
+		return false
+	}
+	return *v.data.Containers
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) HasStep() bool {
+	return v.data.Step != nil
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) Step() string {
+	if v.data.Step == nil {
+		return ""
+	}
+	return *v.data.Step
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetSandboxArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpGetSandboxResultsData struct {
+	Usage         *SandboxUsage      `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
+	Containers    *[]*ContainerUsage `cbor:"1,keyasint,omitempty" json:"containers,omitempty"`
+	Series        *[]*UsageSeries    `cbor:"2,keyasint,omitempty" json:"series,omitempty"`
+	Exit          *SandboxExit       `cbor:"3,keyasint,omitempty" json:"exit,omitempty"`
+	CrashLoop     *CrashLoopState    `cbor:"4,keyasint,omitempty" json:"crash_loop,omitempty"`
+	Image         *string            `cbor:"5,keyasint,omitempty" json:"image,omitempty"`
+	RestartPolicy *string            `cbor:"6,keyasint,omitempty" json:"restart_policy,omitempty"`
+	Window        *UsageWindow       `cbor:"7,keyasint,omitempty" json:"window,omitempty"`
+	Warnings      *[]string          `cbor:"8,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageHttpGetSandboxResults struct {
+	call rpc.Call
+	data resourceUsageHttpGetSandboxResultsData
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetUsage(usage *SandboxUsage) {
+	v.data.Usage = usage
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetContainers(containers []*ContainerUsage) {
+	x := slices.Clone(containers)
+	v.data.Containers = &x
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetSeries(series []*UsageSeries) {
+	x := slices.Clone(series)
+	v.data.Series = &x
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetExit(exit *SandboxExit) {
+	v.data.Exit = exit
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetCrashLoop(crash_loop *CrashLoopState) {
+	v.data.CrashLoop = crash_loop
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetImage(image string) {
+	v.data.Image = &image
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetRestartPolicy(restart_policy string) {
+	v.data.RestartPolicy = &restart_policy
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetSandboxResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpListNodesArgsData struct {
+	Since     *string `cbor:"0,keyasint,omitempty" json:"since,omitempty"`
+	Until     *string `cbor:"1,keyasint,omitempty" json:"until,omitempty"`
+	Aggregate *string `cbor:"2,keyasint,omitempty" json:"aggregate,omitempty"`
+	Sort      *string `cbor:"3,keyasint,omitempty" json:"sort,omitempty"`
+	Order     *string `cbor:"4,keyasint,omitempty" json:"order,omitempty"`
+	Limit     *int32  `cbor:"5,keyasint,omitempty" json:"limit,omitempty"`
+}
+
+type ResourceUsageHttpListNodesArgs struct {
+	call rpc.Call
+	data resourceUsageHttpListNodesArgsData
+}
+
+func (v *ResourceUsageHttpListNodesArgs) HasSince() bool {
+	return v.data.Since != nil
+}
+
+func (v *ResourceUsageHttpListNodesArgs) Since() string {
+	if v.data.Since == nil {
+		return ""
+	}
+	return *v.data.Since
+}
+
+func (v *ResourceUsageHttpListNodesArgs) HasUntil() bool {
+	return v.data.Until != nil
+}
+
+func (v *ResourceUsageHttpListNodesArgs) Until() string {
+	if v.data.Until == nil {
+		return ""
+	}
+	return *v.data.Until
+}
+
+func (v *ResourceUsageHttpListNodesArgs) HasAggregate() bool {
+	return v.data.Aggregate != nil
+}
+
+func (v *ResourceUsageHttpListNodesArgs) Aggregate() string {
+	if v.data.Aggregate == nil {
+		return ""
+	}
+	return *v.data.Aggregate
+}
+
+func (v *ResourceUsageHttpListNodesArgs) HasSort() bool {
+	return v.data.Sort != nil
+}
+
+func (v *ResourceUsageHttpListNodesArgs) Sort() string {
+	if v.data.Sort == nil {
+		return ""
+	}
+	return *v.data.Sort
+}
+
+func (v *ResourceUsageHttpListNodesArgs) HasOrder() bool {
+	return v.data.Order != nil
+}
+
+func (v *ResourceUsageHttpListNodesArgs) Order() string {
+	if v.data.Order == nil {
+		return ""
+	}
+	return *v.data.Order
+}
+
+func (v *ResourceUsageHttpListNodesArgs) HasLimit() bool {
+	return v.data.Limit != nil
+}
+
+func (v *ResourceUsageHttpListNodesArgs) Limit() int32 {
+	if v.data.Limit == nil {
+		return 0
+	}
+	return *v.data.Limit
+}
+
+func (v *ResourceUsageHttpListNodesArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListNodesArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpListNodesArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListNodesArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpListNodesResultsData struct {
+	Nodes       *[]*NodeUsage       `cbor:"0,keyasint,omitempty" json:"nodes,omitempty"`
+	Cluster     *ResourceTotals     `cbor:"1,keyasint,omitempty" json:"cluster,omitempty"`
+	Capacity    *NodeCapacity       `cbor:"2,keyasint,omitempty" json:"capacity,omitempty"`
+	Window      *UsageWindow        `cbor:"3,keyasint,omitempty" json:"window,omitempty"`
+	CollectedAt *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"collected_at,omitempty"`
+	Warnings    *[]string           `cbor:"5,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageHttpListNodesResults struct {
+	call rpc.Call
+	data resourceUsageHttpListNodesResultsData
+}
+
+func (v *ResourceUsageHttpListNodesResults) SetNodes(nodes []*NodeUsage) {
+	x := slices.Clone(nodes)
+	v.data.Nodes = &x
+}
+
+func (v *ResourceUsageHttpListNodesResults) SetCluster(cluster *ResourceTotals) {
+	v.data.Cluster = cluster
+}
+
+func (v *ResourceUsageHttpListNodesResults) SetCapacity(capacity *NodeCapacity) {
+	v.data.Capacity = capacity
+}
+
+func (v *ResourceUsageHttpListNodesResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageHttpListNodesResults) SetCollectedAt(collected_at *standard.Timestamp) {
+	v.data.CollectedAt = collected_at
+}
+
+func (v *ResourceUsageHttpListNodesResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageHttpListNodesResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListNodesResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpListNodesResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListNodesResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpGetNodeArgsData struct {
+	Node      *string `cbor:"0,keyasint,omitempty" json:"node,omitempty"`
+	Since     *string `cbor:"1,keyasint,omitempty" json:"since,omitempty"`
+	Until     *string `cbor:"2,keyasint,omitempty" json:"until,omitempty"`
+	Aggregate *string `cbor:"3,keyasint,omitempty" json:"aggregate,omitempty"`
+}
+
+type ResourceUsageHttpGetNodeArgs struct {
+	call rpc.Call
+	data resourceUsageHttpGetNodeArgsData
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) HasNode() bool {
+	return v.data.Node != nil
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) Node() string {
+	if v.data.Node == nil {
+		return ""
+	}
+	return *v.data.Node
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) HasSince() bool {
+	return v.data.Since != nil
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) Since() string {
+	if v.data.Since == nil {
+		return ""
+	}
+	return *v.data.Since
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) HasUntil() bool {
+	return v.data.Until != nil
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) Until() string {
+	if v.data.Until == nil {
+		return ""
+	}
+	return *v.data.Until
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) HasAggregate() bool {
+	return v.data.Aggregate != nil
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) Aggregate() string {
+	if v.data.Aggregate == nil {
+		return ""
+	}
+	return *v.data.Aggregate
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetNodeArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpGetNodeResultsData struct {
+	Usage    *NodeUsage   `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
+	Window   *UsageWindow `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Warnings *[]string    `cbor:"2,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageHttpGetNodeResults struct {
+	call rpc.Call
+	data resourceUsageHttpGetNodeResultsData
+}
+
+func (v *ResourceUsageHttpGetNodeResults) SetUsage(usage *NodeUsage) {
+	v.data.Usage = usage
+}
+
+func (v *ResourceUsageHttpGetNodeResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageHttpGetNodeResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageHttpGetNodeResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetNodeResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpGetNodeResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetNodeResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpListAppsArgsData struct {
+	Since     *string `cbor:"0,keyasint,omitempty" json:"since,omitempty"`
+	Until     *string `cbor:"1,keyasint,omitempty" json:"until,omitempty"`
+	Aggregate *string `cbor:"2,keyasint,omitempty" json:"aggregate,omitempty"`
+	Sort      *string `cbor:"3,keyasint,omitempty" json:"sort,omitempty"`
+	Order     *string `cbor:"4,keyasint,omitempty" json:"order,omitempty"`
+	Limit     *int32  `cbor:"5,keyasint,omitempty" json:"limit,omitempty"`
+	Addons    *bool   `cbor:"6,keyasint,omitempty" json:"addons,omitempty"`
+	Node      *string `cbor:"7,keyasint,omitempty" json:"node,omitempty"`
+}
+
+type ResourceUsageHttpListAppsArgs struct {
+	call rpc.Call
+	data resourceUsageHttpListAppsArgsData
+}
+
+func (v *ResourceUsageHttpListAppsArgs) HasSince() bool {
+	return v.data.Since != nil
+}
+
+func (v *ResourceUsageHttpListAppsArgs) Since() string {
+	if v.data.Since == nil {
+		return ""
+	}
+	return *v.data.Since
+}
+
+func (v *ResourceUsageHttpListAppsArgs) HasUntil() bool {
+	return v.data.Until != nil
+}
+
+func (v *ResourceUsageHttpListAppsArgs) Until() string {
+	if v.data.Until == nil {
+		return ""
+	}
+	return *v.data.Until
+}
+
+func (v *ResourceUsageHttpListAppsArgs) HasAggregate() bool {
+	return v.data.Aggregate != nil
+}
+
+func (v *ResourceUsageHttpListAppsArgs) Aggregate() string {
+	if v.data.Aggregate == nil {
+		return ""
+	}
+	return *v.data.Aggregate
+}
+
+func (v *ResourceUsageHttpListAppsArgs) HasSort() bool {
+	return v.data.Sort != nil
+}
+
+func (v *ResourceUsageHttpListAppsArgs) Sort() string {
+	if v.data.Sort == nil {
+		return ""
+	}
+	return *v.data.Sort
+}
+
+func (v *ResourceUsageHttpListAppsArgs) HasOrder() bool {
+	return v.data.Order != nil
+}
+
+func (v *ResourceUsageHttpListAppsArgs) Order() string {
+	if v.data.Order == nil {
+		return ""
+	}
+	return *v.data.Order
+}
+
+func (v *ResourceUsageHttpListAppsArgs) HasLimit() bool {
+	return v.data.Limit != nil
+}
+
+func (v *ResourceUsageHttpListAppsArgs) Limit() int32 {
+	if v.data.Limit == nil {
+		return 0
+	}
+	return *v.data.Limit
+}
+
+func (v *ResourceUsageHttpListAppsArgs) HasAddons() bool {
+	return v.data.Addons != nil
+}
+
+func (v *ResourceUsageHttpListAppsArgs) Addons() bool {
+	if v.data.Addons == nil {
+		return false
+	}
+	return *v.data.Addons
+}
+
+func (v *ResourceUsageHttpListAppsArgs) HasNode() bool {
+	return v.data.Node != nil
+}
+
+func (v *ResourceUsageHttpListAppsArgs) Node() string {
+	if v.data.Node == nil {
+		return ""
+	}
+	return *v.data.Node
+}
+
+func (v *ResourceUsageHttpListAppsArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListAppsArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpListAppsArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListAppsArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpListAppsResultsData struct {
+	Apps        *[]*AppUsage        `cbor:"0,keyasint,omitempty" json:"apps,omitempty"`
+	Cluster     *ResourceTotals     `cbor:"1,keyasint,omitempty" json:"cluster,omitempty"`
+	TotalCount  *int32              `cbor:"2,keyasint,omitempty" json:"total_count,omitempty"`
+	Window      *UsageWindow        `cbor:"3,keyasint,omitempty" json:"window,omitempty"`
+	CollectedAt *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"collected_at,omitempty"`
+	Warnings    *[]string           `cbor:"5,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageHttpListAppsResults struct {
+	call rpc.Call
+	data resourceUsageHttpListAppsResultsData
+}
+
+func (v *ResourceUsageHttpListAppsResults) SetApps(apps []*AppUsage) {
+	x := slices.Clone(apps)
+	v.data.Apps = &x
+}
+
+func (v *ResourceUsageHttpListAppsResults) SetCluster(cluster *ResourceTotals) {
+	v.data.Cluster = cluster
+}
+
+func (v *ResourceUsageHttpListAppsResults) SetTotalCount(total_count int32) {
+	v.data.TotalCount = &total_count
+}
+
+func (v *ResourceUsageHttpListAppsResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageHttpListAppsResults) SetCollectedAt(collected_at *standard.Timestamp) {
+	v.data.CollectedAt = collected_at
+}
+
+func (v *ResourceUsageHttpListAppsResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageHttpListAppsResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListAppsResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpListAppsResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpListAppsResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpGetAppArgsData struct {
+	App       *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	Since     *string `cbor:"1,keyasint,omitempty" json:"since,omitempty"`
+	Until     *string `cbor:"2,keyasint,omitempty" json:"until,omitempty"`
+	Aggregate *string `cbor:"3,keyasint,omitempty" json:"aggregate,omitempty"`
+	Addons    *bool   `cbor:"4,keyasint,omitempty" json:"addons,omitempty"`
+}
+
+type ResourceUsageHttpGetAppArgs struct {
+	call rpc.Call
+	data resourceUsageHttpGetAppArgsData
+}
+
+func (v *ResourceUsageHttpGetAppArgs) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *ResourceUsageHttpGetAppArgs) HasSince() bool {
+	return v.data.Since != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) Since() string {
+	if v.data.Since == nil {
+		return ""
+	}
+	return *v.data.Since
+}
+
+func (v *ResourceUsageHttpGetAppArgs) HasUntil() bool {
+	return v.data.Until != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) Until() string {
+	if v.data.Until == nil {
+		return ""
+	}
+	return *v.data.Until
+}
+
+func (v *ResourceUsageHttpGetAppArgs) HasAggregate() bool {
+	return v.data.Aggregate != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) Aggregate() string {
+	if v.data.Aggregate == nil {
+		return ""
+	}
+	return *v.data.Aggregate
+}
+
+func (v *ResourceUsageHttpGetAppArgs) HasAddons() bool {
+	return v.data.Addons != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) Addons() bool {
+	if v.data.Addons == nil {
+		return false
+	}
+	return *v.data.Addons
+}
+
+func (v *ResourceUsageHttpGetAppArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetAppArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpGetAppArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetAppArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageHttpGetAppResultsData struct {
+	Usage    *AppUsage    `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
+	Window   *UsageWindow `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Warnings *[]string    `cbor:"2,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageHttpGetAppResults struct {
+	call rpc.Call
+	data resourceUsageHttpGetAppResultsData
+}
+
+func (v *ResourceUsageHttpGetAppResults) SetUsage(usage *AppUsage) {
+	v.data.Usage = usage
+}
+
+func (v *ResourceUsageHttpGetAppResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageHttpGetAppResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageHttpGetAppResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetAppResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageHttpGetAppResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageHttpGetAppResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type ResourceUsageListSandboxes struct {
+	rpc.Call
+	args    ResourceUsageListSandboxesArgs
+	results ResourceUsageListSandboxesResults
+}
+
+func (t *ResourceUsageListSandboxes) Args() *ResourceUsageListSandboxesArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageListSandboxes) Results() *ResourceUsageListSandboxesResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageGetSandbox struct {
+	rpc.Call
+	args    ResourceUsageGetSandboxArgs
+	results ResourceUsageGetSandboxResults
+}
+
+func (t *ResourceUsageGetSandbox) Args() *ResourceUsageGetSandboxArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageGetSandbox) Results() *ResourceUsageGetSandboxResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageListNodes struct {
+	rpc.Call
+	args    ResourceUsageListNodesArgs
+	results ResourceUsageListNodesResults
+}
+
+func (t *ResourceUsageListNodes) Args() *ResourceUsageListNodesArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageListNodes) Results() *ResourceUsageListNodesResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageListApps struct {
+	rpc.Call
+	args    ResourceUsageListAppsArgs
+	results ResourceUsageListAppsResults
+}
+
+func (t *ResourceUsageListApps) Args() *ResourceUsageListAppsArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageListApps) Results() *ResourceUsageListAppsResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageHttpListSandboxes struct {
+	rpc.Call
+	args    ResourceUsageHttpListSandboxesArgs
+	results ResourceUsageHttpListSandboxesResults
+}
+
+func (t *ResourceUsageHttpListSandboxes) Args() *ResourceUsageHttpListSandboxesArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageHttpListSandboxes) Results() *ResourceUsageHttpListSandboxesResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageHttpGetSandbox struct {
+	rpc.Call
+	args    ResourceUsageHttpGetSandboxArgs
+	results ResourceUsageHttpGetSandboxResults
+}
+
+func (t *ResourceUsageHttpGetSandbox) Args() *ResourceUsageHttpGetSandboxArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageHttpGetSandbox) Results() *ResourceUsageHttpGetSandboxResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageHttpListNodes struct {
+	rpc.Call
+	args    ResourceUsageHttpListNodesArgs
+	results ResourceUsageHttpListNodesResults
+}
+
+func (t *ResourceUsageHttpListNodes) Args() *ResourceUsageHttpListNodesArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageHttpListNodes) Results() *ResourceUsageHttpListNodesResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageHttpGetNode struct {
+	rpc.Call
+	args    ResourceUsageHttpGetNodeArgs
+	results ResourceUsageHttpGetNodeResults
+}
+
+func (t *ResourceUsageHttpGetNode) Args() *ResourceUsageHttpGetNodeArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageHttpGetNode) Results() *ResourceUsageHttpGetNodeResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageHttpListApps struct {
+	rpc.Call
+	args    ResourceUsageHttpListAppsArgs
+	results ResourceUsageHttpListAppsResults
+}
+
+func (t *ResourceUsageHttpListApps) Args() *ResourceUsageHttpListAppsArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageHttpListApps) Results() *ResourceUsageHttpListAppsResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageHttpGetApp struct {
+	rpc.Call
+	args    ResourceUsageHttpGetAppArgs
+	results ResourceUsageHttpGetAppResults
+}
+
+func (t *ResourceUsageHttpGetApp) Args() *ResourceUsageHttpGetAppArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageHttpGetApp) Results() *ResourceUsageHttpGetAppResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsage interface {
+	ListSandboxes(ctx context.Context, state *ResourceUsageListSandboxes) error
+	GetSandbox(ctx context.Context, state *ResourceUsageGetSandbox) error
+	ListNodes(ctx context.Context, state *ResourceUsageListNodes) error
+	ListApps(ctx context.Context, state *ResourceUsageListApps) error
+	HttpListSandboxes(ctx context.Context, state *ResourceUsageHttpListSandboxes) error
+	HttpGetSandbox(ctx context.Context, state *ResourceUsageHttpGetSandbox) error
+	HttpListNodes(ctx context.Context, state *ResourceUsageHttpListNodes) error
+	HttpGetNode(ctx context.Context, state *ResourceUsageHttpGetNode) error
+	HttpListApps(ctx context.Context, state *ResourceUsageHttpListApps) error
+	HttpGetApp(ctx context.Context, state *ResourceUsageHttpGetApp) error
+}
+
+type reexportResourceUsage struct {
+	client rpc.Client
+}
+
+func (reexportResourceUsage) ListSandboxes(ctx context.Context, state *ResourceUsageListSandboxes) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) GetSandbox(ctx context.Context, state *ResourceUsageGetSandbox) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) ListNodes(ctx context.Context, state *ResourceUsageListNodes) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) ListApps(ctx context.Context, state *ResourceUsageListApps) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) HttpListSandboxes(ctx context.Context, state *ResourceUsageHttpListSandboxes) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) HttpGetSandbox(ctx context.Context, state *ResourceUsageHttpGetSandbox) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) HttpListNodes(ctx context.Context, state *ResourceUsageHttpListNodes) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) HttpGetNode(ctx context.Context, state *ResourceUsageHttpGetNode) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) HttpListApps(ctx context.Context, state *ResourceUsageHttpListApps) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) HttpGetApp(ctx context.Context, state *ResourceUsageHttpGetApp) error {
+	panic("not implemented")
+}
+
+func (t reexportResourceUsage) CapabilityClient() rpc.Client {
+	return t.client
+}
+
+func AdaptResourceUsage(t ResourceUsage) *rpc.Interface {
+	methods := []rpc.Method{
+		{
+			Name:          "listSandboxes",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			Params:        []string{"selector", "window", "ordering"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ListSandboxes(ctx, &ResourceUsageListSandboxes{Call: call})
+			},
+		},
+		{
+			Name:          "getSandbox",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			Params:        []string{"sandbox", "window", "options"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.GetSandbox(ctx, &ResourceUsageGetSandbox{Call: call})
+			},
+		},
+		{
+			Name:          "listNodes",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			Params:        []string{"selector", "window", "ordering"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ListNodes(ctx, &ResourceUsageListNodes{Call: call})
+			},
+		},
+		{
+			Name:          "listApps",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			Params:        []string{"selector", "window", "ordering"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ListApps(ctx, &ResourceUsageListApps{Call: call})
+			},
+		},
+		{
+			Name:          "httpListSandboxes",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			RestOnly:      true,
+			Params:        []string{"app", "service", "node", "kind", "status", "include_system", "since", "until", "aggregate", "sort", "order", "limit"},
+			HTTP: &rpc.HTTPBinding{
+				Verb:       "GET",
+				Path:       "/api/v1/usage/sandboxes",
+				Body:       "",
+				PathParams: []string{},
+				Query: []rpc.HTTPParam{
+					{Name: "app", Kind: "string"},
+					{Name: "service", Kind: "string"},
+					{Name: "node", Kind: "string"},
+					{Name: "kind", Kind: "string"},
+					{Name: "status", Kind: "string"},
+					{Name: "include_system", Kind: "bool"},
+					{Name: "since", Kind: "string"},
+					{Name: "until", Kind: "string"},
+					{Name: "aggregate", Kind: "string"},
+					{Name: "sort", Kind: "string"},
+					{Name: "order", Kind: "string"},
+					{Name: "limit", Kind: "int"},
+				},
+			},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.HttpListSandboxes(ctx, &ResourceUsageHttpListSandboxes{Call: call})
+			},
+		},
+		{
+			Name:          "httpGetSandbox",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			RestOnly:      true,
+			Params:        []string{"sandbox", "since", "until", "aggregate", "series", "containers", "step"},
+			HTTP: &rpc.HTTPBinding{
+				Verb:       "GET",
+				Path:       "/api/v1/usage/sandboxes/{sandbox}",
+				Body:       "",
+				PathParams: []string{"sandbox"},
+				Query: []rpc.HTTPParam{
+					{Name: "since", Kind: "string"},
+					{Name: "until", Kind: "string"},
+					{Name: "aggregate", Kind: "string"},
+					{Name: "series", Kind: "bool"},
+					{Name: "containers", Kind: "bool"},
+					{Name: "step", Kind: "string"},
+				},
+			},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.HttpGetSandbox(ctx, &ResourceUsageHttpGetSandbox{Call: call})
+			},
+		},
+		{
+			Name:          "httpListNodes",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			RestOnly:      true,
+			Params:        []string{"since", "until", "aggregate", "sort", "order", "limit"},
+			HTTP: &rpc.HTTPBinding{
+				Verb:       "GET",
+				Path:       "/api/v1/usage/nodes",
+				Body:       "",
+				PathParams: []string{},
+				Query: []rpc.HTTPParam{
+					{Name: "since", Kind: "string"},
+					{Name: "until", Kind: "string"},
+					{Name: "aggregate", Kind: "string"},
+					{Name: "sort", Kind: "string"},
+					{Name: "order", Kind: "string"},
+					{Name: "limit", Kind: "int"},
+				},
+			},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.HttpListNodes(ctx, &ResourceUsageHttpListNodes{Call: call})
+			},
+		},
+		{
+			Name:          "httpGetNode",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			RestOnly:      true,
+			Params:        []string{"node", "since", "until", "aggregate"},
+			HTTP: &rpc.HTTPBinding{
+				Verb:       "GET",
+				Path:       "/api/v1/usage/nodes/{node}",
+				Body:       "",
+				PathParams: []string{"node"},
+				Query: []rpc.HTTPParam{
+					{Name: "since", Kind: "string"},
+					{Name: "until", Kind: "string"},
+					{Name: "aggregate", Kind: "string"},
+				},
+			},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.HttpGetNode(ctx, &ResourceUsageHttpGetNode{Call: call})
+			},
+		},
+		{
+			Name:          "httpListApps",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			RestOnly:      true,
+			Params:        []string{"since", "until", "aggregate", "sort", "order", "limit", "addons", "node"},
+			HTTP: &rpc.HTTPBinding{
+				Verb:       "GET",
+				Path:       "/api/v1/usage/apps",
+				Body:       "",
+				PathParams: []string{},
+				Query: []rpc.HTTPParam{
+					{Name: "since", Kind: "string"},
+					{Name: "until", Kind: "string"},
+					{Name: "aggregate", Kind: "string"},
+					{Name: "sort", Kind: "string"},
+					{Name: "order", Kind: "string"},
+					{Name: "limit", Kind: "int"},
+					{Name: "addons", Kind: "bool"},
+					{Name: "node", Kind: "string"},
+				},
+			},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.HttpListApps(ctx, &ResourceUsageHttpListApps{Call: call})
+			},
+		},
+		{
+			Name:          "httpGetApp",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			RestOnly:      true,
+			Params:        []string{"app", "since", "until", "aggregate", "addons"},
+			HTTP: &rpc.HTTPBinding{
+				Verb:       "GET",
+				Path:       "/api/v1/usage/apps/{app}",
+				Body:       "",
+				PathParams: []string{"app"},
+				Query: []rpc.HTTPParam{
+					{Name: "since", Kind: "string"},
+					{Name: "until", Kind: "string"},
+					{Name: "aggregate", Kind: "string"},
+					{Name: "addons", Kind: "bool"},
+				},
+			},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.HttpGetApp(ctx, &ResourceUsageHttpGetApp{Call: call})
+			},
+		},
+	}
+
+	return rpc.NewInterface(methods, t)
+}
+
+type ResourceUsageClient struct {
+	rpc.Client
+}
+
+func NewResourceUsageClient(client rpc.Client) *ResourceUsageClient {
+	return &ResourceUsageClient{Client: client}
+}
+
+func (c ResourceUsageClient) Export() ResourceUsage {
+	return reexportResourceUsage{client: c.Client}
+}
+
+type ResourceUsageClientListSandboxesResults struct {
+	client rpc.Client
+	data   resourceUsageListSandboxesResultsData
+}
+
+func (v *ResourceUsageClientListSandboxesResults) HasSandboxes() bool {
+	return v.data.Sandboxes != nil
+}
+
+func (v *ResourceUsageClientListSandboxesResults) Sandboxes() []*SandboxUsage {
+	if v.data.Sandboxes == nil {
+		return nil
+	}
+	return *v.data.Sandboxes
+}
+
+func (v *ResourceUsageClientListSandboxesResults) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageClientListSandboxesResults) Window() *UsageWindow {
+	return v.data.Window
+}
+
+func (v *ResourceUsageClientListSandboxesResults) HasCluster() bool {
+	return v.data.Cluster != nil
+}
+
+func (v *ResourceUsageClientListSandboxesResults) Cluster() *ResourceTotals {
+	return v.data.Cluster
+}
+
+func (v *ResourceUsageClientListSandboxesResults) HasTotalCount() bool {
+	return v.data.TotalCount != nil
+}
+
+func (v *ResourceUsageClientListSandboxesResults) TotalCount() int32 {
+	if v.data.TotalCount == nil {
+		return 0
+	}
+	return *v.data.TotalCount
+}
+
+func (v *ResourceUsageClientListSandboxesResults) HasCollectedAt() bool {
+	return v.data.CollectedAt != nil
+}
+
+func (v *ResourceUsageClientListSandboxesResults) CollectedAt() *standard.Timestamp {
+	return v.data.CollectedAt
+}
+
+func (v *ResourceUsageClientListSandboxesResults) HasWarnings() bool {
+	return v.data.Warnings != nil
+}
+
+func (v *ResourceUsageClientListSandboxesResults) Warnings() []string {
+	if v.data.Warnings == nil {
+		return nil
+	}
+	return *v.data.Warnings
+}
+
+func (v ResourceUsageClient) ListSandboxes(ctx context.Context, selector *Selector, window *Window, ordering *Ordering) (*ResourceUsageClientListSandboxesResults, error) {
+	args := ResourceUsageListSandboxesArgs{}
+	args.data.Selector = selector
+	args.data.Window = window
+	args.data.Ordering = ordering
+
+	var ret resourceUsageListSandboxesResultsData
+
+	err := v.Call(ctx, "listSandboxes", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceUsageClientListSandboxesResults{client: v.Client, data: ret}, nil
+}
+
+type ResourceUsageClientGetSandboxResults struct {
+	client rpc.Client
+	data   resourceUsageGetSandboxResultsData
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasUsage() bool {
+	return v.data.Usage != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) Usage() *SandboxUsage {
+	return v.data.Usage
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasContainers() bool {
+	return v.data.Containers != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) Containers() []*ContainerUsage {
+	if v.data.Containers == nil {
+		return nil
+	}
+	return *v.data.Containers
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasSeries() bool {
+	return v.data.Series != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) Series() []*UsageSeries {
+	if v.data.Series == nil {
+		return nil
+	}
+	return *v.data.Series
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasExit() bool {
+	return v.data.Exit != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) Exit() *SandboxExit {
+	return v.data.Exit
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasCrashLoop() bool {
+	return v.data.CrashLoop != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) CrashLoop() *CrashLoopState {
+	return v.data.CrashLoop
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasImage() bool {
+	return v.data.Image != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) Image() string {
+	if v.data.Image == nil {
+		return ""
+	}
+	return *v.data.Image
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasRestartPolicy() bool {
+	return v.data.RestartPolicy != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) RestartPolicy() string {
+	if v.data.RestartPolicy == nil {
+		return ""
+	}
+	return *v.data.RestartPolicy
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) Window() *UsageWindow {
+	return v.data.Window
+}
+
+func (v *ResourceUsageClientGetSandboxResults) HasWarnings() bool {
+	return v.data.Warnings != nil
+}
+
+func (v *ResourceUsageClientGetSandboxResults) Warnings() []string {
+	if v.data.Warnings == nil {
+		return nil
+	}
+	return *v.data.Warnings
+}
+
+func (v ResourceUsageClient) GetSandbox(ctx context.Context, sandbox string, window *Window, options *DetailOptions) (*ResourceUsageClientGetSandboxResults, error) {
+	args := ResourceUsageGetSandboxArgs{}
+	args.data.Sandbox = &sandbox
+	args.data.Window = window
+	args.data.Options = options
+
+	var ret resourceUsageGetSandboxResultsData
+
+	err := v.Call(ctx, "getSandbox", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceUsageClientGetSandboxResults{client: v.Client, data: ret}, nil
+}
+
+type ResourceUsageClientListNodesResults struct {
+	client rpc.Client
+	data   resourceUsageListNodesResultsData
+}
+
+func (v *ResourceUsageClientListNodesResults) HasNodes() bool {
+	return v.data.Nodes != nil
+}
+
+func (v *ResourceUsageClientListNodesResults) Nodes() []*NodeUsage {
+	if v.data.Nodes == nil {
+		return nil
+	}
+	return *v.data.Nodes
+}
+
+func (v *ResourceUsageClientListNodesResults) HasCluster() bool {
+	return v.data.Cluster != nil
+}
+
+func (v *ResourceUsageClientListNodesResults) Cluster() *ResourceTotals {
+	return v.data.Cluster
+}
+
+func (v *ResourceUsageClientListNodesResults) HasCapacity() bool {
+	return v.data.Capacity != nil
+}
+
+func (v *ResourceUsageClientListNodesResults) Capacity() *NodeCapacity {
+	return v.data.Capacity
+}
+
+func (v *ResourceUsageClientListNodesResults) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageClientListNodesResults) Window() *UsageWindow {
+	return v.data.Window
+}
+
+func (v *ResourceUsageClientListNodesResults) HasCollectedAt() bool {
+	return v.data.CollectedAt != nil
+}
+
+func (v *ResourceUsageClientListNodesResults) CollectedAt() *standard.Timestamp {
+	return v.data.CollectedAt
+}
+
+func (v *ResourceUsageClientListNodesResults) HasWarnings() bool {
+	return v.data.Warnings != nil
+}
+
+func (v *ResourceUsageClientListNodesResults) Warnings() []string {
+	if v.data.Warnings == nil {
+		return nil
+	}
+	return *v.data.Warnings
+}
+
+func (v ResourceUsageClient) ListNodes(ctx context.Context, selector *Selector, window *Window, ordering *Ordering) (*ResourceUsageClientListNodesResults, error) {
+	args := ResourceUsageListNodesArgs{}
+	args.data.Selector = selector
+	args.data.Window = window
+	args.data.Ordering = ordering
+
+	var ret resourceUsageListNodesResultsData
+
+	err := v.Call(ctx, "listNodes", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceUsageClientListNodesResults{client: v.Client, data: ret}, nil
+}
+
+type ResourceUsageClientListAppsResults struct {
+	client rpc.Client
+	data   resourceUsageListAppsResultsData
+}
+
+func (v *ResourceUsageClientListAppsResults) HasApps() bool {
+	return v.data.Apps != nil
+}
+
+func (v *ResourceUsageClientListAppsResults) Apps() []*AppUsage {
+	if v.data.Apps == nil {
+		return nil
+	}
+	return *v.data.Apps
+}
+
+func (v *ResourceUsageClientListAppsResults) HasCluster() bool {
+	return v.data.Cluster != nil
+}
+
+func (v *ResourceUsageClientListAppsResults) Cluster() *ResourceTotals {
+	return v.data.Cluster
+}
+
+func (v *ResourceUsageClientListAppsResults) HasTotalCount() bool {
+	return v.data.TotalCount != nil
+}
+
+func (v *ResourceUsageClientListAppsResults) TotalCount() int32 {
+	if v.data.TotalCount == nil {
+		return 0
+	}
+	return *v.data.TotalCount
+}
+
+func (v *ResourceUsageClientListAppsResults) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageClientListAppsResults) Window() *UsageWindow {
+	return v.data.Window
+}
+
+func (v *ResourceUsageClientListAppsResults) HasCollectedAt() bool {
+	return v.data.CollectedAt != nil
+}
+
+func (v *ResourceUsageClientListAppsResults) CollectedAt() *standard.Timestamp {
+	return v.data.CollectedAt
+}
+
+func (v *ResourceUsageClientListAppsResults) HasWarnings() bool {
+	return v.data.Warnings != nil
+}
+
+func (v *ResourceUsageClientListAppsResults) Warnings() []string {
+	if v.data.Warnings == nil {
+		return nil
+	}
+	return *v.data.Warnings
+}
+
+func (v ResourceUsageClient) ListApps(ctx context.Context, selector *Selector, window *Window, ordering *Ordering) (*ResourceUsageClientListAppsResults, error) {
+	args := ResourceUsageListAppsArgs{}
+	args.data.Selector = selector
+	args.data.Window = window
+	args.data.Ordering = ordering
+
+	var ret resourceUsageListAppsResultsData
+
+	err := v.Call(ctx, "listApps", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceUsageClientListAppsResults{client: v.Client, data: ret}, nil
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -352,6 +352,43 @@ miren deploy --analyze
 		}),
 	))
 
+	d.Dispatch("top", Infer("top", "Show cluster-wide resource usage", Top,
+		WithGroup(GroupMonitoring),
+		WithDescription(topDescription),
+		WithExample(mflags.Example{
+			Name: "What is using the cluster's CPU",
+			Body: "miren top",
+		}),
+		WithExample(mflags.Example{
+			Name: "Which host is hot, and whether an app is to blame",
+			Body: "miren top --nodes",
+		}),
+		WithExample(mflags.Example{
+			Name: "Per-app totals, including each app's dedicated addons",
+			Body: "miren top --apps",
+		}),
+		WithExample(mflags.Example{
+			Name: "One app's usage",
+			Body: "miren top --apps --app myapp",
+		}),
+		WithExample(mflags.Example{
+			Name: "Narrow to one runner",
+			Body: "miren top --runner miren-garden-runner-1",
+		}),
+		WithExample(mflags.Example{
+			Name: "Find a spike that has already passed",
+			Body: "miren top --since 1h --aggregate max",
+		}),
+		WithExample(mflags.Example{
+			Name: "Watch continuously",
+			Body: "miren top --watch",
+		}),
+		WithExample(mflags.Example{
+			Name: "Machine-readable output",
+			Body: "miren top --format json",
+		}),
+	))
+
 	// Sandbox commands
 	d.Dispatch("sandbox", Section("sandbox", "Sandbox management commands", "", WithSectionDescription(sandboxSectionDescription), WithSectionGroup(GroupMonitoring)))
 	d.Dispatch("sandbox list", Infer("sandbox list", "List sandboxes (excludes dead by default)", SandboxList,
@@ -391,6 +428,20 @@ miren deploy --analyze
 		WithExample(mflags.Example{
 			Name: "Force delete without confirmation",
 			Body: "miren sandbox delete sb_abc123 --force",
+		}),
+	))
+	d.Dispatch("sandbox inspect", Infer("sandbox inspect", "Show one sandbox's resource usage and failure history", SandboxInspect,
+		WithExample(mflags.Example{
+			Name: "Inspect a sandbox",
+			Body: "miren sandbox inspect sb_abc123",
+		}),
+		WithExample(mflags.Example{
+			Name: "Inspect over the last hour",
+			Body: "miren sandbox inspect sb_abc123 --since 1h",
+		}),
+		WithExample(mflags.Example{
+			Name: "Include CPU and memory history",
+			Body: "miren sandbox inspect sb_abc123 --series",
 		}),
 	))
 	d.Dispatch("sandbox exec", Infer("sandbox exec", "Open interactive shell in an existing sandbox", SandboxExec,

--- a/cli/commands/sandbox_inspect.go
+++ b/cli/commands/sandbox_inspect.go
@@ -1,0 +1,285 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"miren.dev/runtime/pkg/theme"
+
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/pkg/rpc/standard"
+	"miren.dev/runtime/pkg/units"
+)
+
+// SandboxInspect reports one sandbox in detail: what it is using, what it runs,
+// and why it has been failing if it has.
+//
+// This is the last step before reading logs. A listing says which sandbox is
+// hot; this says whether that is normal for it, and whether the pool behind it
+// has given up replacing it.
+func SandboxInspect(ctx *Context, opts struct {
+	Sandbox string `position:"0" usage:"ID or short ID of the sandbox to inspect" required:"true"`
+
+	Since  string `long:"since" description:"Measure over this window, e.g. 30s, 5m, 1h (default 1m)"`
+	Series bool   `long:"series" description:"Include CPU and memory history"`
+
+	FormatOptions
+	ConfigCentric
+}) error {
+	if strings.TrimSpace(opts.Sandbox) == "" {
+		return fmt.Errorf("a sandbox ID is required")
+	}
+
+	client, err := ctx.RPCClient(ServiceUsage)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	lookback, err := parseTopDuration(opts.Since)
+	if err != nil {
+		return fmt.Errorf("--since: %w", err)
+	}
+
+	uc := usage_v1alpha.NewResourceUsageClient(client)
+
+	var w usage_v1alpha.Window
+	if lookback > 0 {
+		w.SetStart(standard.ToTimestamp(time.Now().Add(-lookback)))
+	}
+
+	// Containers are left off: the stored series sum a sandbox's containers
+	// together before they are written, so a per-container split cannot be
+	// recovered from them. It needs the live per-node probe.
+	var detail usage_v1alpha.DetailOptions
+	detail.SetIncludeSeries(opts.Series)
+
+	res, err := uc.GetSandbox(ctx, opts.Sandbox, &w, &detail)
+	if err != nil {
+		return err
+	}
+
+	if opts.IsJSON() {
+		return PrintJSON(inspectJSON(res))
+	}
+
+	ctx.Printf("%s", renderInspect(res))
+	return nil
+}
+
+func renderInspect(res *usage_v1alpha.ResourceUsageClientGetSandboxResults) string {
+	// Same styles and shape as `miren app status`, which is the other
+	// single-resource detail view: a bold title, then bold-muted labels
+	// carrying their own colon, then title-case section headings.
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Info)
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Muted)
+
+	u := res.Usage()
+	ref := u.Ref()
+
+	var b strings.Builder
+
+	name := ref.SandboxShortId()
+	if name == "" {
+		name = ref.Sandbox()
+	}
+	fmt.Fprintf(&b, "%s\n\n", headerStyle.Render("Usage for sandbox "+name))
+
+	field := func(label, value string) {
+		if value == "" || value == "-" {
+			return
+		}
+		fmt.Fprintf(&b, "%s %s\n", labelStyle.Render(label+":"), value)
+	}
+
+	field("Sandbox", ref.Sandbox())
+	field("App", ref.App())
+	field("Service", ref.Service())
+	field("Kind", ref.Kind())
+	field("Runner", ref.NodeName())
+	field("Status", ref.Status())
+	field("Image", res.Image())
+	field("Restart policy", res.RestartPolicy())
+	if ts := ref.StartedAt(); ts != nil {
+		if t := standard.FromTimestamp(ts); !t.IsZero() {
+			field("Started", formatDuration(time.Since(t))+" ago")
+		}
+	}
+
+	fmt.Fprintf(&b, "\n%s\n", labelStyle.Render("Usage:"))
+	if u.Stale() {
+		// Distinguishing "not measured" from "measured as zero" is the whole
+		// point here: one means the app is quiet, the other means the telemetry
+		// pipeline is broken, and they need opposite responses.
+		fmt.Fprintf(&b, "  no samples in this window - the sandbox may have just started, or metrics collection may be down\n")
+	} else {
+		fmt.Fprintf(&b, "  CPU:     %s\n", formatCores(u.Cpu().Cores()))
+		if p := u.Cpu().PercentOfNode(); p > 0 {
+			fmt.Fprintf(&b, "  Of node: %.1f%%\n", p)
+		}
+		fmt.Fprintf(&b, "  Memory:  %s\n", units.Bytes(u.Memory().Bytes()).Short())
+	}
+
+	// Miren does not set per-sandbox CPU or memory ceilings, so there is nothing
+	// to be throttled against. Saying so beats printing a zero that reads as
+	// "never throttled".
+	fmt.Fprintf(&b, "  Limits:  none set (Miren does not cap sandbox CPU or memory)\n")
+
+	if cl := res.CrashLoop(); cl != nil && cl.ConsecutiveCrashes() > 0 {
+		fmt.Fprintf(&b, "\n%s\n", labelStyle.Render("Crash loop:"))
+		fmt.Fprintf(&b, "  Consecutive crashes: %d\n", cl.ConsecutiveCrashes())
+		if t := standard.FromTimestamp(cl.LastCrashAt()); !t.IsZero() {
+			fmt.Fprintf(&b, "  Last crash:          %s ago\n", formatDuration(time.Since(t)))
+		}
+		if t := standard.FromTimestamp(cl.CooldownUntil()); t.After(time.Now()) {
+			fmt.Fprintf(&b, "  Cooldown:            restarts paused for %s\n", formatDuration(time.Until(t)))
+		}
+	}
+
+	if e := res.Exit(); e != nil {
+		fmt.Fprintf(&b, "\n%s\n", labelStyle.Render("Exit:"))
+		fmt.Fprintf(&b, "  Code:      %d\n", e.Code())
+		if c := e.Container(); c != "" {
+			fmt.Fprintf(&b, "  Container: %s\n", c)
+		}
+		if t := standard.FromTimestamp(e.At()); !t.IsZero() {
+			fmt.Fprintf(&b, "  At:        %s ago\n", formatDuration(time.Since(t)))
+		}
+	}
+
+	if containers := res.Containers(); len(containers) > 0 {
+		fmt.Fprintf(&b, "\n%s\n", labelStyle.Render("Containers:"))
+		for _, c := range containers {
+			cname := c.Name()
+			if cname == "" {
+				cname = "(pause)"
+			}
+			fmt.Fprintf(&b, "  %s: %s CPU, %s\n", cname,
+				formatCores(c.Cpu().Cores()), units.Bytes(c.Memory().Bytes()).Short())
+		}
+	}
+
+	if series := res.Series(); len(series) > 0 {
+		fmt.Fprintf(&b, "\n%s\n", labelStyle.Render("History:"))
+		for _, sr := range series {
+			fmt.Fprintf(&b, "  %s: %d points\n", sr.Metric(), len(sr.Points()))
+		}
+	}
+
+	if w := res.Window(); w != nil && w.HasStart() && w.HasEnd() {
+		span := standard.FromTimestamp(w.End()).Sub(standard.FromTimestamp(w.Start()))
+		fmt.Fprintf(&b, "\n%s\n", mutedStyle.Render(
+			fmt.Sprintf("measured over %s (%s)", formatDuration(span), w.Aggregate())))
+	}
+
+	b.WriteString(renderWarnings(res.Warnings()))
+
+	return b.String()
+}
+
+type inspectResultJSON struct {
+	Sandbox       sandboxUsageJSON  `json:"sandbox"`
+	Image         string            `json:"image,omitempty"`
+	RestartPolicy string            `json:"restart_policy,omitempty"`
+	ExitCode      *int32            `json:"exit_code,omitempty"`
+	ExitAt        string            `json:"exit_at,omitempty"`
+	ExitContainer string            `json:"exit_container,omitempty"`
+	CrashLoop     *crashLoopJSON    `json:"crash_loop,omitempty"`
+	Containers    []containerJSON   `json:"containers,omitempty"`
+	Series        []usageSeriesJSON `json:"series,omitempty"`
+	WindowStart   string            `json:"window_start,omitempty"`
+	WindowEnd     string            `json:"window_end,omitempty"`
+	Warnings      []string          `json:"warnings,omitempty"`
+}
+
+type crashLoopJSON struct {
+	ConsecutiveCrashes int32  `json:"consecutive_crashes"`
+	LastCrashAt        string `json:"last_crash_at,omitempty"`
+	CooldownUntil      string `json:"cooldown_until,omitempty"`
+}
+
+type containerJSON struct {
+	Name        string  `json:"name"`
+	CPUCores    float64 `json:"cpu_cores"`
+	MemoryBytes int64   `json:"memory_bytes"`
+}
+
+type usageSeriesJSON struct {
+	Metric string           `json:"metric"`
+	Points []usagePointJSON `json:"points"`
+}
+
+type usagePointJSON struct {
+	At    string  `json:"at"`
+	Value float64 `json:"value"`
+}
+
+func inspectJSON(res *usage_v1alpha.ResourceUsageClientGetSandboxResults) inspectResultJSON {
+	w := res.Usage()
+	ref := w.Ref()
+
+	out := inspectResultJSON{
+		Sandbox: sandboxUsageJSON{
+			Sandbox:      ref.Sandbox(),
+			SandboxShort: ref.SandboxShortId(),
+			App:          ref.App(),
+			Service:      ref.Service(),
+			Kind:         ref.Kind(),
+			Runner:       ref.NodeName(),
+			Node:         ref.Node(),
+			Status:       ref.Status(),
+			CPUCores:     w.Cpu().Cores(),
+			CPUNodePct:   w.Cpu().PercentOfNode(),
+			MemoryBytes:  w.Memory().Bytes(),
+			Stale:        w.Stale(),
+			StartedAt:    timestampRFC3339(ref.StartedAt()),
+		},
+		Image:         res.Image(),
+		RestartPolicy: res.RestartPolicy(),
+		Warnings:      res.Warnings(),
+	}
+
+	if win := res.Window(); win != nil {
+		out.WindowStart = timestampRFC3339(win.Start())
+		out.WindowEnd = timestampRFC3339(win.End())
+	}
+
+	if e := res.Exit(); e != nil {
+		code := e.Code()
+		out.ExitCode = &code
+		out.ExitAt = timestampRFC3339(e.At())
+		out.ExitContainer = e.Container()
+	}
+
+	if cl := res.CrashLoop(); cl != nil {
+		out.CrashLoop = &crashLoopJSON{
+			ConsecutiveCrashes: cl.ConsecutiveCrashes(),
+			LastCrashAt:        timestampRFC3339(cl.LastCrashAt()),
+			CooldownUntil:      timestampRFC3339(cl.CooldownUntil()),
+		}
+	}
+
+	for _, c := range res.Containers() {
+		out.Containers = append(out.Containers, containerJSON{
+			Name:        c.Name(),
+			CPUCores:    c.Cpu().Cores(),
+			MemoryBytes: c.Memory().Bytes(),
+		})
+	}
+
+	for _, s := range res.Series() {
+		sj := usageSeriesJSON{Metric: s.Metric()}
+		for _, p := range s.Points() {
+			sj.Points = append(sj.Points, usagePointJSON{
+				At:    timestampRFC3339(p.At()),
+				Value: p.Value(),
+			})
+		}
+		out.Series = append(out.Series, sj)
+	}
+
+	return out
+}

--- a/cli/commands/top.go
+++ b/cli/commands/top.go
@@ -59,7 +59,7 @@ type topOptions struct {
 	Since     string `long:"since" description:"Measure over this window, e.g. 30s, 5m, 1h (default 1m)"`
 	Aggregate string `long:"aggregate" description:"How to collapse the window: avg, max, min, last" default:"avg"`
 
-	Sort  string `long:"sort" description:"Sort by: cpu, memory, app, service, node" default:"cpu"`
+	Sort  string `long:"sort" description:"Sort by: cpu, memory, name, app, service, node" default:"cpu"`
 	Order string `long:"order" description:"Sort direction: desc or asc (default: desc for usage, asc for names)"`
 	Limit int    `long:"limit" description:"Show at most this many rows (0 for all)"`
 

--- a/cli/commands/top.go
+++ b/cli/commands/top.go
@@ -60,7 +60,7 @@ type topOptions struct {
 	Aggregate string `long:"aggregate" description:"How to collapse the window: avg, max, min, last" default:"avg"`
 
 	Sort  string `long:"sort" description:"Sort by: cpu, memory, app, service, node" default:"cpu"`
-	Order string `long:"order" description:"Sort direction: desc or asc" default:"desc"`
+	Order string `long:"order" description:"Sort direction: desc or asc (default: desc for usage, asc for names)"`
 	Limit int    `long:"limit" description:"Show at most this many rows (0 for all)"`
 
 	Watch    bool   `short:"w" long:"watch" description:"Refresh continuously until interrupted"`

--- a/cli/commands/top.go
+++ b/cli/commands/top.go
@@ -1,0 +1,817 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
+
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/pkg/rpc/standard"
+	"miren.dev/runtime/pkg/theme"
+	"miren.dev/runtime/pkg/ui"
+	"miren.dev/runtime/pkg/units"
+)
+
+// ServiceUsage is the cluster-wide resource usage service, served only by the
+// coordinator.
+const ServiceUsage = "dev.miren.runtime/usage"
+
+// mutedStyle renders the trailing summary and warning lines that sit under a
+// table, keeping them subordinate to the rows themselves. It matches the muted
+// label colour the other detail views use rather than borrowing doctor's
+// palette, which is scoped to that command's own output.
+var mutedStyle = lipgloss.NewStyle().Foreground(theme.Muted)
+
+// warnStyle marks a line reporting something the server could not answer.
+var warnStyle = lipgloss.NewStyle().Foreground(theme.Warning)
+
+// minWatchInterval floors how often a watch loop refreshes.
+//
+// Numbers reaching this command are already a few seconds old -- the collectors
+// sample once a second, the writer batches, and the query engine deliberately
+// lags to let late points land. Refreshing faster than that redraws the same
+// figures repeatedly while making a query per redraw, so the floor protects the
+// cluster from a watcher that gains nothing by asking harder.
+const minWatchInterval = 2 * time.Second
+
+type topOptions struct {
+	FormatOptions
+	ConfigCentric
+
+	App     string `long:"app" description:"Only show sandboxes belonging to this app"`
+	Service string `long:"service" description:"Only show sandboxes of this service (e.g. web, worker)"`
+	Runner  string `long:"runner" description:"Only show sandboxes on this runner (name, ID, or short ID)"`
+	Kind    string `long:"kind" description:"Only show sandboxes of this kind (app, addon, run)"`
+	Status  string `long:"status" description:"Only show sandboxes in this status"`
+
+	Nodes  bool `long:"nodes" description:"Show per-node usage instead of per-sandbox"`
+	Apps   bool `long:"apps" description:"Show per-app totals instead of per-sandbox"`
+	System bool `long:"system" description:"Include addon and platform sandboxes"`
+
+	NoAddons bool `long:"no-addons" description:"With --apps, exclude each app's dedicated addons from its total"`
+
+	Since     string `long:"since" description:"Measure over this window, e.g. 30s, 5m, 1h (default 1m)"`
+	Aggregate string `long:"aggregate" description:"How to collapse the window: avg, max, min, last" default:"avg"`
+
+	Sort  string `long:"sort" description:"Sort by: cpu, memory, app, service, node" default:"cpu"`
+	Order string `long:"order" description:"Sort direction: desc or asc" default:"desc"`
+	Limit int    `long:"limit" description:"Show at most this many rows (0 for all)"`
+
+	Watch    bool   `short:"w" long:"watch" description:"Refresh continuously until interrupted"`
+	Interval string `long:"interval" description:"Refresh interval when watching" default:"5s"`
+	Samples  int    `long:"samples" description:"Stop after this many refreshes (0 for unlimited)"`
+}
+
+// Top reports what a cluster is spending its CPU and memory on.
+func Top(ctx *Context, opts topOptions) error {
+	client, err := ctx.RPCClient(ServiceUsage)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	uc := usage_v1alpha.NewResourceUsageClient(client)
+
+	lookback, err := parseTopDuration(opts.Since)
+	if err != nil {
+		return fmt.Errorf("--since: %w", err)
+	}
+
+	q := topQuery{client: uc, opts: opts, lookback: lookback}
+
+	// JSON is a single snapshot even under --watch: a stream of whole documents
+	// is not something a consumer can parse, and the flags contradict rather
+	// than compose.
+	if opts.IsJSON() {
+		return q.renderJSON(ctx)
+	}
+
+	// --samples implies watching: asking for six of something is asking for it
+	// more than once, and requiring --watch alongside it would only be a way to
+	// get the flag combination wrong.
+	if !opts.Watch && opts.Samples <= 1 {
+		out, err := q.render(ctx)
+		if err != nil {
+			return err
+		}
+		ctx.Printf("%s", out)
+		return nil
+	}
+
+	interval, err := time.ParseDuration(opts.Interval)
+	if err != nil {
+		return fmt.Errorf("--interval: %w", err)
+	}
+	if interval < minWatchInterval {
+		interval = minWatchInterval
+	}
+
+	// Two cases print successive snapshots instead of redrawing one in place.
+	//
+	// A bounded run keeps all of its samples, because the point of asking for
+	// six of them is to compare them. And a run with no terminal has nothing to
+	// redraw in: piped to a file or called from a script, the TUI library fails
+	// with an error about /dev/tty that tells the reader nothing about what to
+	// do, so it falls back the way top -b does.
+	if opts.Samples > 0 || !term.IsTerminal(int(os.Stdout.Fd())) {
+		return q.watchBatch(ctx, interval, opts.Samples)
+	}
+
+	return q.watch(ctx, interval)
+}
+
+// watchBatch prints a fresh snapshot every interval, separated by a timestamp.
+// It runs samples times, or until interrupted when samples is zero. Used for a
+// bounded run, and whenever there is no terminal to redraw in.
+func (q topQuery) watchBatch(ctx *Context, interval time.Duration, samples int) error {
+	for n := 0; samples <= 0 || n < samples; n++ {
+		out, err := q.render(ctx)
+		if err != nil {
+			return err
+		}
+
+		ctx.Printf("%s\n%s\n", mutedStyle.Render(time.Now().Format(time.RFC3339)), out)
+
+		if samples > 0 && n == samples-1 {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(interval):
+		}
+	}
+
+	return nil
+}
+
+// topQuery holds everything a single refresh needs, so the watch loop and the
+// one-shot path render through exactly the same code.
+type topQuery struct {
+	client   *usage_v1alpha.ResourceUsageClient
+	opts     topOptions
+	lookback time.Duration
+}
+
+// selector, window and ordering build the three request groups once, so all
+// three views ask the same way and a new flag has one place to land.
+func (q topQuery) selector() *usage_v1alpha.Selector {
+	o := q.opts
+
+	var sel usage_v1alpha.Selector
+	sel.SetApp(o.App)
+	sel.SetService(o.Service)
+	sel.SetNode(o.Runner)
+	sel.SetKind(o.Kind)
+	sel.SetStatus(o.Status)
+	sel.SetIncludeSystem(o.System)
+	sel.SetIncludeAddons(!o.NoAddons)
+
+	return &sel
+}
+
+func (q topQuery) window() *usage_v1alpha.Window {
+	var w usage_v1alpha.Window
+
+	// Only the start is sent. The server treats an unset end as now, which is
+	// what a live view wants, and sending a client-computed "now" would make
+	// the window depend on clock skew between the two machines.
+	if q.lookback > 0 {
+		w.SetStart(standard.ToTimestamp(time.Now().Add(-q.lookback)))
+	}
+	w.SetAggregate(q.opts.Aggregate)
+
+	return &w
+}
+
+func (q topQuery) ordering() *usage_v1alpha.Ordering {
+	var o usage_v1alpha.Ordering
+	o.SetSort(q.opts.Sort)
+	o.SetOrder(q.opts.Order)
+	o.SetLimit(int32(q.opts.Limit))
+	return &o
+}
+
+func (q topQuery) fetchSandboxes(ctx context.Context) (*usage_v1alpha.ResourceUsageClientListSandboxesResults, error) {
+	return q.client.ListSandboxes(ctx, q.selector(), q.window(), q.ordering())
+}
+
+func (q topQuery) fetchNodes(ctx context.Context) (*usage_v1alpha.ResourceUsageClientListNodesResults, error) {
+	return q.client.ListNodes(ctx, q.selector(), q.window(), q.ordering())
+}
+
+func (q topQuery) fetchApps(ctx context.Context) (*usage_v1alpha.ResourceUsageClientListAppsResults, error) {
+	return q.client.ListApps(ctx, q.selector(), q.window(), q.ordering())
+}
+
+func (q topQuery) renderJSON(ctx *Context) error {
+	if q.opts.Apps {
+		res, err := q.fetchApps(ctx)
+		if err != nil {
+			return err
+		}
+		return PrintJSON(appsJSON(res))
+	}
+
+	if q.opts.Nodes {
+		res, err := q.fetchNodes(ctx)
+		if err != nil {
+			return err
+		}
+		return PrintJSON(nodesJSON(res))
+	}
+
+	res, err := q.fetchSandboxes(ctx)
+	if err != nil {
+		return err
+	}
+	return PrintJSON(sandboxesJSON(res))
+}
+
+func (q topQuery) render(ctx context.Context) (string, error) {
+	if q.opts.Apps {
+		res, err := q.fetchApps(ctx)
+		if err != nil {
+			return "", err
+		}
+		return renderAppTable(res), nil
+	}
+
+	if q.opts.Nodes {
+		res, err := q.fetchNodes(ctx)
+		if err != nil {
+			return "", err
+		}
+		return renderNodeTable(res), nil
+	}
+
+	res, err := q.fetchSandboxes(ctx)
+	if err != nil {
+		return "", err
+	}
+	return renderSandboxTable(res), nil
+}
+
+// --- table rendering ---
+
+func renderSandboxTable(res *usage_v1alpha.ResourceUsageClientListSandboxesResults) string {
+	sandboxes := res.Sandboxes()
+	if len(sandboxes) == 0 {
+		return "No sandboxes are reporting usage.\n" + renderWarnings(res.Warnings())
+	}
+
+	headers := []string{"APP", "SERVICE", "RUNNER", "CPU", "NODE%", "MEM", "STATUS"}
+	rows := make([]ui.Row, 0, len(sandboxes))
+
+	for _, w := range sandboxes {
+		ref := w.Ref()
+
+		// A stale row is one whose sandbox is running but reporting nothing.
+		// Its numbers are shown as unknown rather than zero, because zero would
+		// read as idle when the truth is that nobody is measuring.
+		cpu, nodePct, mem := "-", "-", "-"
+		if !w.Stale() {
+			cpu = formatCores(w.Cpu().Cores())
+			mem = units.Bytes(w.Memory().Bytes()).Short()
+
+			// A zero share has two causes that must not look alike: the
+			// sandbox is genuinely idle, or its node never reported a core
+			// count to divide by. Only the second is unknown.
+			switch {
+			case w.Cpu().Cores() == 0:
+				nodePct = "0%"
+			case w.Cpu().PercentOfNode() > 0:
+				nodePct = fmt.Sprintf("%.0f%%", w.Cpu().PercentOfNode())
+			}
+		}
+
+		rows = append(rows, ui.Row{
+			orDash(ref.App()),
+			orDash(ref.Service()),
+			orDash(ref.NodeName()),
+			cpu,
+			nodePct,
+			mem,
+			orDash(ref.Status()),
+		})
+	}
+
+	out := renderUsageTable(headers, rows)
+	out += "\n" + renderFooter(res.Cluster(), res.Window(), int(res.TotalCount()), len(sandboxes))
+	out += renderWarnings(res.Warnings())
+
+	return out
+}
+
+func renderNodeTable(res *usage_v1alpha.ResourceUsageClientListNodesResults) string {
+	nodes := res.Nodes()
+	if len(nodes) == 0 {
+		return "No nodes are reporting usage.\n" + renderWarnings(res.Warnings())
+	}
+
+	// The sandbox and system columns are the point of this view: they say
+	// whether a hot node is hot because of someone's app or because of the
+	// platform underneath it.
+	headers := []string{"NODE", "ROLE", "CPU", "SANDBOX", "SYSTEM", "CORES", "MEM", "TOTAL", "LOAD", "PODS", "STATUS"}
+	rows := make([]ui.Row, 0, len(nodes))
+
+	for _, n := range nodes {
+		cpu, sandboxCPU, systemCPU, cores := "-", "-", "-", "-"
+		mem, memTotal := "-", "-"
+
+		if !n.Stale() {
+			cpu = formatCores(n.Total().CpuCores())
+			sandboxCPU = formatCores(n.Sandboxes().CpuCores())
+			systemCPU = formatCores(n.System().CpuCores())
+			mem = units.Bytes(n.Total().MemoryBytes()).Short()
+		}
+		if c := n.Capacity().CpuCores(); c > 0 {
+			cores = fmt.Sprintf("%.0f", c)
+		}
+		if b := n.Capacity().MemoryBytes(); b > 0 {
+			memTotal = units.Bytes(b).Short()
+		}
+
+		status := n.Status()
+		if n.Stale() {
+			status = "not reporting"
+		} else if n.Scheduling() == "cordoned" {
+			status += " (cordoned)"
+		}
+
+		rows = append(rows, ui.Row{
+			orDash(n.NodeName()),
+			orDash(n.Role()),
+			cpu,
+			sandboxCPU,
+			systemCPU,
+			cores,
+			mem,
+			memTotal,
+			fmt.Sprintf("%.2f", n.Load1()),
+			fmt.Sprintf("%d", n.SandboxCount()),
+			orDash(status),
+		})
+	}
+
+	out := renderUsageTable(headers, rows)
+	out += "\n" + renderFooter(res.Cluster(), res.Window(), len(nodes), len(nodes))
+	out += renderWarnings(res.Warnings())
+
+	return out
+}
+
+func renderUsageTable(headers []string, rows []ui.Row) string {
+	columns := ui.AutoSizeColumns(headers, rows, nil)
+	table := ui.NewTable(ui.WithColumns(columns), ui.WithRows(rows))
+	return table.Render() + "\n"
+}
+
+func renderFooter(cluster *usage_v1alpha.ResourceTotals, w *usage_v1alpha.UsageWindow, total, shown int) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s CPU, %s memory",
+		formatCores(cluster.CpuCores()), units.Bytes(cluster.MemoryBytes()).Short())
+
+	if w != nil && w.HasStart() && w.HasEnd() {
+		span := standard.FromTimestamp(w.End()).Sub(standard.FromTimestamp(w.Start()))
+		fmt.Fprintf(&b, " over %s (%s)", formatDuration(span), w.Aggregate())
+	}
+
+	if total > shown {
+		fmt.Fprintf(&b, ", showing %d of %d", shown, total)
+	}
+
+	return mutedStyle.Render(b.String()) + "\n"
+}
+
+// renderWarnings surfaces what the server could not answer. These are printed
+// rather than swallowed because a missing column has a cause, and an operator
+// staring at blank numbers deserves to know it was the query and not the app.
+func renderWarnings(warnings []string) string {
+	if len(warnings) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, w := range warnings {
+		fmt.Fprintf(&b, "%s %s\n", warnStyle.Render("warning:"), w)
+	}
+	return b.String()
+}
+
+// --- JSON output ---
+
+type sandboxUsageJSON struct {
+	Sandbox      string  `json:"sandbox"`
+	SandboxShort string  `json:"sandbox_short_id,omitempty"`
+	App          string  `json:"app,omitempty"`
+	Service      string  `json:"service,omitempty"`
+	Kind         string  `json:"kind,omitempty"`
+	Runner       string  `json:"runner,omitempty"`
+	Node         string  `json:"node,omitempty"`
+	Status       string  `json:"status,omitempty"`
+	CPUCores     float64 `json:"cpu_cores"`
+	CPUNodePct   float64 `json:"cpu_percent_of_node"`
+	MemoryBytes  int64   `json:"memory_bytes"`
+	Stale        bool    `json:"stale"`
+	StartedAt    string  `json:"started_at,omitempty"`
+}
+
+type sandboxListJSON struct {
+	Sandboxes   []sandboxUsageJSON `json:"sandboxes"`
+	TotalCount  int32              `json:"total_count"`
+	WindowStart string             `json:"window_start,omitempty"`
+	WindowEnd   string             `json:"window_end,omitempty"`
+	Aggregate   string             `json:"aggregate,omitempty"`
+	Warnings    []string           `json:"warnings,omitempty"`
+}
+
+func sandboxesJSON(res *usage_v1alpha.ResourceUsageClientListSandboxesResults) sandboxListJSON {
+	out := sandboxListJSON{
+		Sandboxes:  make([]sandboxUsageJSON, 0, len(res.Sandboxes())),
+		TotalCount: res.TotalCount(),
+		Warnings:   res.Warnings(),
+	}
+
+	if w := res.Window(); w != nil {
+		out.WindowStart = timestampRFC3339(w.Start())
+		out.WindowEnd = timestampRFC3339(w.End())
+		out.Aggregate = w.Aggregate()
+	}
+
+	for _, w := range res.Sandboxes() {
+		ref := w.Ref()
+		out.Sandboxes = append(out.Sandboxes, sandboxUsageJSON{
+			Sandbox:      ref.Sandbox(),
+			SandboxShort: ref.SandboxShortId(),
+			App:          ref.App(),
+			Service:      ref.Service(),
+			Kind:         ref.Kind(),
+			Runner:       ref.NodeName(),
+			Node:         ref.Node(),
+			Status:       ref.Status(),
+			CPUCores:     w.Cpu().Cores(),
+			CPUNodePct:   w.Cpu().PercentOfNode(),
+			MemoryBytes:  w.Memory().Bytes(),
+			Stale:        w.Stale(),
+			StartedAt:    timestampRFC3339(ref.StartedAt()),
+		})
+	}
+
+	return out
+}
+
+type nodeJSON struct {
+	Node               string  `json:"node"`
+	Name               string  `json:"name,omitempty"`
+	RunnerID           string  `json:"runner_id,omitempty"`
+	Role               string  `json:"role,omitempty"`
+	Status             string  `json:"status,omitempty"`
+	Scheduling         string  `json:"scheduling,omitempty"`
+	CPUCoresTotal      float64 `json:"cpu_cores_total"`
+	CPUCoresUsed       float64 `json:"cpu_cores_used"`
+	CPUCoresSandbox    float64 `json:"cpu_cores_sandbox"`
+	CPUCoresSystem     float64 `json:"cpu_cores_system"`
+	MemoryBytesTotal   int64   `json:"memory_bytes_total"`
+	MemoryBytesUsed    int64   `json:"memory_bytes_used"`
+	MemoryBytesSandbox int64   `json:"memory_bytes_sandbox"`
+	MemoryBytesSystem  int64   `json:"memory_bytes_system"`
+	Load1              float64 `json:"load1"`
+	Load5              float64 `json:"load5"`
+	Load15             float64 `json:"load15"`
+	SandboxCount       int64   `json:"sandbox_count"`
+	Stale              bool    `json:"stale"`
+}
+
+type nodeListJSON struct {
+	Nodes       []nodeJSON `json:"nodes"`
+	WindowStart string     `json:"window_start,omitempty"`
+	WindowEnd   string     `json:"window_end,omitempty"`
+	Aggregate   string     `json:"aggregate,omitempty"`
+	Warnings    []string   `json:"warnings,omitempty"`
+}
+
+func nodesJSON(res *usage_v1alpha.ResourceUsageClientListNodesResults) nodeListJSON {
+	out := nodeListJSON{
+		Nodes:    make([]nodeJSON, 0, len(res.Nodes())),
+		Warnings: res.Warnings(),
+	}
+
+	if w := res.Window(); w != nil {
+		out.WindowStart = timestampRFC3339(w.Start())
+		out.WindowEnd = timestampRFC3339(w.End())
+		out.Aggregate = w.Aggregate()
+	}
+
+	for _, n := range res.Nodes() {
+		out.Nodes = append(out.Nodes, nodeJSON{
+			Node:               n.Node(),
+			Name:               n.NodeName(),
+			RunnerID:           n.RunnerId(),
+			Role:               n.Role(),
+			Status:             n.Status(),
+			Scheduling:         n.Scheduling(),
+			CPUCoresTotal:      n.Capacity().CpuCores(),
+			CPUCoresUsed:       n.Total().CpuCores(),
+			CPUCoresSandbox:    n.Sandboxes().CpuCores(),
+			CPUCoresSystem:     n.System().CpuCores(),
+			MemoryBytesTotal:   n.Capacity().MemoryBytes(),
+			MemoryBytesUsed:    n.Total().MemoryBytes(),
+			MemoryBytesSandbox: n.Sandboxes().MemoryBytes(),
+			MemoryBytesSystem:  n.System().MemoryBytes(),
+			Load1:              n.Load1(),
+			Load5:              n.Load5(),
+			Load15:             n.Load15(),
+			SandboxCount:       n.SandboxCount(),
+			Stale:              n.Stale(),
+		})
+	}
+
+	return out
+}
+
+// --- watch mode ---
+
+type topModel struct {
+	q        topQuery
+	interval time.Duration
+
+	// ctx bounds every refresh this model issues. Without it a hung query
+	// would run to completion after the user has already quit, and there would
+	// be no way to interrupt it.
+	ctx context.Context
+
+	body     string
+	err      error
+	quitting bool
+}
+
+// topResultMsg carries a completed refresh back to Update.
+//
+// The result travels in the message rather than being written to the model
+// because bubbletea runs every tea.Cmd on its own goroutine. Assigning to the
+// model from inside a command would race with View reading it, and Update is
+// the only place bubbletea guarantees exclusive access.
+type topResultMsg struct {
+	body string
+	err  error
+}
+
+type topRefreshMsg struct{}
+
+func (q topQuery) watch(ctx *Context, interval time.Duration) error {
+	m := &topModel{q: q, interval: interval, ctx: ctx}
+
+	prog := tea.NewProgram(m)
+	if _, err := prog.Run(); err != nil {
+		return err
+	}
+
+	return m.err
+}
+
+func (m *topModel) Init() tea.Cmd {
+	return m.refresh()
+}
+
+func (m *topModel) refresh() tea.Cmd {
+	ctx := m.ctx
+	q := m.q
+
+	return func() tea.Msg {
+		body, err := q.render(ctx)
+		return topResultMsg{body: body, err: err}
+	}
+}
+
+func (m *topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+		case "r":
+			return m, m.refresh()
+		}
+
+	case topResultMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			return m, tea.Quit
+		}
+
+		m.body = msg.body
+
+		if m.quitting {
+			return m, tea.Quit
+		}
+
+		return m, tea.Tick(m.interval, func(time.Time) tea.Msg {
+			return topRefreshMsg{}
+		})
+
+	case topRefreshMsg:
+		if m.quitting {
+			return m, tea.Quit
+		}
+		return m, m.refresh()
+	}
+
+	return m, nil
+}
+
+func (m *topModel) View() string {
+	if m.err != nil {
+		return fmt.Sprintf("error: %v\n", m.err)
+	}
+	if m.body == "" {
+		return "Collecting usage...\n"
+	}
+	return m.body + mutedStyle.Render(fmt.Sprintf("refreshing every %s - q to quit, r to refresh now", m.interval)) + "\n"
+}
+
+// --- helpers ---
+
+// formatCores renders CPU the way top does: as a percentage of one core, which
+// exceeds 100% for a sandbox using more than one core.
+func formatCores(cores float64) string {
+	return fmt.Sprintf("%.0f%%", cores*100)
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func timestampRFC3339(ts *standard.Timestamp) string {
+	if ts == nil {
+		return ""
+	}
+	t := standard.FromTimestamp(ts)
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}
+
+// parseTopDuration reads a window flag. An empty value yields zero, which
+// leaves the server to pick its own default.
+func parseTopDuration(s string) (time.Duration, error) {
+	if strings.TrimSpace(s) == "" {
+		return 0, nil
+	}
+
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("must be positive, got %s", s)
+	}
+
+	return d, nil
+}
+
+const topDescription = `Show what a cluster is spending its CPU and memory on, ordered by the busiest.
+
+Each row is one live sandbox. Three replicas of a service are three rows, and
+dead sandboxes are left out entirely. By default only app sandboxes are listed;
+addon servers and one-off task runs are hidden unless you pass --system, so the
+listing answers "what are my apps doing".
+
+CPU is reported the way top reports it: as a percentage of one core. A sandbox
+using two full cores reads 200%. NODE% is the same figure against the host it
+runs on, which is what says whether 200% matters.
+
+Four flags cover most investigations:
+
+  --nodes     Which machine is hot, split into what sandboxes are using and what
+              Miren's own moving parts are using underneath them. Start here.
+  --apps      One row per app instead of per sandbox, summed across everything
+              that app owns. See below.
+  --runner    Narrow to one host once you know which.
+  --since     Look back. A live view only shows now, so a spike that has already
+              passed is invisible; --since 1h --aggregate max finds it.
+
+--apps answers "what is app X costing me" without you adding up rows. An app's
+total includes the dedicated addons it owns -- a database exists because the app
+asked for it -- and the SERVICES and ADDONS columns show how the total divides,
+so "2.1 cores, 1.6 of it Postgres" is one line rather than an investigation.
+Pass --no-addons to count only the app's own code.
+
+There is no restart column. Miren replaces a failed sandbox rather than
+restarting it, so no single sandbox accumulates a restart count; repeated
+failure shows up as a crash loop on the pool, which "miren sandbox inspect"
+reports.
+
+A row showing "-" for its numbers is running but reporting nothing. That is a
+finding rather than an omission: either it has just started, or metrics
+collection is down for it.
+`
+
+func renderAppTable(res *usage_v1alpha.ResourceUsageClientListAppsResults) string {
+	apps := res.Apps()
+	if len(apps) == 0 {
+		return "No apps are reporting usage.\n" + renderWarnings(res.Warnings())
+	}
+
+	// SERVICES and ADDONS break the total down, so a busy app can be attributed
+	// to the code someone wrote or to the database it depends on.
+	headers := []string{"APP", "CPU", "SERVICES", "ADDONS", "MEM", "SANDBOXES"}
+	rows := make([]ui.Row, 0, len(apps))
+
+	for _, a := range apps {
+		cpu, services, addons, mem := "-", "-", "-", "-"
+		if !a.Stale() {
+			cpu = formatCores(a.Total().CpuCores())
+			services = formatCores(a.Services().CpuCores())
+			addons = formatCores(a.Addons().CpuCores())
+			mem = units.Bytes(a.Total().MemoryBytes()).Short()
+		}
+
+		// An app with no addons shows a dash rather than 0%, so an empty column
+		// reads as "none of these" rather than "these are idle".
+		if a.AddonCount() == 0 {
+			addons = "-"
+		}
+
+		counts := fmt.Sprintf("%d", a.SandboxCount())
+		if a.AddonCount() > 0 {
+			counts = fmt.Sprintf("%d (+%d addon)", a.ServiceCount(), a.AddonCount())
+		}
+
+		rows = append(rows, ui.Row{orDash(a.App()), cpu, services, addons, mem, counts})
+	}
+
+	out := renderUsageTable(headers, rows)
+	out += "\n" + renderFooter(res.Cluster(), res.Window(), int(res.TotalCount()), len(apps))
+	out += renderWarnings(res.Warnings())
+
+	return out
+}
+
+type appUsageJSON struct {
+	App                string  `json:"app"`
+	AppID              string  `json:"app_id,omitempty"`
+	CPUCores           float64 `json:"cpu_cores"`
+	CPUCoresServices   float64 `json:"cpu_cores_services"`
+	CPUCoresAddons     float64 `json:"cpu_cores_addons"`
+	MemoryBytes        int64   `json:"memory_bytes"`
+	MemoryBytesService int64   `json:"memory_bytes_services"`
+	MemoryBytesAddons  int64   `json:"memory_bytes_addons"`
+	SandboxCount       int64   `json:"sandbox_count"`
+	ServiceCount       int64   `json:"service_count"`
+	AddonCount         int64   `json:"addon_count"`
+	Stale              bool    `json:"stale"`
+}
+
+type appListJSON struct {
+	Apps        []appUsageJSON `json:"apps"`
+	WindowStart string         `json:"window_start,omitempty"`
+	WindowEnd   string         `json:"window_end,omitempty"`
+	Aggregate   string         `json:"aggregate,omitempty"`
+	Warnings    []string       `json:"warnings,omitempty"`
+}
+
+func appsJSON(res *usage_v1alpha.ResourceUsageClientListAppsResults) appListJSON {
+	out := appListJSON{
+		Apps:     make([]appUsageJSON, 0, len(res.Apps())),
+		Warnings: res.Warnings(),
+	}
+
+	if w := res.Window(); w != nil {
+		out.WindowStart = timestampRFC3339(w.Start())
+		out.WindowEnd = timestampRFC3339(w.End())
+		out.Aggregate = w.Aggregate()
+	}
+
+	for _, a := range res.Apps() {
+		out.Apps = append(out.Apps, appUsageJSON{
+			App:                a.App(),
+			AppID:              a.AppId(),
+			CPUCores:           a.Total().CpuCores(),
+			CPUCoresServices:   a.Services().CpuCores(),
+			CPUCoresAddons:     a.Addons().CpuCores(),
+			MemoryBytes:        a.Total().MemoryBytes(),
+			MemoryBytesService: a.Services().MemoryBytes(),
+			MemoryBytesAddons:  a.Addons().MemoryBytes(),
+			SandboxCount:       a.SandboxCount(),
+			ServiceCount:       a.ServiceCount(),
+			AddonCount:         a.AddonCount(),
+			Stale:              a.Stale(),
+		})
+	}
+
+	return out
+}

--- a/cli/commands/top.go
+++ b/cli/commands/top.go
@@ -552,6 +552,13 @@ type topModel struct {
 	body     string
 	err      error
 	quitting bool
+
+	// gen identifies the current refresh chain. Every refresh starts a new one,
+	// and messages from an older chain are dropped. Without it, pressing r
+	// while a tick is already pending leaves both running: the manual refresh
+	// schedules its own tick, the pending one fires and schedules another, and
+	// the poll rate doubles for every press.
+	gen int
 }
 
 // topResultMsg carries a completed refresh back to Update.
@@ -561,11 +568,14 @@ type topModel struct {
 // model from inside a command would race with View reading it, and Update is
 // the only place bubbletea guarantees exclusive access.
 type topResultMsg struct {
+	gen  int
 	body string
 	err  error
 }
 
-type topRefreshMsg struct{}
+type topRefreshMsg struct {
+	gen int
+}
 
 func (q topQuery) watch(ctx *Context, interval time.Duration) error {
 	m := &topModel{q: q, interval: interval, ctx: ctx}
@@ -582,13 +592,19 @@ func (m *topModel) Init() tea.Cmd {
 	return m.refresh()
 }
 
+// refresh starts a new chain and returns the command that runs it. It is only
+// ever called from Init and Update, so the write to gen is on bubbletea's own
+// goroutine; the command reads the captured copy instead of the field.
 func (m *topModel) refresh() tea.Cmd {
 	ctx := m.ctx
 	q := m.q
 
+	m.gen++
+	gen := m.gen
+
 	return func() tea.Msg {
 		body, err := q.render(ctx)
-		return topResultMsg{body: body, err: err}
+		return topResultMsg{gen: gen, body: body, err: err}
 	}
 }
 
@@ -604,9 +620,15 @@ func (m *topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case topResultMsg:
+		// An error is worth reporting whichever chain found it, but a stale
+		// body is not worth drawing: a newer refresh is already on its way.
 		if msg.err != nil {
 			m.err = msg.err
 			return m, tea.Quit
+		}
+
+		if msg.gen != m.gen {
+			return m, nil
 		}
 
 		m.body = msg.body
@@ -615,11 +637,15 @@ func (m *topModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
+		gen := m.gen
 		return m, tea.Tick(m.interval, func(time.Time) tea.Msg {
-			return topRefreshMsg{}
+			return topRefreshMsg{gen: gen}
 		})
 
 	case topRefreshMsg:
+		if msg.gen != m.gen {
+			return m, nil
+		}
 		if m.quitting {
 			return m, tea.Quit
 		}

--- a/cli/commands/top_test.go
+++ b/cli/commands/top_test.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+func newTopModel() *topModel {
+	// The interval only has to be short enough that running a scheduled tick
+	// does not slow the test; nothing here measures elapsed time.
+	return &topModel{interval: time.Millisecond, ctx: context.Background()}
+}
+
+func pressR() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+}
+
+// A completed refresh schedules the next tick, so a manual refresh arriving
+// while one is already pending leaves two chains running: the manual result
+// schedules its own tick, the pending one fires and schedules another, and the
+// poll rate doubles for every press. In the node view one refresh is several
+// metrics queries, so this is not a subtle cost.
+func TestTopWatchManualRefreshDoesNotMultiplyThePollRate(t *testing.T) {
+	r := require.New(t)
+	m := newTopModel()
+
+	r.NotNil(m.Init(), "the model refreshes on start")
+
+	_, cmd := m.Update(topResultMsg{gen: 1, body: "first"})
+	r.NotNil(cmd)
+	r.Equal(topRefreshMsg{gen: 1}, cmd(), "a result schedules the next tick")
+
+	_, cmd = m.Update(pressR())
+	r.NotNil(cmd, "r refreshes immediately")
+
+	_, cmd = m.Update(topRefreshMsg{gen: 1})
+	r.Nil(cmd, "the superseded chain's tick must not start another refresh")
+
+	_, cmd = m.Update(topResultMsg{gen: 2, body: "second"})
+	r.NotNil(cmd)
+	r.Equal(topRefreshMsg{gen: 2}, cmd(), "the current chain schedules its own tick")
+	r.Equal("second", m.body)
+
+	_, cmd = m.Update(topRefreshMsg{gen: 2})
+	r.NotNil(cmd, "the current chain keeps refreshing")
+}
+
+// Two presses in quick succession leave two refreshes in flight. The first to
+// return is already out of date, and drawing it would show the older of the two
+// snapshots.
+func TestTopWatchIgnoresASupersededResult(t *testing.T) {
+	r := require.New(t)
+	m := newTopModel()
+
+	m.Init()
+	m.Update(pressR())
+
+	_, cmd := m.Update(topResultMsg{gen: 1, body: "stale"})
+	r.Nil(cmd, "a superseded result must not schedule a tick")
+	r.Empty(m.body, "a superseded result must not be drawn")
+}
+
+// Which chain found a failure says nothing about whether it is real, so an
+// error is reported even when its refresh has been superseded.
+func TestTopWatchReportsAnErrorFromAnySuperseededChain(t *testing.T) {
+	r := require.New(t)
+	m := newTopModel()
+
+	m.Init()
+	m.Update(pressR())
+
+	boom := errors.New("metrics backend unreachable")
+	_, cmd := m.Update(topResultMsg{gen: 1, err: boom})
+
+	r.Equal(boom, m.err)
+	r.NotNil(cmd, "an error quits rather than waiting for the current chain")
+}

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -54,8 +54,14 @@ type CoordinatorConfig struct {
 	Cpu           *metrics.CPUUsage
 	HTTP          *metrics.HTTPMetrics
 	MetricsWriter *metrics.VictoriaMetricsWriter
-	Logs          *observability.LogReader
-	LogWriter     observability.LogWriter
+
+	// MetricsReader queries the cluster's metrics directly, rather than through
+	// the app-shaped helpers on Cpu and Mem. The usage service needs arbitrary
+	// groupings -- by sandbox, by node -- that those helpers do not express.
+	MetricsReader *metrics.VictoriaMetricsReader
+
+	Logs      *observability.LogReader
+	LogWriter observability.LogWriter
 
 	// Observability addresses for distributed runners
 	VictoriametricsAddress string

--- a/components/coordinate/resource_usage.go
+++ b/components/coordinate/resource_usage.go
@@ -1,0 +1,42 @@
+package coordinate
+
+import (
+	"context"
+	"errors"
+
+	aes "miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	usagesrv "miren.dev/runtime/servers/usage"
+)
+
+// NewResourceUsage constructs the cluster-wide usage service on top of an
+// already-created foundation.
+func NewResourceUsage(foundation *Foundation) *ResourceUsage {
+	return &ResourceUsage{Foundation: foundation}
+}
+
+// ResourceUsage answers what the cluster is spending its CPU and memory on.
+//
+// This lives only on the coordinator because it is the only process holding
+// both the entity store and a reader for every node's metrics; a runner can
+// answer for itself but not for the cluster.
+type ResourceUsage struct {
+	*Foundation
+}
+
+// Start exposes usage queries to clients. A nil MetricsReader is not an error:
+// the service still answers "what is running where" from the entity store, and
+// reports the figures it cannot measure as warnings.
+func (c *ResourceUsage) Start(ctx context.Context) error {
+	if c.state == nil || c.eac == nil {
+		return errors.New("cluster foundation is not ready")
+	}
+
+	ec := aes.NewClient(c.Log, c.eac)
+
+	server := c.state.Server()
+	server.ExposeValue("dev.miren.runtime/usage",
+		usage_v1alpha.AdaptResourceUsage(usagesrv.NewServer(c.Log, ec, c.MetricsReader)))
+
+	return nil
+}

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -82,7 +82,12 @@ type RunnerDeps struct {
 	LogsMaintainer *observability.LogsMaintainer
 	LogWriter      observability.LogWriter
 	StatusMon      *observability.StatusMonitor
-	MetricsWriter  *metrics.VictoriaMetricsWriter
+
+	// MetricsWriter is also where host-level resource series are published. It
+	// is the same writer the sandbox collectors use, taken directly rather than
+	// through them because node series are labeled by node rather than by
+	// sandbox. Nil disables host metrics, as it does for sandbox metrics.
+	MetricsWriter *metrics.VictoriaMetricsWriter
 
 	// Network config
 	IPv4Routable    netip.Prefix
@@ -953,6 +958,15 @@ func (r *SandboxHost) SetupControllers(
 			"node": r.Id,
 		}),
 	)
+
+	// Host-level metrics start here rather than alongside the other collectors
+	// in boot because this is the one place that runs for both the
+	// coordinator's embedded runner and a distributed one, and it is where the
+	// node identity these series are keyed by is known.
+	if r.deps.MetricsWriter != nil {
+		nodeUsage := metrics.NewNodeUsage(r.Log, r.deps.MetricsWriter, r.nodeId().String(), r.Id, r.DataPath)
+		go nodeUsage.Monitor(ctx)
+	}
 
 	// Initialize NetServ if not provided (distributed runner mode)
 	if r.deps.NetServ == nil {

--- a/components/server/boot_foundation.go
+++ b/components/server/boot_foundation.go
@@ -48,6 +48,7 @@ func (b *foundationBoot) start(ctx context.Context, ipDiscovery ipDiscoveryBootO
 	config.Cpu = observability.cpu
 	config.HTTP = observability.http
 	config.MetricsWriter = observability.metricsWriter
+	config.MetricsReader = observability.metricsReader
 	config.Logs = observability.logs
 	config.LogWriter = observability.logWriter
 	config.VictoriametricsAddress = observability.victoriaMetricsAddress

--- a/components/server/boot_resource_usage.go
+++ b/components/server/boot_resource_usage.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package server
+
+import (
+	"context"
+
+	"miren.dev/runtime/components/coordinate"
+	"miren.dev/runtime/pkg/boot"
+)
+
+type resourceUsageBootOutput struct {
+	resourceUsage *coordinate.ResourceUsage
+}
+
+type resourceUsageBoot struct {
+	component *boot.Component
+	value     *coordinate.ResourceUsage
+	output    boot.Output[resourceUsageBootOutput]
+}
+
+func newResourceUsageBoot(foundation boot.Output[foundationBootOutput]) *resourceUsageBoot {
+	b := &resourceUsageBoot{}
+	b.component, b.output = boot.Provide1("resource-usage", foundation, b.start)
+	return b
+}
+
+func (b *resourceUsageBoot) start(ctx context.Context, foundation foundationBootOutput) (resourceUsageBootOutput, error) {
+	b.value = coordinate.NewResourceUsage(foundation.foundation)
+	if err := b.value.Start(ctx); err != nil {
+		return resourceUsageBootOutput{}, err
+	}
+	return resourceUsageBootOutput{resourceUsage: b.value}, nil
+}

--- a/components/server/runtime.go
+++ b/components/server/runtime.go
@@ -97,6 +97,7 @@ func (s *startup) addComponents() error {
 		s.foundation.component,
 		s.appData.component,
 		s.secretStore.component,
+		s.resourceUsage.component,
 		s.runnerEndpoints.component,
 		s.clusterAccess.component,
 		s.nodeStorage.component,

--- a/components/server/startup.go
+++ b/components/server/startup.go
@@ -46,6 +46,7 @@ type startup struct {
 	foundation            *foundationBoot
 	appData               *appDataBoot
 	secretStore           *secretStoreBoot
+	resourceUsage         *resourceUsageBoot
 	runnerEndpoints       *runnerEndpointsBoot
 	clusterAccess         *clusterAccessBoot
 	nodeStorage           *nodeStorageBoot
@@ -109,6 +110,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 	)
 	appData := newAppDataBoot(foundation.output)
 	secretStore := newSecretStoreBoot(foundation.output)
+	resourceUsage := newResourceUsageBoot(foundation.output)
 	runnerEndpoints := newRunnerEndpointsBoot(foundation.output, secretStore.component)
 	deploymentAttempts := newDeploymentAttemptMigrationBoot(foundation.output, appData.component, entitySyncDiagnostics)
 	entityAccess := newEntityAccessBoot(entityAccessInputs(options), foundation.output, observability.output)
@@ -171,6 +173,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 		foundation:            foundation,
 		appData:               appData,
 		secretStore:           secretStore,
+		resourceUsage:         resourceUsage,
 		runnerEndpoints:       runnerEndpoints,
 		clusterAccess:         clusterAccess,
 		nodeStorage:           nodeStorage,

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -36,6 +36,11 @@ type createSandboxDeps struct {
 	networking SandboxNetworking
 	runtime    SandboxContainerRuntime
 	obs        SandboxObservability
+
+	// nodeID labels the metrics this saga registers. A saga only ever runs on
+	// the node whose cgroups it is attaching to, so the value is fixed for the
+	// life of the controller rather than derived per sandbox.
+	nodeID string
 }
 
 // logSandboxEvent surfaces a startup diagnostic on the sandbox's own log stream
@@ -426,7 +431,7 @@ func addMetrics(ctx context.Context, in addMetricsIn) (addMetricsOut, error) {
 		return addMetricsOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
 
-	le, attrs := sandboxMetricsIdentity(sb)
+	le, attrs := sandboxMetricsIdentity(sb, deps.nodeID)
 
 	if err := deps.obs.AddMetrics(le, in.AllCgroups, attrs); err != nil {
 		return addMetricsOut{}, fmt.Errorf("adding metrics: %w", err)
@@ -680,6 +685,7 @@ func registerCreateSandboxSaga(
 	networking SandboxNetworking,
 	runtime SandboxContainerRuntime,
 	obs SandboxObservability,
+	nodeID string,
 	log *slog.Logger,
 ) error {
 	deps := &createSandboxDeps{
@@ -687,6 +693,7 @@ func registerCreateSandboxSaga(
 		networking: networking,
 		runtime:    runtime,
 		obs:        obs,
+		nodeID:     nodeID,
 	}
 
 	return saga.Define(sagaCreateSandbox).

--- a/controllers/sandbox/create_saga_test.go
+++ b/controllers/sandbox/create_saga_test.go
@@ -504,7 +504,7 @@ func newTestHarness(t *testing.T) *testHarness {
 
 	// Register the saga definition
 	log := slog.Default()
-	err := registerCreateSandboxSaga(h.registry, h.entities, h.networking, h.runtime, h.obs, log)
+	err := registerCreateSandboxSaga(h.registry, h.entities, h.networking, h.runtime, h.obs, "node/test-node", log)
 	require.NoError(t, err)
 
 	h.executor = saga.NewExecutor(h.storage,

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -61,7 +61,7 @@ func (s *SagaSandboxController) Init(ctx context.Context) error {
 		return err
 	}
 
-	if err := registerCreateSandboxSaga(s.registry, s.ops, s.ops, s.ops, s.ops, s.log); err != nil {
+	if err := registerCreateSandboxSaga(s.registry, s.ops, s.ops, s.ops, s.ops, s.inner.NodeId.String(), s.log); err != nil {
 		return fmt.Errorf("registering create-sandbox saga: %w", err)
 	}
 

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -44,6 +44,7 @@ import (
 	"miren.dev/runtime/pkg/secret"
 	"miren.dev/runtime/pkg/workloadidentity"
 
+	computeapi "miren.dev/runtime/api/compute"
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -1081,14 +1082,21 @@ func sandboxMetricsIdentity(sb *compute.Sandbox, nodeID string) (string, map[str
 		le = sb.ID.String()
 	}
 
-	attrs := map[string]string{
-		"miren.sandbox": sb.ID.String(),
+	attrs := map[string]string{}
+
+	// The sandbox's own attributes go in first so the controller-owned keys
+	// below overwrite them rather than the other way round. These identify the
+	// series; a spec that happened to carry miren.node could otherwise report a
+	// sandbox's usage against a host it never ran on.
+	for _, lbl := range sb.Spec.LogAttribute {
+		attrs[lbl.Key] = lbl.Value
 	}
 
-	// Without this, usage can be attributed to a workload but not to a host,
-	// which is what makes "which node is hot" unanswerable. It costs no extra
-	// time series: it is functionally dependent on miren.sandbox, which is
-	// already an attribute here.
+	attrs["miren.sandbox"] = sb.ID.String()
+
+	// Without the node, usage can be attributed to a workload but not to a
+	// host, which is what makes "which node is hot" unanswerable. It costs no
+	// extra time series: it is functionally dependent on miren.sandbox.
 	if nodeID != "" {
 		attrs["miren.node"] = nodeID
 	}
@@ -1097,44 +1105,9 @@ func sandboxMetricsIdentity(sb *compute.Sandbox, nodeID string) (string, map[str
 		attrs["miren.version"] = sb.Spec.Version.String()
 	}
 
-	for _, lbl := range sb.Spec.LogAttribute {
-		attrs[lbl.Key] = lbl.Value
-	}
-
-	attrs["miren.kind"] = sandboxWorkloadKind(sb)
+	attrs["miren.kind"] = string(computeapi.SandboxKind(sb))
 
 	return le, attrs
-}
-
-// sandboxWorkloadKind classifies a sandbox as an app service, an addon server,
-// or a task run, so a usage report can separate a user's web process from the
-// database sitting behind it.
-//
-// The classification is read back out of attributes the sandbox already
-// carries rather than stored on it: appspec stamps miren.stage=app-run on
-// deployed services and the run controller stamps miren.stage=run, while the
-// addon framework passes the addon's own labels through as log attributes and
-// sets no stage.
-func sandboxWorkloadKind(sb *compute.Sandbox) string {
-	var stage string
-
-	for _, lbl := range sb.Spec.LogAttribute {
-		switch lbl.Key {
-		case "addon":
-			return "addon"
-		case "miren.stage":
-			stage = lbl.Value
-		}
-	}
-
-	switch stage {
-	case "run":
-		return "run"
-	case "app-run":
-		return "app"
-	default:
-		return "other"
-	}
 }
 
 // sandboxCgroups reads the cgroup path of each of a sandbox's live containers

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1070,7 +1070,12 @@ func (c *SandboxController) pauseContainerPID(ctx context.Context, pauseID strin
 // keyed by, plus the attributes those metrics carry. Every registration site
 // shares this so the key always matches the one StopSandbox removes, and so
 // new attributes reach all of them at once.
-func sandboxMetricsIdentity(sb *compute.Sandbox) (string, map[string]string) {
+//
+// nodeID is the node this sandbox's cgroups live on. It is passed in rather
+// than read off the sandbox because the sandbox entity does not carry one --
+// the schedule that assigns it is a separate component -- and the controller
+// registering the metrics is by definition running on that node.
+func sandboxMetricsIdentity(sb *compute.Sandbox, nodeID string) (string, map[string]string) {
 	le := sb.Spec.LogEntity
 	if le == "" {
 		le = sb.ID.String()
@@ -1078,6 +1083,14 @@ func sandboxMetricsIdentity(sb *compute.Sandbox) (string, map[string]string) {
 
 	attrs := map[string]string{
 		"miren.sandbox": sb.ID.String(),
+	}
+
+	// Without this, usage can be attributed to a workload but not to a host,
+	// which is what makes "which node is hot" unanswerable. It costs no extra
+	// time series: it is functionally dependent on miren.sandbox, which is
+	// already an attribute here.
+	if nodeID != "" {
+		attrs["miren.node"] = nodeID
 	}
 
 	if sb.Spec.Version != "" {
@@ -1088,7 +1101,40 @@ func sandboxMetricsIdentity(sb *compute.Sandbox) (string, map[string]string) {
 		attrs[lbl.Key] = lbl.Value
 	}
 
+	attrs["miren.kind"] = sandboxWorkloadKind(sb)
+
 	return le, attrs
+}
+
+// sandboxWorkloadKind classifies a sandbox as an app service, an addon server,
+// or a task run, so a usage report can separate a user's web process from the
+// database sitting behind it.
+//
+// The classification is read back out of attributes the sandbox already
+// carries rather than stored on it: appspec stamps miren.stage=app-run on
+// deployed services and the run controller stamps miren.stage=run, while the
+// addon framework passes the addon's own labels through as log attributes and
+// sets no stage.
+func sandboxWorkloadKind(sb *compute.Sandbox) string {
+	var stage string
+
+	for _, lbl := range sb.Spec.LogAttribute {
+		switch lbl.Key {
+		case "addon":
+			return "addon"
+		case "miren.stage":
+			stage = lbl.Value
+		}
+	}
+
+	switch stage {
+	case "run":
+		return "run"
+	case "app-run":
+		return "app"
+	default:
+		return "other"
+	}
 }
 
 // sandboxCgroups reads the cgroup path of each of a sandbox's live containers
@@ -1131,7 +1177,7 @@ func (c *SandboxController) sandboxCgroups(ctx context.Context, sb *compute.Sand
 // every reconcile for adopted sandboxes, and re-adding would reset the CPU
 // delta baseline each time (MIR-1013).
 func (c *SandboxController) ensureMetrics(ctx context.Context, sb *compute.Sandbox) error {
-	le, attrs := sandboxMetricsIdentity(sb)
+	le, attrs := sandboxMetricsIdentity(sb, c.NodeId.String())
 
 	// Cheap bail-out so the common case doesn't ask containerd for a spec per
 	// container on every reconcile. AddIfAbsent below is what actually keeps
@@ -1535,7 +1581,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 		return err
 	}
 
-	le, attrs := sandboxMetricsIdentity(co)
+	le, attrs := sandboxMetricsIdentity(co, c.NodeId.String())
 
 	err = c.Metrics.Add(le, cgroups, attrs)
 	if err != nil {

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -112,6 +112,14 @@ func TestSandboxControllerFrozen(t *testing.T) {
 		// saga does not mint duplicate Endpoints and double-DNAT. No saga edit:
 		// actionUpdateSvcs reaches this through sandboxOps.UpdateServices.
 		//
+		// Resource attribution (revised after review): the sandbox's own log
+		// attributes are copied in FIRST so the controller-owned identity keys
+		// overwrite them rather than the other way round. A spec carrying
+		// miren.node could otherwise report its usage against a host it never
+		// ran on. The kind classification moved to api/compute.SandboxKind,
+		// which the usage service now shares, so the two cannot drift into
+		// disagreeing about what a sandbox is.
+		//
 		// Resource attribution: sandboxMetricsIdentity now takes the node the
 		// sandbox runs on and stamps miren.node and miren.kind onto every
 		// metric series, so cluster-wide usage can say which host a workload's
@@ -125,7 +133,7 @@ func TestSandboxControllerFrozen(t *testing.T) {
 		// directly, so createSandboxDeps gained a nodeID field, set from
 		// SandboxController.NodeId where the saga is registered in
 		// saga_controller.go.
-		"sandbox.go":  "2e97940b3d8d5b95a2cba712a6197b3552addda37db7ed76d8135135babd307e",
+		"sandbox.go":  "5138024c3f1904fe397cbf6600ffe9f7b4ca5f3ff6328d9141e86c2e67563850",
 		"volume.go":   "4105e65c8453fd7c3c7025da93aaffb0ee5c5416aa3ca1432c23fec850aedb15",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -111,7 +111,21 @@ func TestSandboxControllerFrozen(t *testing.T) {
 		// (service, ip, port) that already exists, so a resumed create-sandbox
 		// saga does not mint duplicate Endpoints and double-DNAT. No saga edit:
 		// actionUpdateSvcs reaches this through sandboxOps.UpdateServices.
-		"sandbox.go":  "fa9c00356596acc5a3fe5ea2134da374f17ba74f258c456374e9805c8ae1f3bd",
+		//
+		// Resource attribution: sandboxMetricsIdentity now takes the node the
+		// sandbox runs on and stamps miren.node and miren.kind onto every
+		// metric series, so cluster-wide usage can say which host a workload's
+		// load landed on and whether it is an app, an addon or a task run.
+		// Neither label adds a time series -- both are functionally dependent
+		// on miren.sandbox, which was already there.
+		//
+		// Saga path audited: this one is NOT inherited, because the node id has
+		// to reach a function that previously needed only the sandbox.
+		// create_saga.go's addMetrics action calls sandboxMetricsIdentity
+		// directly, so createSandboxDeps gained a nodeID field, set from
+		// SandboxController.NodeId where the saga is registered in
+		// saga_controller.go.
+		"sandbox.go":  "2e97940b3d8d5b95a2cba712a6197b3552addda37db7ed76d8135135babd307e",
 		"volume.go":   "4105e65c8453fd7c3c7025da93aaffb0ee5c5416aa3ca1432c23fec850aedb15",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -456,7 +456,7 @@ func TestSandbox(t *testing.T) {
 		_, err = co.EAC.Put(ctx, &runningE)
 		r.NoError(err)
 
-		le, _ := sandboxMetricsIdentity(&tco)
+		le, _ := sandboxMetricsIdentity(&tco, co.NodeId.String())
 
 		// The process that booted the sandbox is gone, and its cgroup
 		// monitoring went with it. The containers keep running.
@@ -1988,4 +1988,47 @@ func TestShouldRetireInsteadOfRestart(t *testing.T) {
 
 	// The default policy never retires; services depend on being rebooted.
 	r.False(shouldRetireInsteadOfRestart(&compute.Sandbox{Status: compute.RUNNING}))
+}
+
+func TestSandboxWorkloadKind(t *testing.T) {
+	withAttrs := func(kv ...string) *compute.Sandbox {
+		sb := &compute.Sandbox{}
+		sb.Spec.LogAttribute = types.LabelSet(kv...)
+		return sb
+	}
+
+	r := require.New(t)
+
+	r.Equal("app", sandboxWorkloadKind(withAttrs("miren.stage", "app-run", "miren.service", "web")),
+		"appspec stamps app-run on every deployed service")
+	r.Equal("run", sandboxWorkloadKind(withAttrs("miren.stage", "run", "miren.task", "migrate")),
+		"the run controller stamps run on one-off tasks")
+
+	// Addon servers set no stage at all, so the addon label is the only signal
+	// that a sandbox is infrastructure rather than someone's app.
+	r.Equal("addon", sandboxWorkloadKind(withAttrs("addon", "postgresql", "app", "myapp")),
+		"an addon is infrastructure even though it carries an app label")
+
+	r.Equal("other", sandboxWorkloadKind(withAttrs()),
+		"an unclassifiable sandbox is reported as such rather than assumed to be an app")
+}
+
+func TestSandboxMetricsIdentityLabelsNode(t *testing.T) {
+	sb := &compute.Sandbox{ID: "sb_abc"}
+	sb.Spec.LogEntity = "app_xyz"
+	sb.Spec.LogAttribute = types.LabelSet("miren.stage", "app-run")
+
+	r := require.New(t)
+
+	le, attrs := sandboxMetricsIdentity(sb, "node/runner-1")
+	r.Equal("app_xyz", le)
+	r.Equal("sb_abc", attrs["miren.sandbox"])
+	r.Equal("node/runner-1", attrs["miren.node"])
+	r.Equal("app", attrs["miren.kind"])
+
+	// Callers that genuinely do not know their node must not emit an empty
+	// label: a series tagged miren.node="" would roll up under a nonexistent
+	// host rather than being visibly absent.
+	_, attrs = sandboxMetricsIdentity(sb, "")
+	r.NotContains(attrs, "miren.node")
 }

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -1990,29 +1990,6 @@ func TestShouldRetireInsteadOfRestart(t *testing.T) {
 	r.False(shouldRetireInsteadOfRestart(&compute.Sandbox{Status: compute.RUNNING}))
 }
 
-func TestSandboxWorkloadKind(t *testing.T) {
-	withAttrs := func(kv ...string) *compute.Sandbox {
-		sb := &compute.Sandbox{}
-		sb.Spec.LogAttribute = types.LabelSet(kv...)
-		return sb
-	}
-
-	r := require.New(t)
-
-	r.Equal("app", sandboxWorkloadKind(withAttrs("miren.stage", "app-run", "miren.service", "web")),
-		"appspec stamps app-run on every deployed service")
-	r.Equal("run", sandboxWorkloadKind(withAttrs("miren.stage", "run", "miren.task", "migrate")),
-		"the run controller stamps run on one-off tasks")
-
-	// Addon servers set no stage at all, so the addon label is the only signal
-	// that a sandbox is infrastructure rather than someone's app.
-	r.Equal("addon", sandboxWorkloadKind(withAttrs("addon", "postgresql", "app", "myapp")),
-		"an addon is infrastructure even though it carries an app label")
-
-	r.Equal("other", sandboxWorkloadKind(withAttrs()),
-		"an unclassifiable sandbox is reported as such rather than assumed to be an app")
-}
-
 func TestSandboxMetricsIdentityLabelsNode(t *testing.T) {
 	sb := &compute.Sandbox{ID: "sb_abc"}
 	sb.Spec.LogEntity = "app_xyz"
@@ -2031,4 +2008,28 @@ func TestSandboxMetricsIdentityLabelsNode(t *testing.T) {
 	// host rather than being visibly absent.
 	_, attrs = sandboxMetricsIdentity(sb, "")
 	r.NotContains(attrs, "miren.node")
+}
+
+// The identity keys are what a series is attributed by, so a sandbox spec must
+// not be able to claim them. A spec carrying miren.node would otherwise report
+// its usage against a host it never ran on.
+func TestSandboxMetricsIdentityIgnoresSpoofedIdentityAttributes(t *testing.T) {
+	sb := &compute.Sandbox{ID: "sb_real"}
+	sb.Spec.LogEntity = "app_xyz"
+	sb.Spec.Version = "app_version/real"
+	sb.Spec.LogAttribute = types.LabelSet(
+		"miren.stage", "app-run",
+		"miren.node", "node/somewhere-else",
+		"miren.sandbox", "sb_impostor",
+		"miren.version", "app_version/fake",
+		"miren.kind", "addon",
+	)
+
+	_, attrs := sandboxMetricsIdentity(sb, "node/real")
+
+	r := require.New(t)
+	r.Equal("node/real", attrs["miren.node"])
+	r.Equal("sb_real", attrs["miren.sandbox"])
+	r.Equal("app_version/real", attrs["miren.version"])
+	r.Equal("app", attrs["miren.kind"])
 }

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -311,6 +311,7 @@
     "items": [
       "command/sandbox-delete",
       "command/sandbox-exec",
+      "command/sandbox-inspect",
       "command/sandbox-list",
       "command/sandbox-stop"
     ]
@@ -374,6 +375,7 @@
       "command/server-upgrade-rollback"
     ]
   },
+  "command/top",
   "command/upgrade",
   "command/version",
   "command/whoami"

--- a/docs/docs/command/sandbox-inspect.md
+++ b/docs/docs/command/sandbox-inspect.md
@@ -1,0 +1,58 @@
+---
+title: "miren sandbox inspect"
+sidebar_label: "sandbox inspect"
+description: "Show one sandbox's resource usage and failure history"
+---
+
+# miren sandbox inspect
+
+Show one sandbox's resource usage and failure history
+
+## Usage
+
+```bash
+miren sandbox inspect <sandbox> [flags]
+```
+
+## Arguments
+
+- `sandbox` — ID or short ID of the sandbox to inspect
+
+## Flags
+
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--format` — Output format (text, json) (default: `text`)
+- `--json` — Shorthand for --format json
+- `--series` — Include CPU and memory history
+- `--since` — Measure over this window, e.g. 30s, 5m, 1h (default 1m)
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Inspect a sandbox:**
+
+```bash
+miren sandbox inspect sb_abc123
+```
+
+**Inspect over the last hour:**
+
+```bash
+miren sandbox inspect sb_abc123 --since 1h
+```
+
+**Include CPU and memory history:**
+
+```bash
+miren sandbox inspect sb_abc123 --series
+```
+
+## See also
+
+- [`miren sandbox`](./sandbox.md)

--- a/docs/docs/command/sandbox.md
+++ b/docs/docs/command/sandbox.md
@@ -20,5 +20,6 @@ miren sandbox [flags]
 
 - [`miren sandbox delete`](./sandbox-delete.md) — Delete a dead sandbox
 - [`miren sandbox exec`](./sandbox-exec.md) — Open interactive shell in an existing sandbox
+- [`miren sandbox inspect`](./sandbox-inspect.md) — Show one sandbox's resource usage and failure history
 - [`miren sandbox list`](./sandbox-list.md) — List sandboxes (excludes dead by default)
 - [`miren sandbox stop`](./sandbox-stop.md) — Stop a sandbox

--- a/docs/docs/command/top.md
+++ b/docs/docs/command/top.md
@@ -64,7 +64,7 @@ miren top [flags]
 - `--limit` — Show at most this many rows (0 for all) (default: `0`)
 - `--no-addons` — With --apps, exclude each app's dedicated addons from its total
 - `--nodes` — Show per-node usage instead of per-sandbox
-- `--order` — Sort direction: desc or asc (default: `desc`)
+- `--order` — Sort direction: desc or asc (default: desc for usage, asc for names)
 - `--runner` — Only show sandboxes on this runner (name, ID, or short ID)
 - `--samples` — Stop after this many refreshes (0 for unlimited) (default: `0`)
 - `--service` — Only show sandboxes of this service (e.g. web, worker)

--- a/docs/docs/command/top.md
+++ b/docs/docs/command/top.md
@@ -69,7 +69,7 @@ miren top [flags]
 - `--samples` — Stop after this many refreshes (0 for unlimited) (default: `0`)
 - `--service` — Only show sandboxes of this service (e.g. web, worker)
 - `--since` — Measure over this window, e.g. 30s, 5m, 1h (default 1m)
-- `--sort` — Sort by: cpu, memory, app, service, node (default: `cpu`)
+- `--sort` — Sort by: cpu, memory, name, app, service, node (default: `cpu`)
 - `--status` — Only show sandboxes in this status
 - `--system` — Include addon and platform sandboxes
 - `--watch, -w` — Refresh continuously until interrupted

--- a/docs/docs/command/top.md
+++ b/docs/docs/command/top.md
@@ -1,0 +1,131 @@
+---
+title: "miren top"
+sidebar_label: "top"
+description: "Show cluster-wide resource usage"
+---
+
+# miren top
+
+Show cluster-wide resource usage
+
+Show what a cluster is spending its CPU and memory on, ordered by the busiest.
+
+Each row is one live sandbox. Three replicas of a service are three rows, and
+dead sandboxes are left out entirely. By default only app sandboxes are listed;
+addon servers and one-off task runs are hidden unless you pass --system, so the
+listing answers "what are my apps doing".
+
+CPU is reported the way top reports it: as a percentage of one core. A sandbox
+using two full cores reads 200%. NODE% is the same figure against the host it
+runs on, which is what says whether 200% matters.
+
+Four flags cover most investigations:
+
+  --nodes     Which machine is hot, split into what sandboxes are using and what
+              Miren's own moving parts are using underneath them. Start here.
+  --apps      One row per app instead of per sandbox, summed across everything
+              that app owns. See below.
+  --runner    Narrow to one host once you know which.
+  --since     Look back. A live view only shows now, so a spike that has already
+              passed is invisible; --since 1h --aggregate max finds it.
+
+--apps answers "what is app X costing me" without you adding up rows. An app's
+total includes the dedicated addons it owns -- a database exists because the app
+asked for it -- and the SERVICES and ADDONS columns show how the total divides,
+so "2.1 cores, 1.6 of it Postgres" is one line rather than an investigation.
+Pass --no-addons to count only the app's own code.
+
+There is no restart column. Miren replaces a failed sandbox rather than
+restarting it, so no single sandbox accumulates a restart count; repeated
+failure shows up as a crash loop on the pool, which "miren sandbox inspect"
+reports.
+
+A row showing "-" for its numbers is running but reporting nothing. That is a
+finding rather than an omission: either it has just started, or metrics
+collection is down for it.
+
+## Usage
+
+```bash
+miren top [flags]
+```
+
+## Flags
+
+- `--aggregate` — How to collapse the window: avg, max, min, last (default: `avg`)
+- `--app` — Only show sandboxes belonging to this app
+- `--apps` — Show per-app totals instead of per-sandbox
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--format` — Output format (text, json) (default: `text`)
+- `--interval` — Refresh interval when watching (default: `5s`)
+- `--json` — Shorthand for --format json
+- `--kind` — Only show sandboxes of this kind (app, addon, run)
+- `--limit` — Show at most this many rows (0 for all) (default: `0`)
+- `--no-addons` — With --apps, exclude each app's dedicated addons from its total
+- `--nodes` — Show per-node usage instead of per-sandbox
+- `--order` — Sort direction: desc or asc (default: `desc`)
+- `--runner` — Only show sandboxes on this runner (name, ID, or short ID)
+- `--samples` — Stop after this many refreshes (0 for unlimited) (default: `0`)
+- `--service` — Only show sandboxes of this service (e.g. web, worker)
+- `--since` — Measure over this window, e.g. 30s, 5m, 1h (default 1m)
+- `--sort` — Sort by: cpu, memory, app, service, node (default: `cpu`)
+- `--status` — Only show sandboxes in this status
+- `--system` — Include addon and platform sandboxes
+- `--watch, -w` — Refresh continuously until interrupted
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**What is using the cluster's CPU:**
+
+```bash
+miren top
+```
+
+**Which host is hot, and whether an app is to blame:**
+
+```bash
+miren top --nodes
+```
+
+**Per-app totals, including each app's dedicated addons:**
+
+```bash
+miren top --apps
+```
+
+**One app's usage:**
+
+```bash
+miren top --apps --app myapp
+```
+
+**Narrow to one runner:**
+
+```bash
+miren top --runner miren-garden-runner-1
+```
+
+**Find a spike that has already passed:**
+
+```bash
+miren top --since 1h --aggregate max
+```
+
+**Watch continuously:**
+
+```bash
+miren top --watch
+```
+
+**Machine-readable output:**
+
+```bash
+miren top --format json
+```

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -229,6 +229,7 @@ Complete reference for all `miren` CLI commands.
 | [`miren sandbox`](./command/sandbox.md) | Sandbox management commands |
 | [`miren sandbox delete`](./command/sandbox-delete.md) | Delete a dead sandbox |
 | [`miren sandbox exec`](./command/sandbox-exec.md) | Open interactive shell in an existing sandbox |
+| [`miren sandbox inspect`](./command/sandbox-inspect.md) | Show one sandbox's resource usage and failure history |
 | [`miren sandbox list`](./command/sandbox-list.md) | List sandboxes (excludes dead by default) |
 | [`miren sandbox stop`](./command/sandbox-stop.md) | Stop a sandbox |
 
@@ -275,6 +276,12 @@ Complete reference for all `miren` CLI commands.
 | [`miren server unregister`](./command/server-unregister.md) | Detach this cluster from miren.cloud |
 | [`miren server upgrade`](./command/server-upgrade.md) | Upgrade miren server |
 | [`miren server upgrade rollback`](./command/server-upgrade-rollback.md) | Rollback server to previous version |
+
+## top
+
+| Command | Description |
+|---------|-------------|
+| [`miren top`](./command/top.md) | Show cluster-wide resource usage |
 
 ## upgrade
 

--- a/metrics/node_usage.go
+++ b/metrics/node_usage.go
@@ -1,0 +1,163 @@
+package metrics
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"miren.dev/runtime/pkg/sysstats"
+)
+
+// NodeUsage records what a whole host is doing, as opposed to what any single
+// sandbox on it is doing.
+//
+// Two questions need this. First, "how much of this machine is left?" -- a
+// workload burning 200% of a core is unremarkable on a 64-core box and an
+// emergency on a 2-core one, and nothing in the per-sandbox series says which
+// box it is. Second, "is the load even an app?" -- containerd, buildkit, the
+// registry, the log pipeline and miren itself run outside every sandbox cgroup,
+// so they are invisible in the per-sandbox series. Subtracting the sum of
+// sandbox usage from the host total is what surfaces them, and that subtraction
+// needs a host total to start from.
+//
+// Series are labeled by node so they join against the miren.node label the
+// sandbox collectors now attach.
+type NodeUsage struct {
+	Log    *slog.Logger
+	Writer *VictoriaMetricsWriter
+
+	// NodeID is the node entity ID these series describe, and RunnerID is the
+	// runner identifier for the same host. Both are emitted: the entity ID is
+	// what joins to the node record, the runner ID is what an operator typed.
+	NodeID   string
+	RunnerID string
+
+	// DataPath is the filesystem whose capacity is reported. Empty skips the
+	// storage series rather than reporting the root filesystem, which would be
+	// a different disk on most real deployments.
+	DataPath string
+
+	// prevBusy and prevTotal hold the previous tick's raw CPU counters. CPU
+	// utilization is only meaningful as a delta between two samples, so the
+	// first tick after startup emits no CPU series at all.
+	prevBusy  uint64
+	prevTotal uint64
+	primed    bool
+}
+
+const defaultNodeUsageInterval = 10 * time.Second
+
+// NewNodeUsage creates a NodeUsage collector. Writer may be nil for
+// environments without metrics collection, in which case Monitor is a no-op.
+func NewNodeUsage(log *slog.Logger, writer *VictoriaMetricsWriter, nodeID, runnerID, dataPath string) *NodeUsage {
+	return &NodeUsage{
+		Log:      log,
+		Writer:   writer,
+		NodeID:   nodeID,
+		RunnerID: runnerID,
+		DataPath: dataPath,
+	}
+}
+
+// Monitor samples host stats every defaultNodeUsageInterval and pushes one
+// batch of points per tick until ctx is cancelled. Mirrors the cadence and
+// lifecycle of RuntimeMemory.Monitor.
+func (n *NodeUsage) Monitor(ctx context.Context) {
+	if n.Writer == nil {
+		return
+	}
+
+	n.Log.Info("node resource metrics started",
+		"node", n.NodeID, "runner", n.RunnerID, "interval", defaultNodeUsageInterval)
+
+	ticker := time.NewTicker(defaultNodeUsageInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := n.collect(ctx); err != nil {
+				n.Log.Error("failed to record node resource usage", "err", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (n *NodeUsage) collect(ctx context.Context) error {
+	stats := sysstats.CollectSystemStats(n.DataPath)
+
+	// A zero core count means the host's stats could not be read at all --
+	// either /proc is unavailable or this is a platform with no collector
+	// (darwin returns an empty struct). Writing the zeroed struct would publish
+	// a host that appears to have no CPUs and no load, which reads as a healthy
+	// idle machine rather than as missing data. Write nothing instead.
+	if stats.CPUCoreCount == 0 {
+		return nil
+	}
+
+	ts := time.Now()
+	labels := map[string]string{"miren.node": n.NodeID}
+	if n.RunnerID != "" {
+		labels["miren.runner"] = n.RunnerID
+	}
+
+	points := make([]MetricPoint, 0, 9)
+	emit := func(name string, value float64) {
+		points = append(points, MetricPoint{Name: name, Labels: labels, Value: value, Timestamp: ts})
+	}
+
+	emit("node_cpu_cores_total", float64(stats.CPUCoreCount))
+
+	if cores, ok := n.cpuCoresUsed(stats); ok {
+		emit("node_cpu_cores_used", cores)
+	}
+
+	if stats.MemoryTotalBytes > 0 {
+		emit("node_memory_total_bytes", float64(stats.MemoryTotalBytes))
+		emit("node_memory_used_bytes", float64(stats.MemoryBytes))
+	}
+
+	if stats.StorageTotalBytes > 0 {
+		emit("node_storage_total_bytes", float64(stats.StorageTotalBytes))
+		emit("node_storage_used_bytes", float64(stats.StorageBytes))
+	}
+
+	emit("node_load1", stats.Load1)
+	emit("node_load5", stats.Load5)
+	emit("node_load15", stats.Load15)
+
+	return n.Writer.WritePoints(ctx, points)
+}
+
+// cpuCoresUsed converts the jiffy counters into cores busy since the last
+// sample, reporting ok=false when there is nothing to compare against yet.
+//
+// Working in cores rather than a percentage keeps this directly comparable with
+// the per-sandbox CPU series, which is also in cores -- the subtraction that
+// isolates Miren's own overhead needs both sides in the same unit.
+func (n *NodeUsage) cpuCoresUsed(stats sysstats.ResourceUsage) (float64, bool) {
+	busy, total := stats.CPUBusyJiffies, stats.CPUTotalJiffies
+	if total == 0 || stats.CPUCoreCount == 0 {
+		return 0, false
+	}
+
+	prevBusy, prevTotal, primed := n.prevBusy, n.prevTotal, n.primed
+	n.prevBusy, n.prevTotal, n.primed = busy, total, true
+
+	if !primed {
+		return 0, false
+	}
+
+	// A counter that went backwards means the host rebooted between samples.
+	// The delta is meaningless, so skip this tick and let the next one, which
+	// compares two post-reboot samples, report the truth.
+	if busy < prevBusy || total <= prevTotal {
+		return 0, false
+	}
+
+	busyFraction := float64(busy-prevBusy) / float64(total-prevTotal)
+
+	return busyFraction * float64(stats.CPUCoreCount), true
+}

--- a/metrics/node_usage.go
+++ b/metrics/node_usage.go
@@ -77,7 +77,7 @@ func (n *NodeUsage) Monitor(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if err := n.collect(ctx); err != nil {
-				n.Log.Error("failed to record node resource usage", "err", err)
+				n.Log.Warn("failed to record node resource usage", "err", err)
 			}
 		case <-ctx.Done():
 			return

--- a/metrics/node_usage_test.go
+++ b/metrics/node_usage_test.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/sysstats"
+)
+
+func TestNodeUsageCPUCoresUsed(t *testing.T) {
+	sample := func(busy, total uint64) sysstats.ResourceUsage {
+		return sysstats.ResourceUsage{
+			CPUCoreCount:    4,
+			CPUBusyJiffies:  busy,
+			CPUTotalJiffies: total,
+		}
+	}
+
+	r := require.New(t)
+	n := &NodeUsage{}
+
+	// The first sample has nothing to diff against. Reporting zero here would
+	// show every freshly started host as idle.
+	_, ok := n.cpuCoresUsed(sample(1000, 4000))
+	r.False(ok, "the first sample cannot produce a rate")
+
+	// 400 of the next 800 jiffies were busy: half of a 4-core host is 2 cores.
+	cores, ok := n.cpuCoresUsed(sample(1400, 4800))
+	r.True(ok)
+	r.InDelta(2.0, cores, 0.001)
+
+	// A fully saturated interval reports the whole machine, not 100%.
+	cores, ok = n.cpuCoresUsed(sample(2200, 5600))
+	r.True(ok)
+	r.InDelta(4.0, cores, 0.001)
+}
+
+func TestNodeUsageCPUCoresUsedSkipsImpossibleDeltas(t *testing.T) {
+	r := require.New(t)
+
+	// Counters that went backwards mean the host rebooted between samples. The
+	// delta spans two different boots and describes nothing real.
+	n := &NodeUsage{}
+	_, _ = n.cpuCoresUsed(sysstats.ResourceUsage{CPUCoreCount: 2, CPUBusyJiffies: 5000, CPUTotalJiffies: 9000})
+	_, ok := n.cpuCoresUsed(sysstats.ResourceUsage{CPUCoreCount: 2, CPUBusyJiffies: 10, CPUTotalJiffies: 40})
+	r.False(ok, "a counter reset is not a usage measurement")
+
+	// Two samples taken within the same tick leave no elapsed time to divide by.
+	n = &NodeUsage{}
+	_, _ = n.cpuCoresUsed(sysstats.ResourceUsage{CPUCoreCount: 2, CPUBusyJiffies: 100, CPUTotalJiffies: 400})
+	_, ok = n.cpuCoresUsed(sysstats.ResourceUsage{CPUCoreCount: 2, CPUBusyJiffies: 100, CPUTotalJiffies: 400})
+	r.False(ok, "no elapsed jiffies means no measurable utilization")
+
+	// An unreadable /proc/stat leaves the counters at zero, which must not be
+	// mistaken for a perfectly idle host.
+	n = &NodeUsage{}
+	_, ok = n.cpuCoresUsed(sysstats.ResourceUsage{CPUCoreCount: 2})
+	r.False(ok, "missing counters are unknown, not idle")
+}

--- a/pkg/addon/framework.go
+++ b/pkg/addon/framework.go
@@ -93,7 +93,7 @@ func (fw *ProviderFramework) CreateSandboxPool(ctx context.Context, spec CreateS
 		SandboxLabels:    spec.Labels,
 		SandboxPrefix:    spec.SandboxPrefix,
 		SandboxSpec: compute_v1alpha.SandboxSpec{
-			LogAttribute:    spec.Labels,
+			LogAttribute:    metricLabels(spec.Labels),
 			PortWaitTimeout: spec.PortWaitTimeout,
 		},
 	}
@@ -123,6 +123,30 @@ func (fw *ProviderFramework) CreateSandboxPool(ctx context.Context, spec CreateS
 	}
 
 	return poolID, nil
+}
+
+// metricLabels adapts an addon's labels for use as metric attributes.
+//
+// Providers label their sandboxes with a plain "app" key, which is right for an
+// entity label but wrong for a metric: deployed services publish the same fact
+// as "miren.app", and a rollup can only sum an app together with the database it
+// depends on if both spell it the same way. The original key is kept so nothing
+// reading the entity has to change.
+func metricLabels(labels types.Labels) types.Labels {
+	app, ok := labels.Get("app")
+	if !ok || app == "" {
+		return labels
+	}
+	if _, exists := labels.Get("miren.app"); exists {
+		return labels
+	}
+
+	// Copied rather than appended in place: the caller's slice is also stored
+	// as the pool's SandboxLabels, and appending could write through to it.
+	out := make(types.Labels, len(labels), len(labels)+1)
+	copy(out, labels)
+
+	return append(out, types.Label{Key: "miren.app", Value: app})
 }
 
 // WaitForPool watches a pool entity until it has at least one ready instance

--- a/pkg/addon/framework_test.go
+++ b/pkg/addon/framework_test.go
@@ -1,0 +1,51 @@
+package addon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/entity/types"
+)
+
+// An addon's metrics have to be summable with the metrics of the app that owns
+// it, and deployed services publish the app as "miren.app". Without this the two
+// spell the same fact differently and no query can add them together.
+func TestMetricLabelsNormalizesTheAppKey(t *testing.T) {
+	in := types.LabelSet("addon", "postgresql", "app", "myapp", "server", "db1")
+
+	out := metricLabels(in)
+
+	app, ok := out.Get("miren.app")
+	require.True(t, ok)
+	assert.Equal(t, "myapp", app)
+
+	// The original key stays: it is also the pool's entity label, which the
+	// usage directory and other readers already depend on.
+	orig, ok := out.Get("app")
+	require.True(t, ok)
+	assert.Equal(t, "myapp", orig)
+}
+
+func TestMetricLabelsLeavesTheInputAlone(t *testing.T) {
+	in := types.LabelSet("addon", "valkey", "app", "myapp")
+
+	_ = metricLabels(in)
+
+	// The same slice is stored as the pool's SandboxLabels, so appending
+	// through it would leak a metric-only key onto the entity.
+	_, ok := in.Get("miren.app")
+	assert.False(t, ok, "the caller's labels must not be modified in place")
+}
+
+func TestMetricLabelsSkipsSharedAddons(t *testing.T) {
+	// A shared server belongs to no single app and carries no app label, so
+	// there is nothing to attribute it to.
+	in := types.LabelSet("addon", "mysql", "shared", "true")
+
+	out := metricLabels(in)
+
+	_, ok := out.Get("miren.app")
+	assert.False(t, ok, "an empty app label would group every shared server under one phantom app")
+}

--- a/pkg/appspec/appspec.go
+++ b/pkg/appspec/appspec.go
@@ -121,6 +121,20 @@ func Build(log *slog.Logger, opts Options) (*compute_v1alpha.SandboxSpec, error)
 		logAttrs = types.LabelSet("miren.stage", "app-run", "miren.service", serviceName)
 	}
 
+	// miren.app is appended outside the default above because it identifies the
+	// sandbox rather than describing it: a task run supplies its own attributes
+	// and would otherwise lose the app it belongs to.
+	//
+	// The app *name* is used, not its entity id. These attributes become metric
+	// labels, and an app's dedicated addons already label themselves by name
+	// (see the addon providers) -- an app and the database it depends on can
+	// only be summed together if both spell the app the same way.
+	if opts.AppName != "" {
+		if _, ok := logAttrs.Get("miren.app"); !ok {
+			logAttrs = append(logAttrs, types.Label{Key: "miren.app", Value: opts.AppName})
+		}
+	}
+
 	sbSpec := &compute_v1alpha.SandboxSpec{
 		Version:       ver.ID,
 		LogEntity:     opts.AppID.String(),

--- a/pkg/appspec/appspec.go
+++ b/pkg/appspec/appspec.go
@@ -130,9 +130,18 @@ func Build(log *slog.Logger, opts Options) (*compute_v1alpha.SandboxSpec, error)
 	// (see the addon providers) -- an app and the database it depends on can
 	// only be summed together if both spell the app the same way.
 	if opts.AppName != "" {
-		if _, ok := logAttrs.Get("miren.app"); !ok {
-			logAttrs = append(logAttrs, types.Label{Key: "miren.app", Value: opts.AppName})
+		// Copied before appending: opts.LogAttrs belongs to the caller, and
+		// appending in place can write through to a slice with spare capacity.
+		attrs := make(types.Labels, 0, len(logAttrs)+1)
+		for _, lbl := range logAttrs {
+			// The app is the controller's to state, so a caller-supplied value
+			// is replaced rather than kept. These become metric labels, and a
+			// conflicting one would bill an app for another app's usage.
+			if lbl.Key != "miren.app" {
+				attrs = append(attrs, lbl)
+			}
 		}
+		logAttrs = append(attrs, types.Label{Key: "miren.app", Value: opts.AppName})
 	}
 
 	sbSpec := &compute_v1alpha.SandboxSpec{

--- a/pkg/appspec/appspec_test.go
+++ b/pkg/appspec/appspec_test.go
@@ -70,7 +70,9 @@ func TestBuildDefaultsMatchTheLauncher(t *testing.T) {
 
 	assert.Equal(t, entity.Id("app_version/v1"), spec.Version)
 	assert.Equal(t, "app/demo", spec.LogEntity)
-	assert.Equal(t, types.LabelSet("miren.stage", "app-run", "miren.service", "web"), spec.LogAttribute)
+	assert.Equal(t, types.LabelSet(
+		"miren.stage", "app-run", "miren.service", "web", "miren.app", "demo"),
+		spec.LogAttribute)
 	assert.Empty(t, spec.RestartPolicy, "the historical default is to allow restarts")
 
 	require.Len(t, spec.Container, 1)
@@ -463,4 +465,47 @@ func TestBuildTaskEnvCannotShadowSystemVariables(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "tok", envMap(t, spec)["ADMIN_TOKEN"])
+}
+
+// miren.app is what lets an app's usage be summed across its sandboxes, so it
+// has to survive a caller that supplies its own attributes -- a task run does
+// exactly that, and would otherwise lose the app it belongs to.
+func TestBuildAlwaysLabelsTheApp(t *testing.T) {
+	opts := baseOptions()
+	opts.LogAttrs = types.LabelSet("miren.stage", "run", "miren.task", "migrate")
+
+	spec, err := Build(nil, opts)
+	require.NoError(t, err)
+
+	app, ok := spec.LogAttribute.Get("miren.app")
+	require.True(t, ok, "a run must still say which app it belongs to")
+	assert.Equal(t, "demo", app)
+
+	// The caller's own attributes are kept, not replaced.
+	stage, _ := spec.LogAttribute.Get("miren.stage")
+	assert.Equal(t, "run", stage)
+}
+
+// The app NAME, not its entity id: an app's dedicated addons label themselves
+// by name, and the two can only be summed together if they agree.
+func TestBuildLabelsTheAppByName(t *testing.T) {
+	spec, err := Build(nil, baseOptions())
+	require.NoError(t, err)
+
+	app, _ := spec.LogAttribute.Get("miren.app")
+	assert.Equal(t, "demo", app)
+	assert.NotEqual(t, "app/demo", app, "the entity id is what LogEntity already carries")
+}
+
+func TestBuildOmitsTheAppLabelWhenUnknown(t *testing.T) {
+	opts := baseOptions()
+	opts.AppName = ""
+
+	spec, err := Build(nil, opts)
+	require.NoError(t, err)
+
+	// An empty label would group every unnamed sandbox under one phantom app,
+	// which is worse than having no label at all.
+	_, ok := spec.LogAttribute.Get("miren.app")
+	assert.False(t, ok)
 }

--- a/pkg/rpc/actor.go
+++ b/pkg/rpc/actor.go
@@ -159,7 +159,7 @@ func (a *ActorClient) Call(ctx context.Context, name string, arg, ret any) error
 
 	iface := hc.Interface
 
-	m, ok := iface.methods[name]
+	m, ok := iface.rpcMethod(name)
 	if !ok {
 		return cond.NotFound("method", name)
 	}

--- a/pkg/rpc/actor.go
+++ b/pkg/rpc/actor.go
@@ -160,7 +160,7 @@ func (a *ActorClient) Call(ctx context.Context, name string, arg, ret any) error
 	iface := hc.Interface
 
 	m, ok := iface.rpcMethod(name)
-	if !ok {
+	if !ok || m.Handler == nil {
 		return cond.NotFound("method", name)
 	}
 

--- a/pkg/rpc/generator.go
+++ b/pkg/rpc/generator.go
@@ -1758,6 +1758,14 @@ func (g *Generator) generateClient(f *j.File, i *DescInterface) error {
 	f.Line()
 
 	for _, m := range i.Method {
+		// A rest-only method has no client: the RPC transport would answer
+		// "unknown method", so a generated caller could only ever fail at
+		// runtime. Leaving it out turns that into a compile error, and steers
+		// Go callers to the grouped RPC form the URL shape exists to avoid.
+		if m.RestOnly {
+			continue
+		}
+
 		tn := expName + capitalize(m.Name)
 
 		sname, _ := i.addGeneric(tn + "Results")
@@ -2011,6 +2019,9 @@ func (g *Generator) generateInterfaces(f *j.File) error {
 						g.Line().Id("InterfaceName").Op(":").Lit(i.Name)
 						g.Line().Id("Index").Op(":").Lit(m.Index)
 						g.Line().Id("Public").Op(":").Lit(m.Public)
+						if m.RestOnly {
+							g.Line().Id("RestOnly").Op(":").Lit(true)
+						}
 						g.Line().Id("Params").Op(":").Index().String().ValuesFunc(func(g *j.Group) {
 							for _, p := range m.Parameters {
 								g.Lit(p.Name)
@@ -2366,8 +2377,20 @@ type DescMethods struct {
 	// Public marks this method as accessible without TLS client certificate authentication.
 	// Public methods still require capability-level auth (Ed25519 signatures) but allow
 	// unauthenticated callers (e.g., for registration flows where the client doesn't have certs yet).
-	Public bool            `yaml:"public,omitempty"`
-	HTTP   *DescHTTPMethod `yaml:"http,omitempty"`
+	Public bool `yaml:"public,omitempty"`
+	// RestOnly marks this method as reachable only through its http: binding.
+	// It is not dispatched over the RPC transport, not advertised in the
+	// method list, and no client method is generated for it.
+	//
+	// Use it for a method shaped for a URL rather than for a program: flat
+	// scalars a query string can carry, where the RPC surface offers the same
+	// answer through grouped arguments. Without it the URL form becomes a
+	// second, worse way for a Go caller to ask the same question.
+	//
+	// A rest_only method with no http: binding is unreachable and is rejected
+	// at generation time.
+	RestOnly bool            `yaml:"rest_only,omitempty"`
+	HTTP     *DescHTTPMethod `yaml:"http,omitempty"`
 }
 
 // DescHTTPMethod holds method-level REST configuration from the IDL http: block.
@@ -2467,6 +2490,13 @@ func (g *Generator) validateHTTP() error {
 	for _, i := range g.Interfaces {
 		for _, m := range i.Method {
 			if m.HTTP == nil {
+				// rest_only removes a method from the RPC transport, so
+				// without an http: binding there is nothing left that can
+				// reach it. Catching that here beats shipping a method no
+				// caller can invoke by any route.
+				if m.RestOnly {
+					return fmt.Errorf("%s.%s: rest_only requires an http: binding, or the method is unreachable", i.Name, m.Name)
+				}
 				continue
 			}
 

--- a/pkg/rpc/generator_test.go
+++ b/pkg/rpc/generator_test.go
@@ -181,6 +181,30 @@ func TestGeneratorHTTPValidation(t *testing.T) {
 		}))
 	})
 
+	t.Run("accepts rest_only alongside an http binding", func(t *testing.T) {
+		r := require.New(t)
+
+		r.NoError(validate(t, &DescMethods{
+			Name:       "httpGet",
+			RestOnly:   true,
+			HTTP:       &DescHTTPMethod{Get: "/widgets/{id}"},
+			Parameters: []*DescParamater{{Name: "id", Type: "string"}},
+		}))
+	})
+
+	t.Run("rejects rest_only without an http binding", func(t *testing.T) {
+		r := require.New(t)
+
+		// rest_only withdraws the method from the RPC transport, so with no
+		// route left there is no way to reach it at all. Failing here beats
+		// generating a method no caller can invoke.
+		err := validate(t, &DescMethods{
+			Name:     "orphan",
+			RestOnly: true,
+		})
+		r.ErrorContains(err, "rest_only requires an http: binding")
+	})
+
 	t.Run("rejects more than one verb", func(t *testing.T) {
 		r := require.New(t)
 

--- a/pkg/rpc/inline_router.go
+++ b/pkg/rpc/inline_router.go
@@ -159,8 +159,8 @@ func (s *State) serveInlineCalls(ctx context.Context, dec *cbor.Decoder, enc *cb
 				continue
 			}
 
-			mm := iface.methods[rs.Method]
-			if mm.Handler == nil {
+			mm, ok := iface.rpcMethod(rs.Method)
+			if !ok || mm.Handler == nil {
 				if !discardArgs(dec) {
 					return
 				}

--- a/pkg/rpc/restonly_test.go
+++ b/pkg/rpc/restonly_test.go
@@ -2,6 +2,10 @@ package rpc
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,17 +40,46 @@ func restOnlyMethods() []Method {
 func TestRestOnlyMethodIsUnreachableOverRPC(t *testing.T) {
 	iface := NewInterface(restOnlyMethods(), struct{}{})
 
-	ordinary := iface.rpcMethod("listThings")
+	ordinary, found := iface.rpcMethod("listThings")
+	require.True(t, found)
 	require.NotNil(t, ordinary.Handler, "an ordinary method still dispatches")
 
-	restOnly := iface.rpcMethod("httpListThings")
-	assert.Nil(t, restOnly.Handler,
-		"a rest-only method must resolve to nothing dispatchable; every call site treats a nil Handler as unknown")
+	_, ok := iface.rpcMethod("httpListThings")
+	assert.False(t, ok, "a rest-only method must not resolve for RPC dispatch")
 
 	// The same answer a typo gets, which is the point: an RPC caller should not
 	// be able to tell a rest-only method from one that does not exist.
-	missing := iface.rpcMethod("noSuchThing")
-	assert.Equal(t, missing.Handler == nil, restOnly.Handler == nil)
+	_, missing := iface.rpcMethod("noSuchThing")
+	assert.Equal(t, missing, ok)
+}
+
+// Every path that invokes a handler by name has to consult rpcMethod. The first
+// version of this feature guarded three of them and left the inline router, the
+// actor path and the in-process test client reading the map directly, so a
+// rest-only method stayed reachable by all three. This asserts the map has no
+// other readers rather than trusting a grep done once.
+func TestEveryDispatchPathGoesThroughRpcMethod(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+
+	direct := regexp.MustCompile(`\.methods\[`)
+
+	for _, f := range files {
+		if f == "server.go" {
+			// rpcMethod itself is the one sanctioned reader.
+			continue
+		}
+
+		src, err := os.ReadFile(f)
+		require.NoError(t, err)
+
+		for n, line := range strings.Split(string(src), "\n") {
+			if direct.MatchString(line) {
+				t.Errorf("%s:%d reads the method map directly; use Interface.rpcMethod so rest-only methods stay unreachable:\n\t%s",
+					f, n+1, strings.TrimSpace(line))
+			}
+		}
+	}
 }
 
 // Withdrawing it from RPC must not unmount its route. The REST gateway

--- a/pkg/rpc/restonly_test.go
+++ b/pkg/rpc/restonly_test.go
@@ -1,0 +1,80 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// restOnlyMethods builds the arrangement the flag exists for: the same answer
+// offered twice, once shaped for a program and once shaped for a URL.
+func restOnlyMethods() []Method {
+	noop := func(context.Context, Call) error { return nil }
+
+	return []Method{
+		{
+			Name:          "listThings",
+			InterfaceName: "Things",
+			Index:         0,
+			Handler:       noop,
+		},
+		{
+			Name:          "httpListThings",
+			InterfaceName: "Things",
+			Index:         1,
+			RestOnly:      true,
+			Handler:       noop,
+			HTTP:          &HTTPBinding{Verb: "GET", Path: "/api/v1/things"},
+		},
+	}
+}
+
+// rpcMethod is what every dispatch site resolves through, so this is the check
+// that the flag actually withdraws the method rather than merely labelling it.
+func TestRestOnlyMethodIsUnreachableOverRPC(t *testing.T) {
+	iface := NewInterface(restOnlyMethods(), struct{}{})
+
+	ordinary := iface.rpcMethod("listThings")
+	require.NotNil(t, ordinary.Handler, "an ordinary method still dispatches")
+
+	restOnly := iface.rpcMethod("httpListThings")
+	assert.Nil(t, restOnly.Handler,
+		"a rest-only method must resolve to nothing dispatchable; every call site treats a nil Handler as unknown")
+
+	// The same answer a typo gets, which is the point: an RPC caller should not
+	// be able to tell a rest-only method from one that does not exist.
+	missing := iface.rpcMethod("noSuchThing")
+	assert.Equal(t, missing.Handler == nil, restOnly.Handler == nil)
+}
+
+// Withdrawing it from RPC must not unmount its route. The REST gateway
+// enumerates Methods() and dispatches through the handler it finds there.
+func TestRestOnlyMethodKeepsItsHTTPRoute(t *testing.T) {
+	iface := NewInterface(restOnlyMethods(), struct{}{})
+
+	var mounted []string
+	for _, m := range iface.Methods() {
+		if m.HTTP == nil {
+			continue
+		}
+		mounted = append(mounted, m.Name)
+		require.NotNil(t, m.Handler, "the REST gateway dispatches through this handler")
+	}
+
+	assert.Equal(t, []string{"httpListThings"}, mounted)
+}
+
+// The advertised list is how a client discovers what it may call. Listing a
+// rest-only method would invite a call that answers "unknown method".
+func TestRestOnlyMethodIsNotAdvertised(t *testing.T) {
+	iface := NewInterface(restOnlyMethods(), struct{}{})
+
+	resp := newMethodsResponse(iface.methods)
+
+	assert.Contains(t, resp.Methods, "listThings")
+	assert.NotContains(t, resp.Methods, "httpListThings")
+	assert.NotContains(t, resp.Params, "httpListThings",
+		"parameter-level capability detection must not describe it either")
+}

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -135,6 +135,16 @@ type Method struct {
 	// Public marks this method as accessible without TLS client certificate authentication.
 	// The RPC layer will reject unauthenticated calls to non-public methods automatically.
 	Public bool
+	// RestOnly marks this method as reachable through its HTTP binding and
+	// nowhere else. The RPC transport reports it as unknown and it is left out
+	// of the advertised method list, so it is invisible to an RPC caller.
+	//
+	// It exists for methods that are shaped for a URL rather than for a
+	// program: flat scalars a query string can carry, where the RPC surface
+	// offers the same answer through grouped arguments a caller cannot
+	// transpose. Marking the URL form rest-only stops it from becoming a second
+	// way to call the same thing badly.
+	RestOnly bool
 	// Params lists the method's parameter names in schema order. It powers
 	// parameter-level capability detection: a client can ask whether a server
 	// understands a specific parameter (e.g. one added after the method first
@@ -210,6 +220,19 @@ func (i *Interface) Methods() []Method {
 		methods = append(methods, m)
 	}
 	return methods
+}
+
+// rpcMethod resolves a method for dispatch over the RPC transport.
+//
+// A rest-only method is reported as absent, so the caller sees the same
+// "unknown method" a typo would produce. The zero Method has a nil Handler,
+// which is what every dispatch site already treats as not found.
+func (i *Interface) rpcMethod(name string) Method {
+	m := i.methods[name]
+	if m.RestOnly {
+		return Method{}
+	}
+	return m
 }
 
 func (i *Interface) SetAroundContext(fn func(ctx context.Context, call Call) (context.Context, func())) {
@@ -736,6 +759,11 @@ func newMethodsResponse(m map[string]Method) methodsResponse {
 	methods := make([]string, 0, len(m))
 	params := make(map[string][]string, len(m))
 	for name, mm := range m {
+		// A rest-only method is not part of the RPC surface, so advertising it
+		// would invite a client to call something that will answer "unknown".
+		if mm.RestOnly {
+			continue
+		}
 		methods = append(methods, name)
 		if len(mm.Params) > 0 {
 			params[name] = mm.Params
@@ -1089,7 +1117,7 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 
 	iface.touch()
 
-	mm := iface.methods[method]
+	mm := iface.rpcMethod(method)
 	if mm.Handler == nil {
 		w.Header().Add("rpc-status", "unknown")
 		w.Header().Add("rpc-error", "unknown method: "+method)
@@ -1254,7 +1282,7 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 	if ok {
 		iface.touch()
 
-		mm := iface.methods[method]
+		mm := iface.rpcMethod(method)
 		if mm.Handler == nil {
 			w.Header().Add("rpc-status", "unknown")
 			w.Header().Add("rpc-error", "unknown method: "+method)

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -225,14 +225,15 @@ func (i *Interface) Methods() []Method {
 // rpcMethod resolves a method for dispatch over the RPC transport.
 //
 // A rest-only method is reported as absent, so the caller sees the same
-// "unknown method" a typo would produce. The zero Method has a nil Handler,
-// which is what every dispatch site already treats as not found.
-func (i *Interface) rpcMethod(name string) Method {
-	m := i.methods[name]
-	if m.RestOnly {
-		return Method{}
+// "unknown method" a typo would produce. Every path that invokes a handler by
+// name must go through here rather than reading i.methods directly, or the
+// method stays reachable by whichever route was missed.
+func (i *Interface) rpcMethod(name string) (Method, bool) {
+	m, ok := i.methods[name]
+	if !ok || m.RestOnly {
+		return Method{}, false
 	}
-	return m
+	return m, true
 }
 
 func (i *Interface) SetAroundContext(fn func(ctx context.Context, call Call) (context.Context, func())) {
@@ -1117,8 +1118,8 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 
 	iface.touch()
 
-	mm := iface.rpcMethod(method)
-	if mm.Handler == nil {
+	mm, ok := iface.rpcMethod(method)
+	if !ok || mm.Handler == nil {
 		w.Header().Add("rpc-status", "unknown")
 		w.Header().Add("rpc-error", "unknown method: "+method)
 		w.WriteHeader(http.StatusNotFound)
@@ -1282,8 +1283,8 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 	if ok {
 		iface.touch()
 
-		mm := iface.rpcMethod(method)
-		if mm.Handler == nil {
+		mm, ok := iface.rpcMethod(method)
+		if !ok || mm.Handler == nil {
 			w.Header().Add("rpc-status", "unknown")
 			w.Header().Add("rpc-error", "unknown method: "+method)
 			w.WriteHeader(http.StatusNotFound)

--- a/pkg/rpc/server_session.go
+++ b/pkg/rpc/server_session.go
@@ -354,7 +354,7 @@ func (s *Server) prepareMethodCall(ctx context.Context, req opRequest) (context.
 
 	iface.touch()
 
-	mm := iface.methods[req.Method]
+	mm := iface.rpcMethod(req.Method)
 	if mm.Handler == nil {
 		return ctx, nil, Method{}, nil, opReply{Status: "error", Error: "unknown method: " + req.Method}, false
 	}

--- a/pkg/rpc/server_session.go
+++ b/pkg/rpc/server_session.go
@@ -354,8 +354,8 @@ func (s *Server) prepareMethodCall(ctx context.Context, req opRequest) (context.
 
 	iface.touch()
 
-	mm := iface.rpcMethod(req.Method)
-	if mm.Handler == nil {
+	mm, ok := iface.rpcMethod(req.Method)
+	if !ok || mm.Handler == nil {
 		return ctx, nil, Method{}, nil, opReply{Status: "error", Error: "unknown method: " + req.Method}, false
 	}
 

--- a/pkg/rpc/test_helpers.go
+++ b/pkg/rpc/test_helpers.go
@@ -79,7 +79,7 @@ func (l *localClient) listMethods() methodsResponse {
 }
 
 func (l *localClient) Call(ctx context.Context, name string, arg, ret any) error {
-	m, ok := l.iface.methods[name]
+	m, ok := l.iface.rpcMethod(name)
 	if !ok {
 		panic("method not found")
 	}

--- a/pkg/rpc/test_helpers.go
+++ b/pkg/rpc/test_helpers.go
@@ -80,7 +80,7 @@ func (l *localClient) listMethods() methodsResponse {
 
 func (l *localClient) Call(ctx context.Context, name string, arg, ret any) error {
 	m, ok := l.iface.rpcMethod(name)
-	if !ok {
+	if !ok || m.Handler == nil {
 		panic("method not found")
 	}
 

--- a/pkg/sysstats/sysstats.go
+++ b/pkg/sysstats/sysstats.go
@@ -14,21 +14,28 @@ import (
 func CollectSystemStats(dataPath string) ResourceUsage {
 	usage := ResourceUsage{}
 
-	// Get CPU load average (1 minute average) from /proc/loadavg
+	usage.CPUCoreCount = getCPUCount()
+	usage.CPUBusyJiffies, usage.CPUTotalJiffies = readCPUJiffies()
+
+	// Get CPU load average (1, 5 and 15 minute averages) from /proc/loadavg
 	loadavgBytes, err := os.ReadFile("/proc/loadavg")
 	if err == nil {
 		fields := strings.Fields(string(loadavgBytes))
 		if len(fields) > 0 {
 			if load1, err := strconv.ParseFloat(fields[0], 64); err == nil {
 				usage.CPUCores = load1
+				usage.Load1 = load1
 
-				// Calculate percentage based on number of CPUs
-				// Try to get CPU count from /proc/cpuinfo
-				numCPU := getCPUCount()
-				if numCPU > 0 {
-					usage.CPUPercent = (load1 / float64(numCPU)) * 100
+				if usage.CPUCoreCount > 0 {
+					usage.CPUPercent = (load1 / float64(usage.CPUCoreCount)) * 100
 				}
 			}
+		}
+		if len(fields) > 1 {
+			usage.Load5, _ = strconv.ParseFloat(fields[1], 64)
+		}
+		if len(fields) > 2 {
+			usage.Load15, _ = strconv.ParseFloat(fields[2], 64)
 		}
 	}
 
@@ -59,6 +66,7 @@ func CollectSystemStats(dataPath string) ResourceUsage {
 		if memTotal > 0 {
 			memUsed := memTotal - memAvailable
 			usage.MemoryBytes = memUsed
+			usage.MemoryTotalBytes = memTotal
 			usage.MemoryPercent = float64(memUsed) / float64(memTotal) * 100
 		}
 	}
@@ -72,6 +80,7 @@ func CollectSystemStats(dataPath string) ResourceUsage {
 			usedBytes := totalBytes - availBytes
 
 			usage.StorageBytes = int64(usedBytes)
+			usage.StorageTotalBytes = int64(totalBytes)
 			if totalBytes > 0 {
 				usage.StoragePercent = float64(usedBytes) / float64(totalBytes) * 100
 			}
@@ -79,6 +88,57 @@ func CollectSystemStats(dataPath string) ResourceUsage {
 	}
 
 	return usage
+}
+
+// readCPUJiffies returns the host's cumulative busy and total CPU time from the
+// aggregate "cpu" line of /proc/stat.
+//
+// Busy excludes idle and iowait: a core waiting on disk is not a core doing
+// work, and counting it as busy would make every I/O-bound host look pegged.
+// The units are USER_HZ ticks, which this deliberately does not convert --
+// callers take the ratio of two samples, and the ratio is unitless.
+//
+// Both values are zero when /proc/stat is unreadable or malformed, which the
+// caller must treat as "unknown" rather than "idle".
+func readCPUJiffies() (busy, total uint64) {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return 0, 0
+	}
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		fields := strings.Fields(line)
+		// The first line is the all-CPU aggregate, named exactly "cpu"; the
+		// per-core lines that follow are "cpu0", "cpu1" and so on.
+		if len(fields) < 5 || fields[0] != "cpu" {
+			continue
+		}
+
+		// Columns are: user nice system idle iowait irq softirq steal, then
+		// guest and guest_nice. The trailing two are stopped at deliberately:
+		// the kernel already includes guest time inside user and guest_nice
+		// inside nice, so adding them would count a virtualization host's guest
+		// time twice.
+		values := fields[1:]
+		if len(values) > 8 {
+			values = values[:8]
+		}
+
+		for i, f := range values {
+			v, err := strconv.ParseUint(f, 10, 64)
+			if err != nil {
+				return 0, 0
+			}
+			total += v
+			if i != 3 && i != 4 {
+				busy += v
+			}
+		}
+
+		return busy, total
+	}
+
+	return 0, 0
 }
 
 // getCPUCount returns the number of CPUs from /proc/cpuinfo

--- a/pkg/sysstats/types.go
+++ b/pkg/sysstats/types.go
@@ -8,4 +8,31 @@ type ResourceUsage struct {
 	MemoryPercent  float64
 	StorageBytes   int64
 	StoragePercent float64
+
+	// CPUCoreCount is the number of logical CPUs. It is the denominator that
+	// turns a workload's absolute CPU use into a share of the host, which is
+	// what makes "178% of a core" interpretable on a 4-core box versus a 64-core
+	// one.
+	CPUCoreCount int
+
+	// MemoryTotalBytes and StorageTotalBytes are the capacities the used
+	// figures above are a fraction of. The percentages are already derived from
+	// them, but a caller charting usage over time needs the raw ceiling too.
+	MemoryTotalBytes  int64
+	StorageTotalBytes int64
+
+	// Load1 duplicates CPUCores, which is a load average despite its name and
+	// is kept for the callers that already read it. Load5 and Load15 are what
+	// distinguish a momentary spike from sustained pressure.
+	Load1  float64
+	Load5  float64
+	Load15 float64
+
+	// CPUBusyJiffies and CPUTotalJiffies are the raw cumulative counters from
+	// /proc/stat. They are exposed unconverted because their ratio between two
+	// samples is the host's CPU utilization, and taking a ratio cancels the
+	// USER_HZ scaling factor that converting either one to seconds would have
+	// to assume.
+	CPUBusyJiffies  uint64
+	CPUTotalJiffies uint64
 }

--- a/pkg/workloadroles/catalog_test.go
+++ b/pkg/workloadroles/catalog_test.go
@@ -1,0 +1,113 @@
+package workloadroles_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/admin/admin_v1alpha"
+	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/build/build_v1alpha"
+	"miren.dev/runtime/api/debug/debug_v1alpha"
+	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+	"miren.dev/runtime/api/exec/exec_v1alpha"
+	"miren.dev/runtime/api/metric/metric_v1alpha"
+	"miren.dev/runtime/api/runner/runner_v1alpha"
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/workloadroles"
+)
+
+// realMethods maps a catalog resource to the methods its generated interface
+// actually defines.
+//
+// The adapters are handed a nil implementation deliberately: nothing here
+// dispatches a call, it only reads the method table the generator emitted.
+//
+// This is not every interface in the catalog -- adding one is a line here plus
+// an import -- but an entry that IS listed is checked exactly.
+func realMethods(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+
+	ifaces := []*rpc.Interface{
+		usage_v1alpha.AdaptResourceUsage(nil),
+		metric_v1alpha.AdaptSandboxMetrics(nil),
+		runner_v1alpha.AdaptRunnerRegistration(nil),
+		exec_v1alpha.AdaptSandboxExec(nil),
+		app_v1alpha.AdaptCrud(nil),
+		app_v1alpha.AdaptAppStatus(nil),
+		app_v1alpha.AdaptLogs(nil),
+		app_v1alpha.AdaptAddons(nil),
+		deployment_v1alpha.AdaptDeployment(nil),
+		build_v1alpha.AdaptBuilder(nil),
+		admin_v1alpha.AdaptAdmin(nil),
+		debug_v1alpha.AdaptNetDB(nil),
+	}
+
+	out := map[string]map[string]bool{}
+	for _, iface := range ifaces {
+		for _, m := range iface.Methods() {
+			resource := strings.ToLower(m.InterfaceName)
+			if out[resource] == nil {
+				out[resource] = map[string]bool{}
+			}
+			out[resource][strings.ToLower(m.Name)] = true
+		}
+	}
+
+	require.NotEmpty(t, out, "no interfaces resolved; the adapters may have changed shape")
+
+	return out
+}
+
+// A role granting a method that does not exist grants nothing, and nothing else
+// reports it: the catalog compiles, the spot-check tests pass, and the failure
+// only shows up as an authorization denial against a live cluster.
+//
+// This is exactly how the usage API shipped briefly unreachable -- listSandboxes
+// and getSandbox were renamed and the catalog kept naming the old ones, so every
+// workload identity token was denied the very API the rename was meant to
+// improve. The CLI never noticed because it authenticates with a certificate
+// rather than a role.
+func TestCatalogNamesOnlyRealMethods(t *testing.T) {
+	known := realMethods(t)
+
+	for roleName, role := range workloadroles.Roles {
+		for resource, actions := range role.Perms {
+			methods, checked := known[resource]
+			if !checked {
+				// An interface this test does not import yet. Skipping is the
+				// honest thing to do; the alternative is a false failure that
+				// teaches people to delete the assertion.
+				continue
+			}
+
+			for action := range actions {
+				assert.Truef(t, methods[action],
+					"role %q grants %s.%s, which the generated interface does not define",
+					roleName, resource, action)
+			}
+		}
+	}
+}
+
+// The reverse direction is a warning, not a rule: a method nobody grants is
+// often correct (cert-only internals are deliberately ungranted). This asserts
+// only the case we care about -- that the usage API, whose whole point is being
+// callable by something other than the CLI, is fully reachable by a cluster
+// reader.
+func TestClusterReadonlyCanReachEveryUsageMethod(t *testing.T) {
+	role, ok := workloadroles.Lookup(workloadroles.RoleClusterReadonly)
+	require.True(t, ok)
+
+	granted := role.Perms["resourceusage"]
+	require.NotEmpty(t, granted, "cluster-readonly must be able to read usage")
+
+	for _, m := range usage_v1alpha.AdaptResourceUsage(nil).Methods() {
+		action := strings.ToLower(m.Name)
+		assert.Truef(t, granted[action],
+			"cluster-readonly cannot call resourceusage.%s; a caller using workload identity would be denied", action)
+	}
+}

--- a/pkg/workloadroles/roles.go
+++ b/pkg/workloadroles/roles.go
@@ -105,9 +105,22 @@ var (
 		"netdb":              set("listleases", "status"),
 		"sandboxmetrics":     set("snapshot"),
 		"sandboxes":          set("list"),
-		"outboardcontrol":    set("health"),
-		"userquery":          set("whoami"),
-		"builder":            set("analyzeapp"),
+
+		// Usage reads span every app on the cluster, so they can only sit in a
+		// cluster-scoped block; there is no way to confine them to the calling
+		// app the way rpc.AllowApp confines the blocks above.
+		"resourceusage": set(
+			// RPC surface.
+			"listsandboxes", "getsandbox", "listnodes", "listapps",
+			// The same six questions over plain HTTP GET.
+			"httplistsandboxes", "httpgetsandbox",
+			"httplistnodes", "httpgetnode",
+			"httplistapps", "httpgetapp",
+		),
+
+		"outboardcontrol": set("health"),
+		"userquery":       set("whoami"),
+		"builder":         set("analyzeapp"),
 	}
 )
 

--- a/servers/usage/apps.go
+++ b/servers/usage/apps.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"miren.dev/runtime/api/compute"
+
 	"miren.dev/runtime/api/usage/usage_v1alpha"
 	"miren.dev/runtime/pkg/rpc/standard"
 )
@@ -42,7 +44,7 @@ func (s *Server) listApps(ctx context.Context, f filter, w window, ord ordering)
 
 	out := &appListing{cluster: cluster, warnings: warnings, total: int32(len(rows))}
 
-	sortApps(rows, ord.sort, ord.order)
+	sortApps(rows, ord)
 	out.rows = rows[:ord.truncate(len(rows))]
 
 	return out, nil
@@ -164,7 +166,7 @@ func buildAppRows(
 			continue
 		}
 
-		isAddon := sb.ref.Kind() == sandboxKindAddon
+		isAddon := sb.ref.Kind() == string(compute.KindAddon)
 		if isAddon && !includeAddons {
 			continue
 		}
@@ -271,8 +273,9 @@ func (s *Server) appSamples(
 	return cpu, memory, warnings
 }
 
-func sortApps(rows []*usage_v1alpha.AppUsage, key, order string) {
-	desc := !strings.EqualFold(order, "asc")
+func sortApps(rows []*usage_v1alpha.AppUsage, ord ordering) {
+	key := ord.sort
+	desc := ord.descending()
 
 	less := func(a, b *usage_v1alpha.AppUsage) bool {
 		switch strings.ToLower(strings.TrimSpace(key)) {
@@ -281,9 +284,7 @@ func sortApps(rows []*usage_v1alpha.AppUsage, key, order string) {
 		case "sandboxes":
 			return a.SandboxCount() < b.SandboxCount()
 		case "name", "app":
-			// Names sort ascending even under the default descending order:
-			// nobody wants a reverse-alphabetical app list.
-			return a.App() > b.App()
+			return a.App() < b.App()
 		default:
 			return a.Total().CpuCores() < b.Total().CpuCores()
 		}

--- a/servers/usage/apps.go
+++ b/servers/usage/apps.go
@@ -1,0 +1,298 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// appListing is the answer both surfaces return.
+type appListing struct {
+	rows     []*usage_v1alpha.AppUsage
+	cluster  totals
+	total    int32
+	warnings []string
+}
+
+// listApps is the one implementation behind ListApps (RPC) and HttpListApps
+// and HttpGetApp (REST).
+//
+// A caller could add up the sandbox listing itself, but only by knowing that an
+// app's database is a separate sandbox with a different label spelling and a
+// different kind. Doing it here means "what is app X using" has one answer that
+// does not depend on the caller reconstructing Miren's model.
+func (s *Server) listApps(ctx context.Context, f filter, w window, ord ordering) (*appListing, error) {
+	// Every kind is loaded regardless of the addon setting: addons are needed
+	// either to be counted or to be reported as the zero they were excluded at.
+	// The app filter is applied per row rather than in the directory, since an
+	// addon's app comes from a different label than a service's.
+	dir, err := s.loadDirectory(ctx, filter{node: f.node, includeSystem: true})
+	if err != nil {
+		return nil, err
+	}
+
+	cpu, memory, warnings := s.appSamples(ctx, f.node, w, dir)
+
+	rows, cluster := buildAppRows(dir, cpu, memory, f.app, f.includeAddons)
+
+	out := &appListing{cluster: cluster, warnings: warnings, total: int32(len(rows))}
+
+	sortApps(rows, ord.sort, ord.order)
+	out.rows = rows[:ord.truncate(len(rows))]
+
+	return out, nil
+}
+
+// ListApps is the RPC surface.
+func (s *Server) ListApps(ctx context.Context, state *usage_v1alpha.ResourceUsageListApps) error {
+	args := state.Args()
+	w := windowFrom(args.Window())
+
+	listing, err := s.listApps(ctx, selectorToFilter(args.Selector()), w, orderingFrom(args.Ordering()))
+	if err != nil {
+		return err
+	}
+
+	res := state.Results()
+	res.SetApps(listing.rows)
+	res.SetCluster(listing.cluster.encode())
+	res.SetTotalCount(listing.total)
+	res.SetWindow(w.encode())
+	res.SetCollectedAt(standard.ToTimestamp(time.Now()))
+	res.SetWarnings(listing.warnings)
+
+	return nil
+}
+
+// HttpListApps serves GET /api/v1/usage/apps.
+func (s *Server) HttpListApps(ctx context.Context, state *usage_v1alpha.ResourceUsageHttpListApps) error {
+	args := state.Args()
+
+	w := restWindow(args.Since(), args.Until(), args.Aggregate())
+	f := filter{node: args.Node(), includeAddons: !args.HasAddons() || args.Addons()}
+	ord := ordering{sort: args.Sort(), order: args.Order(), limit: int(args.Limit())}
+
+	listing, err := s.listApps(ctx, f, w, ord)
+	if err != nil {
+		return err
+	}
+
+	res := state.Results()
+	res.SetApps(listing.rows)
+	res.SetCluster(listing.cluster.encode())
+	res.SetTotalCount(listing.total)
+	res.SetWindow(w.encode())
+	res.SetCollectedAt(standard.ToTimestamp(time.Now()))
+	res.SetWarnings(listing.warnings)
+
+	return nil
+}
+
+// HttpGetApp serves GET /api/v1/usage/apps/{app}, addressing one app.
+func (s *Server) HttpGetApp(ctx context.Context, state *usage_v1alpha.ResourceUsageHttpGetApp) error {
+	args := state.Args()
+
+	name := args.App()
+	if name == "" {
+		return fmt.Errorf("an app name is required")
+	}
+
+	w := restWindow(args.Since(), args.Until(), args.Aggregate())
+	f := filter{app: name, includeAddons: !args.HasAddons() || args.Addons()}
+
+	listing, err := s.listApps(ctx, f, w, ordering{})
+	if err != nil {
+		return err
+	}
+
+	res := state.Results()
+	res.SetWindow(w.encode())
+	res.SetWarnings(listing.warnings)
+
+	if len(listing.rows) == 0 {
+		return fmt.Errorf("app %q has no running sandboxes", name)
+	}
+
+	res.SetUsage(listing.rows[0])
+
+	return nil
+}
+
+// appTally accumulates one app's sandboxes before they become a row.
+type appTally struct {
+	app      string
+	appID    string
+	services totals
+	addons   totals
+
+	serviceCount int64
+	addonCount   int64
+
+	// sampled records whether any sandbox of this app reported anything. An app
+	// whose every sandbox is silent is reported as stale rather than as idle.
+	sampled bool
+}
+
+// buildAppRows groups the directory's sandboxes by app and attaches their
+// samples.
+//
+// The entity pass drives the row set here exactly as it does for sandboxes: an
+// app is a row because it has sandboxes, not because it has metrics. An app
+// whose sandboxes have all stopped reporting still appears, marked stale.
+func buildAppRows(
+	dir *directory,
+	cpu, memory map[string]float64,
+	appFilter string,
+	includeAddons bool,
+) ([]*usage_v1alpha.AppUsage, totals) {
+	tallies := map[string]*appTally{}
+	order := []string{}
+
+	for _, sb := range dir.sandboxes {
+		app := sb.ref.App()
+		if app == "" {
+			// A sandbox belonging to no app -- a shared addon server, or an
+			// unclassifiable one -- has nothing to roll up into.
+			continue
+		}
+		if appFilter != "" && app != appFilter {
+			continue
+		}
+
+		isAddon := sb.ref.Kind() == sandboxKindAddon
+		if isAddon && !includeAddons {
+			continue
+		}
+
+		t, ok := tallies[app]
+		if !ok {
+			t = &appTally{app: app, appID: sb.ref.AppId()}
+			tallies[app] = t
+			order = append(order, app)
+		}
+		if t.appID == "" {
+			t.appID = sb.ref.AppId()
+		}
+
+		id := sb.ref.Sandbox()
+		cores, haveCPU := cpu[id]
+		bytes, haveMem := memory[id]
+		if haveCPU || haveMem {
+			t.sampled = true
+		}
+
+		if isAddon {
+			t.addons.cpuCores += cores
+			t.addons.memoryBytes += int64(bytes)
+			t.addonCount++
+		} else {
+			t.services.cpuCores += cores
+			t.services.memoryBytes += int64(bytes)
+			t.serviceCount++
+		}
+	}
+
+	rows := make([]*usage_v1alpha.AppUsage, 0, len(order))
+	var cluster totals
+
+	for _, name := range order {
+		t := tallies[name]
+
+		total := totals{
+			cpuCores:    t.services.cpuCores + t.addons.cpuCores,
+			memoryBytes: t.services.memoryBytes + t.addons.memoryBytes,
+		}
+
+		var row usage_v1alpha.AppUsage
+		row.SetApp(t.app)
+		row.SetAppId(t.appID)
+		row.SetTotal(total.encode())
+		row.SetServices(t.services.encode())
+		row.SetAddons(t.addons.encode())
+		row.SetSandboxCount(t.serviceCount + t.addonCount)
+		row.SetServiceCount(t.serviceCount)
+		row.SetAddonCount(t.addonCount)
+		row.SetStale(!t.sampled)
+
+		cluster.cpuCores += total.cpuCores
+		cluster.memoryBytes += total.memoryBytes
+
+		rows = append(rows, &row)
+	}
+
+	return rows, cluster
+}
+
+// appSamples fetches per-sandbox usage for the app rollup.
+//
+// It groups by sandbox rather than by app, even though the answer is per-app,
+// because the services-versus-addons split has to be made per sandbox and the
+// metric labels do not carry that distinction -- the entity model does. Summing
+// in the query would produce a total that could not be broken apart again.
+func (s *Server) appSamples(
+	ctx context.Context,
+	node string,
+	w window,
+	dir *directory,
+) (cpu, memory map[string]float64, warnings []string) {
+	cpu = map[string]float64{}
+	memory = map[string]float64{}
+
+	if s.Reader == nil {
+		return cpu, memory, []string{"no metrics backend configured; usage figures are unavailable"}
+	}
+
+	selector := ""
+	if node != "" {
+		if n := matchNode(dir.nodes, node); n != nil {
+			selector = labelSelector(map[string]string{labelNode: string(n.id)})
+		}
+	}
+
+	dur := w.duration()
+
+	if vals, err := s.instantByLabel(ctx, cpuCoresQuery(labelSandbox, selector, dur, w.aggregate), labelSandbox, w.end); err != nil {
+		warnings = append(warnings, "cpu usage unavailable: "+err.Error())
+	} else {
+		cpu = vals
+	}
+
+	if vals, err := s.instantByLabel(ctx, memoryBytesQuery(labelSandbox, selector, dur, w.aggregate), labelSandbox, w.end); err != nil {
+		warnings = append(warnings, "memory usage unavailable: "+err.Error())
+	} else {
+		memory = vals
+	}
+
+	return cpu, memory, warnings
+}
+
+func sortApps(rows []*usage_v1alpha.AppUsage, key, order string) {
+	desc := !strings.EqualFold(order, "asc")
+
+	less := func(a, b *usage_v1alpha.AppUsage) bool {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "memory", "mem":
+			return a.Total().MemoryBytes() < b.Total().MemoryBytes()
+		case "sandboxes":
+			return a.SandboxCount() < b.SandboxCount()
+		case "name", "app":
+			// Names sort ascending even under the default descending order:
+			// nobody wants a reverse-alphabetical app list.
+			return a.App() > b.App()
+		default:
+			return a.Total().CpuCores() < b.Total().CpuCores()
+		}
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		if desc {
+			return less(rows[j], rows[i])
+		}
+		return less(rows[i], rows[j])
+	})
+}

--- a/servers/usage/apps.go
+++ b/servers/usage/apps.go
@@ -274,21 +274,23 @@ func (s *Server) appSamples(
 }
 
 func sortApps(rows []*usage_v1alpha.AppUsage, ord ordering) {
-	key := ord.sort
-	desc := ord.descending()
+	var (
+		less      func(a, b *usage_v1alpha.AppUsage) bool
+		ascending bool
+	)
 
-	less := func(a, b *usage_v1alpha.AppUsage) bool {
-		switch strings.ToLower(strings.TrimSpace(key)) {
-		case "memory", "mem":
-			return a.Total().MemoryBytes() < b.Total().MemoryBytes()
-		case "sandboxes":
-			return a.SandboxCount() < b.SandboxCount()
-		case "name", "app":
-			return a.App() < b.App()
-		default:
-			return a.Total().CpuCores() < b.Total().CpuCores()
-		}
+	switch strings.ToLower(strings.TrimSpace(ord.sort)) {
+	case "memory", "mem":
+		less = func(a, b *usage_v1alpha.AppUsage) bool { return a.Total().MemoryBytes() < b.Total().MemoryBytes() }
+	case "sandboxes":
+		less = func(a, b *usage_v1alpha.AppUsage) bool { return a.SandboxCount() < b.SandboxCount() }
+	case "name", "app":
+		less, ascending = func(a, b *usage_v1alpha.AppUsage) bool { return a.App() < b.App() }, true
+	default:
+		less = func(a, b *usage_v1alpha.AppUsage) bool { return a.Total().CpuCores() < b.Total().CpuCores() }
 	}
+
+	desc := ord.direction(ascending)
 
 	sort.SliceStable(rows, func(i, j int) bool {
 		if desc {

--- a/servers/usage/apps_test.go
+++ b/servers/usage/apps_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"miren.dev/runtime/api/compute"
 	"miren.dev/runtime/api/usage/usage_v1alpha"
 )
 
@@ -33,9 +34,9 @@ func findApp(rows []*usage_v1alpha.AppUsage, name string) *usage_v1alpha.AppUsag
 // depends on are separate sandboxes, and a caller should not have to know that.
 func TestAppRowsSumServicesAndAddons(t *testing.T) {
 	dir := &directory{sandboxes: []sandboxRow{
-		row("sb/web1", "shop", sandboxKindApp),
-		row("sb/web2", "shop", sandboxKindApp),
-		row("sb/pg", "shop", sandboxKindAddon),
+		row("sb/web1", "shop", string(compute.KindApp)),
+		row("sb/web2", "shop", string(compute.KindApp)),
+		row("sb/pg", "shop", string(compute.KindAddon)),
 	}}
 	cpu := map[string]float64{"sb/web1": 0.5, "sb/web2": 0.25, "sb/pg": 1.5}
 	mem := map[string]float64{"sb/web1": 100, "sb/web2": 100, "sb/pg": 800}
@@ -63,8 +64,8 @@ func TestAppRowsSumServicesAndAddons(t *testing.T) {
 // total and the split stop agreeing.
 func TestAppRowsCanExcludeAddons(t *testing.T) {
 	dir := &directory{sandboxes: []sandboxRow{
-		row("sb/web", "shop", sandboxKindApp),
-		row("sb/pg", "shop", sandboxKindAddon),
+		row("sb/web", "shop", string(compute.KindApp)),
+		row("sb/pg", "shop", string(compute.KindAddon)),
 	}}
 	cpu := map[string]float64{"sb/web": 0.5, "sb/pg": 1.5}
 
@@ -79,9 +80,9 @@ func TestAppRowsCanExcludeAddons(t *testing.T) {
 
 func TestAppRowsSeparateApps(t *testing.T) {
 	dir := &directory{sandboxes: []sandboxRow{
-		row("sb/a", "shop", sandboxKindApp),
-		row("sb/b", "blog", sandboxKindApp),
-		row("sb/c", "blog", sandboxKindAddon),
+		row("sb/a", "shop", string(compute.KindApp)),
+		row("sb/b", "blog", string(compute.KindApp)),
+		row("sb/c", "blog", string(compute.KindAddon)),
 	}}
 	cpu := map[string]float64{"sb/a": 1, "sb/b": 2, "sb/c": 3}
 
@@ -96,8 +97,8 @@ func TestAppRowsSeparateApps(t *testing.T) {
 // would make a broken telemetry pipeline look like an idle cluster.
 func TestAppRowsReportSilentAppsAsStale(t *testing.T) {
 	dir := &directory{sandboxes: []sandboxRow{
-		row("sb/quiet", "shop", sandboxKindApp),
-		row("sb/busy", "blog", sandboxKindApp),
+		row("sb/quiet", "shop", string(compute.KindApp)),
+		row("sb/busy", "blog", string(compute.KindApp)),
 	}}
 	cpu := map[string]float64{"sb/busy": 1}
 
@@ -112,8 +113,8 @@ func TestAppRowsReportSilentAppsAsStale(t *testing.T) {
 // up into, and must not create a row named "".
 func TestAppRowsSkipSandboxesWithNoApp(t *testing.T) {
 	dir := &directory{sandboxes: []sandboxRow{
-		row("sb/shared", "", sandboxKindAddon),
-		row("sb/web", "shop", sandboxKindApp),
+		row("sb/shared", "", string(compute.KindAddon)),
+		row("sb/web", "shop", string(compute.KindApp)),
 	}}
 	cpu := map[string]float64{"sb/shared": 9, "sb/web": 1}
 
@@ -127,8 +128,8 @@ func TestAppRowsSkipSandboxesWithNoApp(t *testing.T) {
 
 func TestAppRowsFilterByApp(t *testing.T) {
 	dir := &directory{sandboxes: []sandboxRow{
-		row("sb/a", "shop", sandboxKindApp),
-		row("sb/b", "blog", sandboxKindApp),
+		row("sb/a", "shop", string(compute.KindApp)),
+		row("sb/b", "blog", string(compute.KindApp)),
 	}}
 
 	rows, _ := buildAppRows(dir, map[string]float64{"sb/a": 1, "sb/b": 2}, nil, "shop", true)

--- a/servers/usage/apps_test.go
+++ b/servers/usage/apps_test.go
@@ -1,0 +1,138 @@
+package usage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+)
+
+// row builds one directory entry. The ref is what the entity pass would have
+// produced; the sample maps are keyed by the same sandbox id.
+func row(sandbox, app, kind string) sandboxRow {
+	var ref usage_v1alpha.SandboxRef
+	ref.SetSandbox(sandbox)
+	ref.SetApp(app)
+	ref.SetAppId("app/" + app)
+	ref.SetKind(kind)
+	return sandboxRow{ref: &ref}
+}
+
+func findApp(rows []*usage_v1alpha.AppUsage, name string) *usage_v1alpha.AppUsage {
+	for _, r := range rows {
+		if r.App() == name {
+			return r
+		}
+	}
+	return nil
+}
+
+// The whole point of the rollup: an app's own services and the database it
+// depends on are separate sandboxes, and a caller should not have to know that.
+func TestAppRowsSumServicesAndAddons(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/web1", "shop", sandboxKindApp),
+		row("sb/web2", "shop", sandboxKindApp),
+		row("sb/pg", "shop", sandboxKindAddon),
+	}}
+	cpu := map[string]float64{"sb/web1": 0.5, "sb/web2": 0.25, "sb/pg": 1.5}
+	mem := map[string]float64{"sb/web1": 100, "sb/web2": 100, "sb/pg": 800}
+
+	rows, cluster := buildAppRows(dir, cpu, mem, "", true)
+	require.Len(t, rows, 1)
+
+	shop := rows[0]
+	assert.InDelta(t, 2.25, shop.Total().CpuCores(), 0.001)
+	assert.InDelta(t, 0.75, shop.Services().CpuCores(), 0.001)
+	assert.InDelta(t, 1.5, shop.Addons().CpuCores(), 0.001)
+	assert.Equal(t, int64(1000), shop.Total().MemoryBytes())
+
+	// The counts say what the split is made of, so "1.5 cores of addon" can be
+	// attributed to something.
+	assert.Equal(t, int64(3), shop.SandboxCount())
+	assert.Equal(t, int64(2), shop.ServiceCount())
+	assert.Equal(t, int64(1), shop.AddonCount())
+
+	assert.InDelta(t, 2.25, cluster.cpuCores, 0.001)
+}
+
+// Excluding addons answers "what is my code doing" rather than "what does this
+// app cost". The addon block must then read zero rather than disappear, or the
+// total and the split stop agreeing.
+func TestAppRowsCanExcludeAddons(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/web", "shop", sandboxKindApp),
+		row("sb/pg", "shop", sandboxKindAddon),
+	}}
+	cpu := map[string]float64{"sb/web": 0.5, "sb/pg": 1.5}
+
+	rows, _ := buildAppRows(dir, cpu, nil, "", false)
+	require.Len(t, rows, 1)
+
+	assert.InDelta(t, 0.5, rows[0].Total().CpuCores(), 0.001)
+	assert.InDelta(t, 0, rows[0].Addons().CpuCores(), 0.001)
+	assert.Equal(t, int64(0), rows[0].AddonCount())
+	assert.Equal(t, int64(1), rows[0].SandboxCount())
+}
+
+func TestAppRowsSeparateApps(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/a", "shop", sandboxKindApp),
+		row("sb/b", "blog", sandboxKindApp),
+		row("sb/c", "blog", sandboxKindAddon),
+	}}
+	cpu := map[string]float64{"sb/a": 1, "sb/b": 2, "sb/c": 3}
+
+	rows, _ := buildAppRows(dir, cpu, nil, "", true)
+	require.Len(t, rows, 2)
+
+	assert.InDelta(t, 1.0, findApp(rows, "shop").Total().CpuCores(), 0.001)
+	assert.InDelta(t, 5.0, findApp(rows, "blog").Total().CpuCores(), 0.001)
+}
+
+// An app whose sandboxes have all gone quiet is a finding. Dropping the row
+// would make a broken telemetry pipeline look like an idle cluster.
+func TestAppRowsReportSilentAppsAsStale(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/quiet", "shop", sandboxKindApp),
+		row("sb/busy", "blog", sandboxKindApp),
+	}}
+	cpu := map[string]float64{"sb/busy": 1}
+
+	rows, _ := buildAppRows(dir, cpu, nil, "", true)
+	require.Len(t, rows, 2, "an app with no samples still gets a row")
+
+	assert.True(t, findApp(rows, "shop").Stale())
+	assert.False(t, findApp(rows, "blog").Stale())
+}
+
+// A sandbox belonging to no app -- a shared addon server -- has nothing to roll
+// up into, and must not create a row named "".
+func TestAppRowsSkipSandboxesWithNoApp(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/shared", "", sandboxKindAddon),
+		row("sb/web", "shop", sandboxKindApp),
+	}}
+	cpu := map[string]float64{"sb/shared": 9, "sb/web": 1}
+
+	rows, cluster := buildAppRows(dir, cpu, nil, "", true)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, "shop", rows[0].App())
+	assert.InDelta(t, 1.0, cluster.cpuCores, 0.001,
+		"an unattributable sandbox must not inflate the cluster total")
+}
+
+func TestAppRowsFilterByApp(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/a", "shop", sandboxKindApp),
+		row("sb/b", "blog", sandboxKindApp),
+	}}
+
+	rows, _ := buildAppRows(dir, map[string]float64{"sb/a": 1, "sb/b": 2}, nil, "shop", true)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, "shop", rows[0].App())
+}

--- a/servers/usage/convert.go
+++ b/servers/usage/convert.go
@@ -1,0 +1,104 @@
+package usage
+
+import (
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+)
+
+// This file is the seam between the two shapes the API is offered in.
+//
+// The RPC surface takes grouped types so a Go caller cannot transpose two
+// arguments; the REST surface takes flat scalars because that is what a query
+// string can carry, and duration strings because that is what a URL should look
+// like. Both funnel into the same internal filter/window/ordering values, so
+// there is one implementation and two front doors.
+
+// ordering is the resolved sort and truncation for a listing.
+type ordering struct {
+	sort  string
+	order string
+	limit int
+}
+
+func (o ordering) truncate(n int) int {
+	if o.limit > 0 && o.limit < n {
+		return o.limit
+	}
+	return n
+}
+
+// --- from the RPC surface ---
+
+func selectorToFilter(sel *usage_v1alpha.Selector) filter {
+	if sel == nil {
+		return filter{}
+	}
+
+	f := filter{
+		app:           sel.App(),
+		service:       sel.Service(),
+		node:          sel.Node(),
+		kind:          sel.Kind(),
+		status:        sel.Status(),
+		includeSystem: sel.IncludeSystem(),
+	}
+
+	// Addons count toward an app's total unless the caller says otherwise, so
+	// the absent case has to be distinguished from an explicit false. The
+	// generated getter cannot do that on its own.
+	f.includeAddons = !sel.HasIncludeAddons() || sel.IncludeAddons()
+
+	return f
+}
+
+func windowFrom(w *usage_v1alpha.Window) window {
+	if w == nil {
+		return resolveWindow(nil, nil, "")
+	}
+	return resolveWindow(w.Start(), w.End(), w.Aggregate())
+}
+
+func orderingFrom(o *usage_v1alpha.Ordering) ordering {
+	if o == nil {
+		return ordering{}
+	}
+	return ordering{sort: o.Sort(), order: o.Order(), limit: int(o.Limit())}
+}
+
+// --- from the REST surface ---
+
+// restWindow converts the duration strings a URL carries into a span.
+//
+// since and until are both measured backwards from now, so "?since=1h" is the
+// last hour and "?since=2h&until=1h" is the hour before that. An unparseable
+// value is ignored rather than rejected: this is a diagnostic endpoint, and
+// answering a typo'd duration with the default beats a 400.
+func restWindow(since, until, aggregate string) window {
+	end := time.Now()
+	if d, ok := parseRESTDuration(until); ok {
+		end = end.Add(-d)
+	}
+
+	start := end.Add(-defaultWindow)
+	if d, ok := parseRESTDuration(since); ok {
+		start = end.Add(-d)
+	}
+
+	return window{start: start, end: end, aggregate: resolveAggregate(aggregate)}
+}
+
+func parseRESTDuration(s string) (time.Duration, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0, false
+	}
+
+	return d, true
+}

--- a/servers/usage/convert.go
+++ b/servers/usage/convert.go
@@ -22,6 +22,28 @@ type ordering struct {
 	limit int
 }
 
+// descending reports which direction to sort in when the caller did not say.
+//
+// The sensible default depends on what is being sorted: a usage column wants
+// the busiest first, while a name wants A to Z. Making the caller pass
+// order=asc just to get an alphabetical list would be a trap, and passing
+// order=desc for a name should still reverse it.
+func (o ordering) descending() bool {
+	switch strings.ToLower(strings.TrimSpace(o.order)) {
+	case "asc":
+		return false
+	case "desc":
+		return true
+	}
+
+	switch strings.ToLower(strings.TrimSpace(o.sort)) {
+	case "name", "app", "service", "node", "runner":
+		return false
+	default:
+		return true
+	}
+}
+
 func (o ordering) truncate(n int) int {
 	if o.limit > 0 && o.limit < n {
 		return o.limit

--- a/servers/usage/convert.go
+++ b/servers/usage/convert.go
@@ -22,13 +22,15 @@ type ordering struct {
 	limit int
 }
 
-// descending reports which direction to sort in when the caller did not say.
+// direction reports whether to sort descending.
 //
-// The sensible default depends on what is being sorted: a usage column wants
-// the busiest first, while a name wants A to Z. Making the caller pass
-// order=asc just to get an alphabetical list would be a trap, and passing
-// order=desc for a name should still reverse it.
-func (o ordering) descending() bool {
+// An explicit order always wins. Otherwise the sensible default depends on what
+// is being sorted, so each comparator states it: a usage column wants the
+// busiest first, a name wants A to Z. Asking the comparator rather than
+// guessing from the key name is what keeps the two in step -- a key one listing
+// sorts by name and another does not implement would otherwise get an
+// alphabetical direction applied to a CPU comparison.
+func (o ordering) direction(defaultAscending bool) bool {
 	switch strings.ToLower(strings.TrimSpace(o.order)) {
 	case "asc":
 		return false
@@ -36,12 +38,7 @@ func (o ordering) descending() bool {
 		return true
 	}
 
-	switch strings.ToLower(strings.TrimSpace(o.sort)) {
-	case "name", "app", "service", "node", "runner":
-		return false
-	default:
-		return true
-	}
+	return !defaultAscending
 }
 
 func (o ordering) truncate(n int) int {

--- a/servers/usage/convert.go
+++ b/servers/usage/convert.go
@@ -95,14 +95,27 @@ func orderingFrom(o *usage_v1alpha.Ordering) ordering {
 // value is ignored rather than rejected: this is a diagnostic endpoint, and
 // answering a typo'd duration with the default beats a 400.
 func restWindow(since, until, aggregate string) window {
-	end := time.Now()
+	// Both offsets come off one captured now. Measuring since from an already
+	// shifted end would make the two cumulative, so ?since=2h&until=1h would
+	// answer with two hours starting three hours ago instead of the hour it
+	// names.
+	now := time.Now()
+
+	end := now
 	if d, ok := parseRESTDuration(until); ok {
-		end = end.Add(-d)
+		end = now.Add(-d)
 	}
 
 	start := end.Add(-defaultWindow)
 	if d, ok := parseRESTDuration(since); ok {
-		start = end.Add(-d)
+		start = now.Add(-d)
+	}
+
+	// A since inside until names no span at all. Falling back to the default
+	// length ending where until asked keeps a diagnostic endpoint answering,
+	// which is the same trade resolveWindow makes for the RPC surface.
+	if !start.Before(end) {
+		start = end.Add(-defaultWindow)
 	}
 
 	return window{start: start, end: end, aggregate: resolveAggregate(aggregate)}

--- a/servers/usage/convert_test.go
+++ b/servers/usage/convert_test.go
@@ -1,0 +1,72 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// roughly compares a duration against a target, absorbing the time.Now() call
+// inside restWindow. The tolerance is far tighter than any span under test.
+func roughly(t *testing.T, want, got time.Duration, msg string) {
+	t.Helper()
+	require.WithinDuration(t,
+		time.Time{}.Add(want), time.Time{}.Add(got), time.Second, msg)
+}
+
+// since and until are each measured backwards from now. Deriving since from an
+// already shifted end would make them cumulative, so the window a caller asks
+// for by name would not be the window they get.
+func TestRESTWindowMeasuresBothOffsetsFromNow(t *testing.T) {
+	now := time.Now()
+
+	w := restWindow("2h", "1h", "")
+
+	roughly(t, time.Hour, now.Sub(w.end), "until should place the end one hour ago")
+	roughly(t, 2*time.Hour, now.Sub(w.start), "since should place the start two hours ago")
+	roughly(t, time.Hour, w.duration(), "?since=2h&until=1h names a one-hour span")
+}
+
+func TestRESTWindowDefaults(t *testing.T) {
+	now := time.Now()
+
+	w := restWindow("", "", "")
+
+	roughly(t, 0, now.Sub(w.end), "an absent until ends the window now")
+	roughly(t, defaultWindow, w.duration(), "an absent since uses the default length")
+}
+
+// until alone still leaves a window of the default length, ending where it asks.
+func TestRESTWindowUntilAloneKeepsDefaultLength(t *testing.T) {
+	now := time.Now()
+
+	w := restWindow("", "30m", "")
+
+	roughly(t, 30*time.Minute, now.Sub(w.end), "until should place the end")
+	roughly(t, defaultWindow, w.duration(), "the span keeps its default length")
+}
+
+// A since inside until describes no span. Answering with the default length is
+// what the RPC surface does for the same case, and a diagnostic endpoint is
+// better off answering than returning a 400.
+func TestRESTWindowRejectsAnInvertedSpan(t *testing.T) {
+	now := time.Now()
+
+	w := restWindow("1h", "2h", "")
+
+	roughly(t, 2*time.Hour, now.Sub(w.end), "until still places the end")
+	require.True(t, w.start.Before(w.end), "the window must not be inverted")
+	roughly(t, defaultWindow, w.duration(), "an inverted span falls back to the default length")
+}
+
+// An unparseable duration is ignored rather than rejected, so a typo answers
+// with the default rather than an error.
+func TestRESTWindowIgnoresUnparseableDurations(t *testing.T) {
+	now := time.Now()
+
+	w := restWindow("banana", "-5m", "")
+
+	roughly(t, 0, now.Sub(w.end), "a negative until is ignored")
+	roughly(t, defaultWindow, w.duration(), "an unparseable since is ignored")
+}

--- a/servers/usage/directory.go
+++ b/servers/usage/directory.go
@@ -1,0 +1,389 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"miren.dev/runtime/api/compute"
+	computev1 "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/rpc/standard"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// sandboxRow is one sandbox with everything needed to describe it, gathered
+// before any metric is read.
+//
+// The entity pass drives the row set and the metric pass only decorates it.
+// That ordering matters: a sandbox that is running but reporting nothing has to
+// appear with blank usage, because a metrics pipeline that has stopped is
+// itself the thing an operator needs to see. Sorting rows by what came back
+// from the time-series database would hide exactly that case.
+type sandboxRow struct {
+	ref    *usage_v1alpha.SandboxRef
+	poolID string
+}
+
+// directory is the resolved entity view of the cluster: every sandbox, joined
+// to the app, service and node that explain it.
+type directory struct {
+	sandboxes []sandboxRow
+	nodes     map[entity.Id]*nodeInfo
+}
+
+type nodeInfo struct {
+	id         entity.Id
+	name       string
+	runnerID   string
+	role       string
+	status     string
+	scheduling string
+}
+
+// displayName is what an operator would recognize the node by. It falls back
+// through the identifiers most-human-first, because an unnamed node is still
+// better identified by a truncated runner id than by nothing.
+func (n *nodeInfo) displayName() string {
+	if n.name != "" {
+		return n.name
+	}
+	if n.runnerID != "" {
+		if len(n.runnerID) > 12 {
+			return n.runnerID[:12]
+		}
+		return n.runnerID
+	}
+	return string(n.id)
+}
+
+// filter narrows a listing. Every field is exact-match, and an empty field
+// means unconstrained.
+type filter struct {
+	app     string
+	service string
+	node    string
+	kind    string
+	status  string
+
+	// includeSystem admits addon and platform sandboxes to a listing that would
+	// otherwise show only app services.
+	includeSystem bool
+
+	// includeAddons applies to app rollups only: whether an app's dedicated
+	// addons count toward its total.
+	includeAddons bool
+}
+
+// matches reports whether a sandbox belongs in the listing.
+func (f filter) matches(ref *usage_v1alpha.SandboxRef) bool {
+	if f.app != "" && ref.App() != f.app {
+		return false
+	}
+	if f.service != "" && ref.Service() != f.service {
+		return false
+	}
+	if f.kind != "" && ref.Kind() != f.kind {
+		return false
+	}
+	if f.status != "" && !strings.EqualFold(ui.CleanStatus(ref.Status()), f.status) {
+		return false
+	}
+
+	// Addons and one-off runs are the platform's own sandboxes. They are hidden
+	// by default so the listing answers "what are my apps doing", but an
+	// explicit --kind for one of them is a direct request and overrides that.
+	if !f.includeSystem && f.kind == "" {
+		switch ref.Kind() {
+		case sandboxKindAddon, sandboxKindRun, sandboxKindOther:
+			return false
+		}
+	}
+
+	return true
+}
+
+// Sandbox kinds, matching the miren.kind attribute the sandbox controller
+// stamps on every metric series.
+const (
+	sandboxKindApp   = "app"
+	sandboxKindAddon = "addon"
+	sandboxKindRun   = "run"
+	sandboxKindOther = "other"
+)
+
+// loadDirectory resolves the entity view of the cluster.
+//
+// When the caller has narrowed to one node this reads only that node's
+// sandboxes, through the schedule index, rather than scanning every sandbox in
+// the cluster. That is the difference between a cheap repeated call and an
+// expensive one, and a watch loop makes this call every few seconds.
+func (s *Server) loadDirectory(ctx context.Context, f filter) (*directory, error) {
+	nodes, err := s.loadNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var scopeNode *nodeInfo
+	if f.node != "" {
+		scopeNode = matchNode(nodes, f.node)
+		if scopeNode == nil {
+			// An unknown node is an empty listing, not an error: the caller may
+			// be watching a runner that has just been removed.
+			return &directory{nodes: nodes}, nil
+		}
+	}
+
+	index := entity.Ref(entity.EntityKind, computev1.KindSandbox)
+	if scopeNode != nil {
+		index = computev1.Index(computev1.KindSandbox, scopeNode.id)
+	}
+
+	sandboxes, err := s.EC.List(ctx, index)
+	if err != nil {
+		return nil, fmt.Errorf("listing sandboxes: %w", err)
+	}
+
+	pools, err := s.loadPools(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	apps, err := s.loadVersionApps(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := &directory{nodes: nodes}
+
+	for sandboxes.Next() {
+		var sb computev1.Sandbox
+		if err := sandboxes.Read(&sb); err != nil {
+			continue
+		}
+
+		ent := sandboxes.Entity()
+
+		var md core_v1alpha.Metadata
+		md.Decode(ent)
+
+		var sch computev1.Schedule
+		sch.Decode(ent)
+
+		// A dead sandbox is not a row. Listing it would show a sandbox using no
+		// resources, which reads as idle rather than as gone.
+		if compute.SandboxDead(sb.Status) {
+			continue
+		}
+
+		poolID, _ := md.Labels.Get("pool")
+
+		dir.sandboxes = append(dir.sandboxes, sandboxRow{
+			ref:    s.buildRef(&sb, &md, &sch, ent, pools, apps, nodes),
+			poolID: poolID,
+		})
+	}
+
+	return dir, nil
+}
+
+// buildRef assembles one sandbox's identity from the several entities that
+// each hold a piece of it.
+func (s *Server) buildRef(
+	sb *computev1.Sandbox,
+	md *core_v1alpha.Metadata,
+	sch *computev1.Schedule,
+	ent *entity.Entity,
+	pools map[string]*poolInfo,
+	apps map[string]*appInfo,
+	nodes map[entity.Id]*nodeInfo,
+) *usage_v1alpha.SandboxRef {
+	var ref usage_v1alpha.SandboxRef
+
+	ref.SetSandbox(sb.ID.String())
+	ref.SetSandboxShortId(ent.ShortId())
+	ref.SetStatus(ui.CleanStatus(string(sb.Status)))
+	ref.SetStartedAt(standard.ToTimestamp(ent.GetCreatedAt()))
+
+	poolID, _ := md.Labels.Get("pool")
+	ref.SetPool(poolID)
+
+	// Service has two sources. The label is one lookup and is present on every
+	// pool-managed sandbox; the pool entity is the fallback for anything that
+	// predates it.
+	service, _ := md.Labels.Get("service")
+	if service == "" {
+		if p := pools[poolID]; p != nil {
+			service = p.service
+		}
+	}
+	ref.SetService(service)
+
+	// The app name likewise has two sources. The label is the app's name
+	// directly; the version reference resolves to the same app but survives a
+	// sandbox created without the label.
+	appName, _ := md.Labels.Get("app")
+	if a := apps[sb.Spec.Version.String()]; a != nil {
+		ref.SetAppId(a.id)
+		ref.SetVersion(a.version)
+		ref.SetVersionShortId(a.shortID)
+		if appName == "" {
+			appName = ui.CleanEntityID(a.id)
+		}
+	}
+	ref.SetApp(appName)
+
+	ref.SetKind(classifySandbox(sb, md))
+
+	if !entity.Empty(sch.Key.Node) {
+		ref.SetNode(sch.Key.Node.String())
+		if n := nodes[sch.Key.Node]; n != nil {
+			ref.SetNodeName(n.displayName())
+			ref.SetRunnerId(n.runnerID)
+		}
+	}
+
+	return &ref
+}
+
+// classifySandbox separates a user's own services from the platform running
+// underneath them.
+//
+// This deliberately mirrors sandboxWorkloadKind in the sandbox controller,
+// which stamps the same value onto the metric series. The two must agree, or a
+// --kind filter would select different rows than the metrics behind them.
+func classifySandbox(sb *computev1.Sandbox, md *core_v1alpha.Metadata) string {
+	if _, ok := md.Labels.Get("addon"); ok {
+		return sandboxKindAddon
+	}
+	if _, ok := md.Labels.Get("run"); ok {
+		return sandboxKindRun
+	}
+
+	var stage string
+	for _, lbl := range sb.Spec.LogAttribute {
+		switch lbl.Key {
+		case "addon":
+			return sandboxKindAddon
+		case "miren.stage":
+			stage = lbl.Value
+		}
+	}
+
+	switch stage {
+	case "run":
+		return sandboxKindRun
+	case "app-run":
+		return sandboxKindApp
+	}
+
+	if !entity.Empty(sb.Spec.Version) {
+		return sandboxKindApp
+	}
+
+	return sandboxKindOther
+}
+
+type poolInfo struct {
+	service            string
+	consecutiveCrashes int32
+}
+
+func (s *Server) loadPools(ctx context.Context) (map[string]*poolInfo, error) {
+	res, err := s.EC.List(ctx, entity.Ref(entity.EntityKind, computev1.KindSandboxPool))
+	if err != nil {
+		return nil, fmt.Errorf("listing sandbox pools: %w", err)
+	}
+
+	pools := map[string]*poolInfo{}
+	for res.Next() {
+		var p computev1.SandboxPool
+		if err := res.Read(&p); err != nil {
+			continue
+		}
+		pools[p.ID.String()] = &poolInfo{
+			service:            p.Service,
+			consecutiveCrashes: int32(p.ConsecutiveCrashCount),
+		}
+	}
+
+	return pools, nil
+}
+
+type appInfo struct {
+	id      string
+	version string
+	shortID string
+}
+
+// loadVersionApps maps an app version to the app it belongs to, which is how a
+// sandbox that carries no app label is still attributed to one.
+func (s *Server) loadVersionApps(ctx context.Context) (map[string]*appInfo, error) {
+	res, err := s.EC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion))
+	if err != nil {
+		return nil, fmt.Errorf("listing app versions: %w", err)
+	}
+
+	apps := map[string]*appInfo{}
+	for res.Next() {
+		var v core_v1alpha.AppVersion
+		if err := res.Read(&v); err != nil {
+			continue
+		}
+		if entity.Empty(v.App) {
+			continue
+		}
+		apps[v.ID.String()] = &appInfo{
+			id:      v.App.String(),
+			version: v.Version,
+			shortID: res.Entity().ShortId(),
+		}
+	}
+
+	return apps, nil
+}
+
+func (s *Server) loadNodes(ctx context.Context) (map[entity.Id]*nodeInfo, error) {
+	res, err := s.EC.List(ctx, entity.Ref(entity.EntityKind, computev1.KindNode))
+	if err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+
+	nodes := map[entity.Id]*nodeInfo{}
+	for res.Next() {
+		var n computev1.Node
+		if err := res.Read(&n); err != nil {
+			continue
+		}
+
+		role, _ := n.Constraints.Get("role")
+		if role == "" {
+			role = "runner"
+		}
+
+		nodes[n.ID] = &nodeInfo{
+			id:         n.ID,
+			name:       n.Name,
+			runnerID:   n.RunnerId,
+			role:       role,
+			status:     ui.CleanStatus(string(n.Status)),
+			scheduling: ui.CleanStatus(string(n.Scheduling)),
+		}
+	}
+
+	return nodes, nil
+}
+
+// matchNode resolves whatever identifier a caller had to hand: the entity id,
+// the runner id, or the display name. Operators type the name, scripts hold the
+// id, and requiring one form would make the filter useless to the other.
+func matchNode(nodes map[entity.Id]*nodeInfo, query string) *nodeInfo {
+	for _, n := range nodes {
+		if string(n.id) == query || n.runnerID == query || n.name == query || n.displayName() == query {
+			return n
+		}
+	}
+	return nil
+}

--- a/servers/usage/directory.go
+++ b/servers/usage/directory.go
@@ -97,22 +97,13 @@ func (f filter) matches(ref *usage_v1alpha.SandboxRef) bool {
 	// explicit --kind for one of them is a direct request and overrides that.
 	if !f.includeSystem && f.kind == "" {
 		switch ref.Kind() {
-		case sandboxKindAddon, sandboxKindRun, sandboxKindOther:
+		case string(compute.KindAddon), string(compute.KindRun), string(compute.KindOther):
 			return false
 		}
 	}
 
 	return true
 }
-
-// Sandbox kinds, matching the miren.kind attribute the sandbox controller
-// stamps on every metric series.
-const (
-	sandboxKindApp   = "app"
-	sandboxKindAddon = "addon"
-	sandboxKindRun   = "run"
-	sandboxKindOther = "other"
-)
 
 // loadDirectory resolves the entity view of the cluster.
 //
@@ -235,7 +226,7 @@ func (s *Server) buildRef(
 	}
 	ref.SetApp(appName)
 
-	ref.SetKind(classifySandbox(sb, md))
+	ref.SetKind(string(compute.SandboxKind(sb)))
 
 	if !entity.Empty(sch.Key.Node) {
 		ref.SetNode(sch.Key.Node.String())
@@ -246,44 +237,6 @@ func (s *Server) buildRef(
 	}
 
 	return &ref
-}
-
-// classifySandbox separates a user's own services from the platform running
-// underneath them.
-//
-// This deliberately mirrors sandboxWorkloadKind in the sandbox controller,
-// which stamps the same value onto the metric series. The two must agree, or a
-// --kind filter would select different rows than the metrics behind them.
-func classifySandbox(sb *computev1.Sandbox, md *core_v1alpha.Metadata) string {
-	if _, ok := md.Labels.Get("addon"); ok {
-		return sandboxKindAddon
-	}
-	if _, ok := md.Labels.Get("run"); ok {
-		return sandboxKindRun
-	}
-
-	var stage string
-	for _, lbl := range sb.Spec.LogAttribute {
-		switch lbl.Key {
-		case "addon":
-			return sandboxKindAddon
-		case "miren.stage":
-			stage = lbl.Value
-		}
-	}
-
-	switch stage {
-	case "run":
-		return sandboxKindRun
-	case "app-run":
-		return sandboxKindApp
-	}
-
-	if !entity.Empty(sb.Spec.Version) {
-		return sandboxKindApp
-	}
-
-	return sandboxKindOther
 }
 
 type poolInfo struct {
@@ -379,11 +332,35 @@ func (s *Server) loadNodes(ctx context.Context) (map[entity.Id]*nodeInfo, error)
 // matchNode resolves whatever identifier a caller had to hand: the entity id,
 // the runner id, or the display name. Operators type the name, scripts hold the
 // id, and requiring one form would make the filter useless to the other.
+//
+// The fields are tried in precedence order rather than first-match, because
+// ranging a map returns matches in a random order. If one node's name happened
+// to equal another's runner id, first-match would pick either, and a refreshing
+// view would alternate between two hosts for the same argument.
 func matchNode(nodes map[entity.Id]*nodeInfo, query string) *nodeInfo {
-	for _, n := range nodes {
-		if string(n.id) == query || n.runnerID == query || n.name == query || n.displayName() == query {
-			return n
+	if query == "" {
+		return nil
+	}
+
+	for _, match := range []func(*nodeInfo) bool{
+		func(n *nodeInfo) bool { return string(n.id) == query },
+		func(n *nodeInfo) bool { return n.runnerID == query },
+		func(n *nodeInfo) bool { return n.name == query },
+		func(n *nodeInfo) bool { return n.displayName() == query },
+	} {
+		// Within one field, ties are broken by id so the answer is the same on
+		// every call even when two nodes share a name.
+		var found *nodeInfo
+		for _, id := range sortedNodeIds(nodes) {
+			if n := nodes[id]; match(n) {
+				found = n
+				break
+			}
+		}
+		if found != nil {
+			return found
 		}
 	}
+
 	return nil
 }

--- a/servers/usage/directory.go
+++ b/servers/usage/directory.go
@@ -75,6 +75,10 @@ type filter struct {
 	// includeAddons applies to app rollups only: whether an app's dedicated
 	// addons count toward its total.
 	includeAddons bool
+
+	// includeDead admits sandboxes that have stopped or died. Only the
+	// single-sandbox detail path wants them; see the skip in loadDirectory.
+	includeDead bool
 }
 
 // matches reports whether a sandbox belongs in the listing.
@@ -164,8 +168,18 @@ func (s *Server) loadDirectory(ctx context.Context, f filter) (*directory, error
 		sch.Decode(ent)
 
 		// A dead sandbox is not a row. Listing it would show a sandbox using no
-		// resources, which reads as idle rather than as gone.
-		if compute.SandboxDead(sb.Status) {
+		// resources, which reads as idle rather than as gone. The detail path
+		// asks for them anyway, because how a sandbox exited is most of what
+		// there is to say about one that has.
+		//
+		// The cost is that a listing is always of what is live now, even when
+		// the window is historical: a sandbox that was busy an hour ago and has
+		// since been replaced is absent from that hour's rows, though its
+		// samples are still in the metrics store. Including it would mean
+		// reconciling the window against each sandbox's death time, and dead
+		// entities are collected eventually, so the answer is to source
+		// historical rows from the series rather than from the entity store.
+		if compute.SandboxDead(sb.Status) && !f.includeDead {
 			continue
 		}
 

--- a/servers/usage/directory_test.go
+++ b/servers/usage/directory_test.go
@@ -1,0 +1,46 @@
+package usage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/entity"
+)
+
+// matchNode accepts any of four identifiers because operators type a name while
+// scripts hold an id. That flexibility creates a collision risk: one node's name
+// can equal another's runner id. Ranging the map and taking the first match made
+// the answer depend on Go's randomized iteration order, so a refreshing view
+// could alternate between two hosts for the same argument.
+func TestMatchNodeResolvesByPrecedenceNotMapOrder(t *testing.T) {
+	// "shared" is the display name of one node and the runner id of another.
+	nodes := map[entity.Id]*nodeInfo{
+		"node/a": {id: "node/a", runnerID: "runner-a", name: "shared"},
+		"node/b": {id: "node/b", runnerID: "shared", name: "b-name"},
+	}
+
+	// Runner id outranks name, so the answer is node/b every time. Repeated
+	// because a single call can pass by luck under map randomization.
+	for i := 0; i < 50; i++ {
+		got := matchNode(nodes, "shared")
+		require.NotNil(t, got)
+		assert.Equal(t, entity.Id("node/b"), got.id,
+			"runner id must outrank display name, on every call")
+	}
+}
+
+func TestMatchNodeAcceptsEveryIdentifier(t *testing.T) {
+	nodes := map[entity.Id]*nodeInfo{
+		"node/a": {id: "node/a", runnerID: "runner-a", name: "alpha"},
+	}
+
+	r := require.New(t)
+	r.Equal(entity.Id("node/a"), matchNode(nodes, "node/a").id)
+	r.Equal(entity.Id("node/a"), matchNode(nodes, "runner-a").id)
+	r.Equal(entity.Id("node/a"), matchNode(nodes, "alpha").id)
+
+	r.Nil(matchNode(nodes, "nope"))
+	r.Nil(matchNode(nodes, ""), "an empty query is not a match against an unnamed node")
+}

--- a/servers/usage/nodes.go
+++ b/servers/usage/nodes.go
@@ -129,7 +129,7 @@ func (s *Server) listNodes(ctx context.Context, f filter, w window, ord ordering
 		rows = append(rows, &row)
 	}
 
-	sortNodes(rows, ord.sort, ord.order)
+	sortNodes(rows, ord)
 	out.rows = rows[:ord.truncate(len(rows))]
 
 	if clusterCapacity.cores > 0 {
@@ -339,8 +339,9 @@ func max0i(v int64) int64 {
 	return v
 }
 
-func sortNodes(rows []*usage_v1alpha.NodeUsage, key, order string) {
-	desc := !strings.EqualFold(order, "asc")
+func sortNodes(rows []*usage_v1alpha.NodeUsage, ord ordering) {
+	key := ord.sort
+	desc := ord.descending()
 
 	less := func(a, b *usage_v1alpha.NodeUsage) bool {
 		switch strings.ToLower(strings.TrimSpace(key)) {
@@ -351,9 +352,7 @@ func sortNodes(rows []*usage_v1alpha.NodeUsage, key, order string) {
 		case "sandboxes":
 			return a.SandboxCount() < b.SandboxCount()
 		case "name":
-			// Names sort ascending even under the default descending order:
-			// nobody wants a reverse-alphabetical node list.
-			return a.NodeName() > b.NodeName()
+			return a.NodeName() < b.NodeName()
 		default:
 			return a.Total().CpuCores() < b.Total().CpuCores()
 		}

--- a/servers/usage/nodes.go
+++ b/servers/usage/nodes.go
@@ -1,0 +1,368 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// nodeListing is the answer both surfaces return.
+type nodeListing struct {
+	rows     []*usage_v1alpha.NodeUsage
+	cluster  totals
+	capacity *usage_v1alpha.NodeCapacity
+	warnings []string
+}
+
+// listNodes is the one implementation behind ListNodes (RPC), HttpListNodes
+// and HttpGetNode (REST).
+//
+// The sandbox-versus-system split is what makes this worth having over a plain
+// host metric. Miren's own moving parts -- the container runtime, the image
+// builder, the registry, the log pipeline, the coordinator itself -- run
+// outside every sandbox cgroup, so they are invisible in the per-sandbox view.
+// Subtracting the sandboxes' total from the host's total is what surfaces them,
+// and answers the question a per-sandbox listing cannot: the node is hot but no
+// app is.
+func (s *Server) listNodes(ctx context.Context, f filter, w window, ord ordering) (*nodeListing, error) {
+	// One directory load serves both the node list and the per-node sandbox
+	// counts, and passing the node filter through lets it use the indexed
+	// schedule lookup rather than scanning every sandbox in the cluster.
+	dir, err := s.loadDirectory(ctx, filter{node: f.node, includeSystem: true})
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := dir.nodes
+	counts := countSandboxesByNode(dir)
+
+	if f.node != "" {
+		match := matchNode(nodes, f.node)
+		nodes = map[entity.Id]*nodeInfo{}
+		if match != nil {
+			nodes[match.id] = match
+		}
+	}
+
+	samples, warnings := s.nodeSamples(ctx, w)
+
+	out := &nodeListing{warnings: warnings}
+
+	rows := make([]*usage_v1alpha.NodeUsage, 0, len(nodes))
+	var clusterCapacity struct {
+		cores   float64
+		memory  int64
+		storage int64
+	}
+
+	// Node ids are sorted before rows are built so a stable sort has a stable
+	// input. Ranging a map directly would give ties a different order on every
+	// call, which a refreshing view renders as rows swapping places.
+	for _, id := range sortedNodeIds(nodes) {
+		n := nodes[id]
+		key := string(id)
+
+		var row usage_v1alpha.NodeUsage
+		row.SetNode(key)
+		row.SetNodeName(n.displayName())
+		row.SetRunnerId(n.runnerID)
+		row.SetRole(n.role)
+		row.SetStatus(n.status)
+		row.SetScheduling(n.scheduling)
+		row.SetMeasuredAt(standard.ToTimestamp(w.end))
+
+		cores := samples[metricNodeCPUCoresTotal][key]
+		memTotal := samples[metricNodeMemTotal][key]
+		storageTotal := samples[metricNodeStorageTotal][key]
+
+		var capacity usage_v1alpha.NodeCapacity
+		capacity.SetCpuCores(cores)
+		capacity.SetMemoryBytes(int64(memTotal))
+		capacity.SetStorageBytes(int64(storageTotal))
+		row.SetCapacity(&capacity)
+
+		// A node that reported nothing in the window still gets a row. A runner
+		// that has gone quiet is exactly what someone is looking for, and
+		// dropping it would leave the cluster looking smaller and healthier
+		// than it is.
+		_, reported := samples[metricNodeCPUCoresTotal][key]
+		row.SetStale(!reported)
+
+		usedCores := samples[metricNodeCPUCoresUsed][key]
+		usedMem := samples[metricNodeMemUsed][key]
+		sandboxCores := samples[sandboxCoresKey][key]
+		sandboxMem := samples[sandboxBytesKey][key]
+
+		row.SetTotal(nodeTotals(usedCores, int64(usedMem), cores, memTotal))
+		row.SetSandboxes(nodeTotals(sandboxCores, int64(sandboxMem), cores, memTotal))
+
+		// Floored at zero deliberately. Page-cache accounting means the host
+		// total and the sum of cgroups do not reconcile exactly, and a small
+		// negative remainder is an artifact of that, not a finding. Reporting
+		// it as negative would be worse than rounding it away.
+		row.SetSystem(nodeTotals(
+			max0(usedCores-sandboxCores),
+			max0i(int64(usedMem)-int64(sandboxMem)),
+			cores, memTotal,
+		))
+
+		row.SetLoad1(samples[metricNodeLoad1][key])
+		row.SetLoad5(samples[metricNodeLoad5][key])
+		row.SetLoad15(samples[metricNodeLoad15][key])
+		row.SetStorageUsedBytes(int64(samples[metricNodeStorageUsed][key]))
+
+		row.SetSandboxCount(counts[id].total)
+		row.SetRunningSandboxCount(counts[id].running)
+
+		out.cluster.cpuCores += usedCores
+		out.cluster.memoryBytes += int64(usedMem)
+		clusterCapacity.cores += cores
+		clusterCapacity.memory += int64(memTotal)
+		clusterCapacity.storage += int64(storageTotal)
+
+		rows = append(rows, &row)
+	}
+
+	sortNodes(rows, ord.sort, ord.order)
+	out.rows = rows[:ord.truncate(len(rows))]
+
+	if clusterCapacity.cores > 0 {
+		out.cluster.cpuPercent = out.cluster.cpuCores / clusterCapacity.cores * 100
+	}
+	if clusterCapacity.memory > 0 {
+		out.cluster.memPercent = float64(out.cluster.memoryBytes) / float64(clusterCapacity.memory) * 100
+	}
+
+	var capacity usage_v1alpha.NodeCapacity
+	capacity.SetCpuCores(clusterCapacity.cores)
+	capacity.SetMemoryBytes(clusterCapacity.memory)
+	capacity.SetStorageBytes(clusterCapacity.storage)
+	out.capacity = &capacity
+
+	return out, nil
+}
+
+// sortedNodeIds returns the map's keys in a fixed order.
+func sortedNodeIds(nodes map[entity.Id]*nodeInfo) []entity.Id {
+	ids := make([]entity.Id, 0, len(nodes))
+	for id := range nodes {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// ListNodes is the RPC surface.
+func (s *Server) ListNodes(ctx context.Context, state *usage_v1alpha.ResourceUsageListNodes) error {
+	args := state.Args()
+	w := windowFrom(args.Window())
+
+	listing, err := s.listNodes(ctx, selectorToFilter(args.Selector()), w, orderingFrom(args.Ordering()))
+	if err != nil {
+		return err
+	}
+
+	res := state.Results()
+	res.SetNodes(listing.rows)
+	res.SetCluster(listing.cluster.encode())
+	res.SetCapacity(listing.capacity)
+	res.SetWindow(w.encode())
+	res.SetCollectedAt(standard.ToTimestamp(time.Now()))
+	res.SetWarnings(listing.warnings)
+
+	return nil
+}
+
+// HttpListNodes serves GET /api/v1/usage/nodes.
+func (s *Server) HttpListNodes(ctx context.Context, state *usage_v1alpha.ResourceUsageHttpListNodes) error {
+	args := state.Args()
+
+	w := restWindow(args.Since(), args.Until(), args.Aggregate())
+	ord := ordering{sort: args.Sort(), order: args.Order(), limit: int(args.Limit())}
+
+	listing, err := s.listNodes(ctx, filter{}, w, ord)
+	if err != nil {
+		return err
+	}
+
+	res := state.Results()
+	res.SetNodes(listing.rows)
+	res.SetCluster(listing.cluster.encode())
+	res.SetCapacity(listing.capacity)
+	res.SetWindow(w.encode())
+	res.SetCollectedAt(standard.ToTimestamp(time.Now()))
+	res.SetWarnings(listing.warnings)
+
+	return nil
+}
+
+// HttpGetNode serves GET /api/v1/usage/nodes/{node}, addressing one host.
+func (s *Server) HttpGetNode(ctx context.Context, state *usage_v1alpha.ResourceUsageHttpGetNode) error {
+	args := state.Args()
+
+	query := args.Node()
+	if query == "" {
+		return fmt.Errorf("a node is required")
+	}
+
+	w := restWindow(args.Since(), args.Until(), args.Aggregate())
+
+	listing, err := s.listNodes(ctx, filter{node: query}, w, ordering{})
+	if err != nil {
+		return err
+	}
+
+	res := state.Results()
+	res.SetWindow(w.encode())
+	res.SetWarnings(listing.warnings)
+
+	if len(listing.rows) == 0 {
+		return fmt.Errorf("node %q not found", query)
+	}
+
+	res.SetUsage(listing.rows[0])
+
+	return nil
+}
+
+// Keys under which the per-node rollups of sandbox usage are stashed alongside
+// the genuine node metrics. They are not metric names, so they are spelled
+// differently on purpose.
+const (
+	sandboxCoresKey = "@sandbox_cores"
+	sandboxBytesKey = "@sandbox_bytes"
+)
+
+// nodeSamples runs every node-level query in one pass, keyed by metric name.
+func (s *Server) nodeSamples(ctx context.Context, w window) (map[string]map[string]float64, []string) {
+	out := map[string]map[string]float64{}
+
+	if s.Reader == nil {
+		return out, []string{"no metrics backend configured; usage figures are unavailable"}
+	}
+
+	dur := w.duration()
+	var warnings []string
+
+	// Capacity gauges are read as last rather than averaged: a host's core
+	// count has no meaningful average, and averaging across a resize would
+	// report a machine size that never existed.
+	gauges := map[string]string{
+		metricNodeCPUCoresTotal: aggregateLast,
+		metricNodeMemTotal:      aggregateLast,
+		metricNodeStorageTotal:  aggregateLast,
+		metricNodeCPUCoresUsed:  w.aggregate,
+		metricNodeMemUsed:       w.aggregate,
+		metricNodeStorageUsed:   w.aggregate,
+		metricNodeLoad1:         w.aggregate,
+		metricNodeLoad5:         w.aggregate,
+		metricNodeLoad15:        w.aggregate,
+	}
+
+	for metric, agg := range gauges {
+		vals, err := s.instantByLabel(ctx, nodeGaugeQuery(metric, "", dur, agg), labelNode, w.end)
+		if err != nil {
+			warnings = append(warnings, metric+" unavailable: "+err.Error())
+			continue
+		}
+		out[metric] = vals
+	}
+
+	// The same sandbox series the listing reads, grouped by node
+	// instead of by sandbox. This is the subtrahend that isolates platform
+	// overhead.
+	if vals, err := s.instantByLabel(ctx, cpuCoresQuery(labelNode, "", dur, w.aggregate), labelNode, w.end); err != nil {
+		warnings = append(warnings, "sandbox cpu rollup unavailable: "+err.Error())
+	} else {
+		out[sandboxCoresKey] = vals
+	}
+
+	if vals, err := s.instantByLabel(ctx, memoryBytesQuery(labelNode, "", dur, w.aggregate), labelNode, w.end); err != nil {
+		warnings = append(warnings, "sandbox memory rollup unavailable: "+err.Error())
+	} else {
+		out[sandboxBytesKey] = vals
+	}
+
+	sort.Strings(warnings)
+
+	return out, warnings
+}
+
+type sandboxCount struct {
+	total   int64
+	running int64
+}
+
+func countSandboxesByNode(dir *directory) map[entity.Id]sandboxCount {
+	counts := map[entity.Id]sandboxCount{}
+	for _, wl := range dir.sandboxes {
+		id := entity.Id(wl.ref.Node())
+		c := counts[id]
+		c.total++
+		if strings.EqualFold(wl.ref.Status(), "running") {
+			c.running++
+		}
+		counts[id] = c
+	}
+
+	return counts
+}
+
+func nodeTotals(cores float64, bytes int64, capacityCores, capacityBytes float64) *usage_v1alpha.ResourceTotals {
+	t := totals{cpuCores: cores, memoryBytes: bytes}
+	if capacityCores > 0 {
+		t.cpuPercent = cores / capacityCores * 100
+	}
+	if capacityBytes > 0 {
+		t.memPercent = float64(bytes) / capacityBytes * 100
+	}
+	return t.encode()
+}
+
+func max0(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func max0i(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func sortNodes(rows []*usage_v1alpha.NodeUsage, key, order string) {
+	desc := !strings.EqualFold(order, "asc")
+
+	less := func(a, b *usage_v1alpha.NodeUsage) bool {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "memory", "mem":
+			return a.Total().MemoryBytes() < b.Total().MemoryBytes()
+		case "load":
+			return a.Load1() < b.Load1()
+		case "sandboxes":
+			return a.SandboxCount() < b.SandboxCount()
+		case "name":
+			// Names sort ascending even under the default descending order:
+			// nobody wants a reverse-alphabetical node list.
+			return a.NodeName() > b.NodeName()
+		default:
+			return a.Total().CpuCores() < b.Total().CpuCores()
+		}
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		if desc {
+			return less(rows[j], rows[i])
+		}
+		return less(rows[i], rows[j])
+	})
+}

--- a/servers/usage/nodes.go
+++ b/servers/usage/nodes.go
@@ -340,23 +340,25 @@ func max0i(v int64) int64 {
 }
 
 func sortNodes(rows []*usage_v1alpha.NodeUsage, ord ordering) {
-	key := ord.sort
-	desc := ord.descending()
+	var (
+		less      func(a, b *usage_v1alpha.NodeUsage) bool
+		ascending bool
+	)
 
-	less := func(a, b *usage_v1alpha.NodeUsage) bool {
-		switch strings.ToLower(strings.TrimSpace(key)) {
-		case "memory", "mem":
-			return a.Total().MemoryBytes() < b.Total().MemoryBytes()
-		case "load":
-			return a.Load1() < b.Load1()
-		case "sandboxes":
-			return a.SandboxCount() < b.SandboxCount()
-		case "name":
-			return a.NodeName() < b.NodeName()
-		default:
-			return a.Total().CpuCores() < b.Total().CpuCores()
-		}
+	switch strings.ToLower(strings.TrimSpace(ord.sort)) {
+	case "memory", "mem":
+		less = func(a, b *usage_v1alpha.NodeUsage) bool { return a.Total().MemoryBytes() < b.Total().MemoryBytes() }
+	case "load":
+		less = func(a, b *usage_v1alpha.NodeUsage) bool { return a.Load1() < b.Load1() }
+	case "sandboxes":
+		less = func(a, b *usage_v1alpha.NodeUsage) bool { return a.SandboxCount() < b.SandboxCount() }
+	case "name", "node", "runner":
+		less, ascending = func(a, b *usage_v1alpha.NodeUsage) bool { return a.NodeName() < b.NodeName() }, true
+	default:
+		less = func(a, b *usage_v1alpha.NodeUsage) bool { return a.Total().CpuCores() < b.Total().CpuCores() }
 	}
+
+	desc := ord.direction(ascending)
 
 	sort.SliceStable(rows, func(i, j int) bool {
 		if desc {

--- a/servers/usage/query.go
+++ b/servers/usage/query.go
@@ -1,0 +1,199 @@
+package usage
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Metric and label names as they exist in VictoriaMetrics.
+//
+// The collectors write attributes with dots (miren.sandbox), but the writer's
+// sanitizeLabelName rewrites every dot to an underscore before the point is
+// stored. Querying the dotted form matches nothing and returns no error, so
+// these constants exist to keep the two spellings from drifting apart.
+const (
+	metricCPUSeconds = "cpu_usage_seconds_total"
+	metricMemoryUsed = "memory_usage_bytes"
+
+	metricNodeCPUCoresTotal = "node_cpu_cores_total"
+	metricNodeCPUCoresUsed  = "node_cpu_cores_used"
+	metricNodeMemTotal      = "node_memory_total_bytes"
+	metricNodeMemUsed       = "node_memory_used_bytes"
+	metricNodeStorageTotal  = "node_storage_total_bytes"
+	metricNodeStorageUsed   = "node_storage_used_bytes"
+	metricNodeLoad1         = "node_load1"
+	metricNodeLoad5         = "node_load5"
+	metricNodeLoad15        = "node_load15"
+
+	labelSandbox = "miren_sandbox"
+	labelNode    = "miren_node"
+	labelRunner  = "miren_runner"
+)
+
+// Aggregates a caller may ask for.
+const (
+	aggregateAvg  = "avg"
+	aggregateMax  = "max"
+	aggregateMin  = "min"
+	aggregateLast = "last"
+)
+
+// defaultWindow is the lookback when a caller does not ask for one. A minute is
+// long enough that a one-second sampler has ~60 points to average, and short
+// enough that the answer still describes "now".
+const defaultWindow = time.Minute
+
+// minRateWindow is the shortest range a rate() is asked for. The collectors
+// sample once a second, but a counter needs at least two points inside the
+// range to produce a rate at all, and a range shorter than the scrape interval
+// yields nothing rather than an error.
+const minRateWindow = 15 * time.Second
+
+// resolveAggregate maps a caller's aggregate to a known one, defaulting to avg.
+// An unrecognized value is not an error: it is more useful to answer a typo'd
+// aggregate with the sensible default than to fail a diagnostic call outright.
+func resolveAggregate(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case aggregateMax:
+		return aggregateMax
+	case aggregateMin:
+		return aggregateMin
+	case aggregateLast:
+		return aggregateLast
+	default:
+		return aggregateAvg
+	}
+}
+
+// promDuration renders a duration the way MetricsQL wants it. Sub-second
+// precision is dropped because no collector here samples that fast, and a "0s"
+// range would match nothing.
+func promDuration(d time.Duration) string {
+	if d < time.Second {
+		d = time.Second
+	}
+	return fmt.Sprintf("%ds", int64(d.Seconds()))
+}
+
+// cpuCoresQuery builds the CPU query for one grouping label.
+//
+// CPU is stored as a cumulative counter of seconds spent on CPU, so a rate over
+// a range is already an average over that range in cores -- which is why avg
+// needs no subquery and max does. The sum is what collapses a sandbox's
+// several containers, and any stray per-process labels, into one series per
+// group; without it a sandbox whose runner restarted mid-window would appear
+// twice.
+func cpuCoresQuery(groupBy string, selector string, window time.Duration, aggregate string) string {
+	// The rate window differs by aggregate, and getting it wrong is silent.
+	//
+	// For an average, the rate is taken over the whole window, because a rate
+	// across a span already is that span's mean. For a max or a min the rate
+	// must instead be taken over a short slice and stepped across the window:
+	// a rate over the whole hour would flatten a one-minute spike into the
+	// hour's average, so a "max" computed that way would equal the average and
+	// never surface the burst it was asked to find.
+	rateWindow := window
+	if aggregate == aggregateMax || aggregate == aggregateMin {
+		rateWindow = window / subqueryPoints
+	}
+	if rateWindow < minRateWindow {
+		rateWindow = minRateWindow
+	}
+
+	inner := fmt.Sprintf("sum by (%s) (rate(%s%s[%s]))",
+		groupBy, metricCPUSeconds, selector, promDuration(rateWindow))
+
+	switch aggregate {
+	case aggregateMax, aggregateMin:
+		return fmt.Sprintf("%s_over_time(%s[%s:%s])",
+			aggregate, inner, promDuration(window), promDuration(rateWindow))
+	default:
+		// avg and last both collapse to the plain rate: a rate over the whole
+		// window IS its average, and there is no cheaper "last" for a counter.
+		return inner
+	}
+}
+
+// memoryBytesQuery builds the memory query for one grouping label.
+//
+// Memory is a gauge, so unlike CPU it needs an explicit over_time collapse for
+// every aggregate except last.
+func memoryBytesQuery(groupBy string, selector string, window time.Duration, aggregate string) string {
+	inner := fmt.Sprintf("sum by (%s) (%s%s)", groupBy, metricMemoryUsed, selector)
+
+	if aggregate == aggregateLast {
+		return inner
+	}
+
+	return overTime(aggregate, inner, window)
+}
+
+// nodeGaugeQuery reads one node-level gauge, collapsed over the window.
+//
+// Capacity gauges use last rather than an average: a host's core count does not
+// have a meaningful average, and averaging across a resize would report a
+// machine size that never existed.
+func nodeGaugeQuery(metric string, selector string, window time.Duration, aggregate string) string {
+	inner := fmt.Sprintf("max by (%s) (%s%s)", labelNode, metric, selector)
+
+	if aggregate == aggregateLast {
+		return inner
+	}
+
+	return overTime(aggregate, inner, window)
+}
+
+// overTime wraps an expression in an <aggregate>_over_time subquery.
+//
+// The resolution after the colon is not optional. A range applied to an
+// expression rather than to a bare metric is a subquery, and without a step the
+// query returns an empty result and no error -- which reads downstream as a
+// sandbox using nothing at all. Every collapse goes through here so that step
+// can never be forgotten at one call site.
+func overTime(aggregate, expr string, window time.Duration) string {
+	step := window / subqueryPoints
+	if step < time.Second {
+		step = time.Second
+	}
+
+	return fmt.Sprintf("%s_over_time(%s[%s:%s])",
+		aggregate, expr, promDuration(window), promDuration(step))
+}
+
+// subqueryPoints is how many samples a collapsed window is evaluated at. Enough
+// that a max is not dominated by where the boundaries happen to fall, few enough
+// that a day-long window does not evaluate thousands of points per row.
+const subqueryPoints = 20
+
+// labelSelector renders an exact-match selector, or "" when unconstrained.
+// Values are escaped because a node name or app name reaches this from a query
+// string and must not be able to close the selector and append its own clauses.
+func labelSelector(pairs map[string]string) string {
+	if len(pairs) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(pairs))
+	for k := range pairs {
+		if pairs[k] != "" {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+
+	slices.Sort(keys)
+
+	clauses := make([]string, 0, len(keys))
+	for _, k := range keys {
+		// %q is what does the escaping here. These values arrive from a query
+		// string, so a name containing a quote must not be able to close the
+		// selector and append clauses of its own.
+		clauses = append(clauses, fmt.Sprintf("%s=%q", k, pairs[k]))
+	}
+
+	return "{" + strings.Join(clauses, ",") + "}"
+}

--- a/servers/usage/query_test.go
+++ b/servers/usage/query_test.go
@@ -150,3 +150,23 @@ func TestMaxUsesAShortRateWindowSteppedAcrossTheWindow(t *testing.T) {
 	avg := cpuCoresQuery(labelSandbox, "", time.Hour, aggregateAvg)
 	r.Equal("sum by (miren_sandbox) (rate(cpu_usage_seconds_total[3600s]))", avg)
 }
+
+// The sensible default direction depends on what is being sorted: a usage
+// column wants the busiest first, a name wants A to Z. An earlier version
+// inverted the name comparator to fake that, which meant an explicit order=asc
+// produced reverse-alphabetical output.
+func TestOrderingDefaultsPerSortKey(t *testing.T) {
+	r := require.New(t)
+
+	r.True(ordering{sort: "cpu"}.descending(), "busiest first when unspecified")
+	r.True(ordering{sort: ""}.descending(), "cpu is the default key, so descending")
+	r.False(ordering{sort: "name"}.descending(), "names read A to Z")
+	r.False(ordering{sort: "app"}.descending())
+	r.False(ordering{sort: "service"}.descending())
+
+	// An explicit direction always wins, in both directions and for both
+	// families of key.
+	r.False(ordering{sort: "cpu", order: "asc"}.descending())
+	r.True(ordering{sort: "name", order: "desc"}.descending())
+	r.False(ordering{sort: "name", order: "ASC"}.descending(), "case-insensitive")
+}

--- a/servers/usage/query_test.go
+++ b/servers/usage/query_test.go
@@ -174,13 +174,18 @@ func TestOrderingDirection(t *testing.T) {
 // the default branch silently sorts by CPU, and if the key was name-like it
 // also inherits an ascending direction, so the caller gets ascending CPU order
 // with no indication anything was ignored.
+//
+// Each row's four name-like fields disagree on purpose, and each key has a
+// different expected winner. A fixture that gave every field the same value
+// would pass even if the app comparator read the service, because the two would
+// sort identically.
 func TestEverySortKeyHasAComparator(t *testing.T) {
-	sandbox := func(id string, cores float64) *usage_v1alpha.SandboxUsage {
+	sandbox := func(short, app, service, node string, cores float64) *usage_v1alpha.SandboxUsage {
 		var ref usage_v1alpha.SandboxRef
-		ref.SetSandboxShortId(id)
-		ref.SetApp(id)
-		ref.SetService(id)
-		ref.SetNodeName(id)
+		ref.SetSandboxShortId(short)
+		ref.SetApp(app)
+		ref.SetService(service)
+		ref.SetNodeName(node)
 
 		var cpu usage_v1alpha.CpuUsage
 		cpu.SetCores(cores)
@@ -192,18 +197,37 @@ func TestEverySortKeyHasAComparator(t *testing.T) {
 		return &row
 	}
 
-	// "a" is the alphabetical first but the CPU last. Any key that falls
-	// through to the CPU comparator puts "c" first instead.
-	for _, key := range []string{"name", "app", "service", "node", "runner"} {
-		rows := []*usage_v1alpha.SandboxUsage{sandbox("c", 3), sandbox("a", 1), sandbox("b", 2)}
-		sortSandboxes(rows, ordering{sort: key})
+	// Rows are identified by short id. "filler" holds the lowest CPU and sorts
+	// last on every name-like field, so it is what an ascending CPU fallthrough
+	// would surface and it can never be the right answer for a name key.
+	rows := func() []*usage_v1alpha.SandboxUsage {
+		return []*usage_v1alpha.SandboxUsage{
+			sandbox("d", "a", "c", "b", 4),
+			sandbox("a", "d", "b", "c", 3),
+			sandbox("c", "b", "a", "d", 2),
+			sandbox("b", "c", "d", "a", 1),
+			sandbox("filler", "filler", "filler", "filler", 0),
+		}
+	}
 
-		assert.Equalf(t, "a", rows[0].Ref().SandboxShortId(),
-			"sort=%s fell through to the CPU comparator", key)
+	// Each key wins on a different row, so a comparator reading the wrong
+	// name-like field is caught rather than passing by coincidence.
+	for key, wantFirst := range map[string]string{
+		"name":    "a",
+		"app":     "d",
+		"service": "c",
+		"node":    "b",
+		"runner":  "b",
+	} {
+		got := rows()
+		sortSandboxes(got, ordering{sort: key})
+
+		assert.Equalf(t, wantFirst, got[0].Ref().SandboxShortId(),
+			"sort=%s picked the wrong row; it may be reading another field, or falling through to CPU", key)
 	}
 
 	// A usage key still reads busiest first.
-	rows := []*usage_v1alpha.SandboxUsage{sandbox("a", 1), sandbox("c", 3)}
-	sortSandboxes(rows, ordering{sort: "cpu"})
-	assert.Equal(t, "c", rows[0].Ref().SandboxShortId())
+	got := rows()
+	sortSandboxes(got, ordering{sort: "cpu"})
+	assert.Equal(t, "d", got[0].Ref().SandboxShortId(), "cpu sorts busiest first")
 }

--- a/servers/usage/query_test.go
+++ b/servers/usage/query_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/usage/usage_v1alpha"
 )
 
 // The metric labels are written with dots and stored with underscores. Querying
@@ -151,22 +154,56 @@ func TestMaxUsesAShortRateWindowSteppedAcrossTheWindow(t *testing.T) {
 	r.Equal("sum by (miren_sandbox) (rate(cpu_usage_seconds_total[3600s]))", avg)
 }
 
-// The sensible default direction depends on what is being sorted: a usage
-// column wants the busiest first, a name wants A to Z. An earlier version
-// inverted the name comparator to fake that, which meant an explicit order=asc
-// produced reverse-alphabetical output.
-func TestOrderingDefaultsPerSortKey(t *testing.T) {
+// An explicit order always wins; otherwise the comparator's own default
+// applies. The direction no longer comes from guessing at the key name, because
+// a key one listing sorts by name and another does not implement would get an
+// alphabetical direction applied to a CPU comparison.
+func TestOrderingDirection(t *testing.T) {
 	r := require.New(t)
 
-	r.True(ordering{sort: "cpu"}.descending(), "busiest first when unspecified")
-	r.True(ordering{sort: ""}.descending(), "cpu is the default key, so descending")
-	r.False(ordering{sort: "name"}.descending(), "names read A to Z")
-	r.False(ordering{sort: "app"}.descending())
-	r.False(ordering{sort: "service"}.descending())
+	r.True(ordering{}.direction(false), "a usage column defaults to busiest first")
+	r.False(ordering{}.direction(true), "a name defaults to A to Z")
 
-	// An explicit direction always wins, in both directions and for both
-	// families of key.
-	r.False(ordering{sort: "cpu", order: "asc"}.descending())
-	r.True(ordering{sort: "name", order: "desc"}.descending())
-	r.False(ordering{sort: "name", order: "ASC"}.descending(), "case-insensitive")
+	r.False(ordering{order: "asc"}.direction(false))
+	r.True(ordering{order: "desc"}.direction(true))
+	r.False(ordering{order: "ASC"}.direction(false), "case-insensitive")
+	r.True(ordering{order: "nonsense"}.direction(false), "an unparseable order falls back to the default")
+}
+
+// Every sort key a listing accepts must have a comparator. A key that reaches
+// the default branch silently sorts by CPU, and if the key was name-like it
+// also inherits an ascending direction, so the caller gets ascending CPU order
+// with no indication anything was ignored.
+func TestEverySortKeyHasAComparator(t *testing.T) {
+	sandbox := func(id string, cores float64) *usage_v1alpha.SandboxUsage {
+		var ref usage_v1alpha.SandboxRef
+		ref.SetSandboxShortId(id)
+		ref.SetApp(id)
+		ref.SetService(id)
+		ref.SetNodeName(id)
+
+		var cpu usage_v1alpha.CpuUsage
+		cpu.SetCores(cores)
+
+		var row usage_v1alpha.SandboxUsage
+		row.SetRef(&ref)
+		row.SetCpu(&cpu)
+		row.SetMemory(&usage_v1alpha.MemoryUsage{})
+		return &row
+	}
+
+	// "a" is the alphabetical first but the CPU last. Any key that falls
+	// through to the CPU comparator puts "c" first instead.
+	for _, key := range []string{"name", "app", "service", "node", "runner"} {
+		rows := []*usage_v1alpha.SandboxUsage{sandbox("c", 3), sandbox("a", 1), sandbox("b", 2)}
+		sortSandboxes(rows, ordering{sort: key})
+
+		assert.Equalf(t, "a", rows[0].Ref().SandboxShortId(),
+			"sort=%s fell through to the CPU comparator", key)
+	}
+
+	// A usage key still reads busiest first.
+	rows := []*usage_v1alpha.SandboxUsage{sandbox("a", 1), sandbox("c", 3)}
+	sortSandboxes(rows, ordering{sort: "cpu"})
+	assert.Equal(t, "c", rows[0].Ref().SandboxShortId())
 }

--- a/servers/usage/query_test.go
+++ b/servers/usage/query_test.go
@@ -1,0 +1,152 @@
+package usage
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The metric labels are written with dots and stored with underscores. Querying
+// the dotted form matches nothing and reports no error, so every generated query
+// is checked for the stored spelling.
+func TestQueriesUseStoredLabelSpelling(t *testing.T) {
+	r := require.New(t)
+
+	queries := []string{
+		cpuCoresQuery(labelSandbox, "", time.Minute, aggregateAvg),
+		cpuCoresQuery(labelNode, "", time.Hour, aggregateMax),
+		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateAvg),
+		nodeGaugeQuery(metricNodeCPUCoresTotal, "", time.Minute, aggregateLast),
+	}
+
+	for _, q := range queries {
+		r.NotContains(q, "miren.", "a dotted label silently matches nothing: %s", q)
+	}
+}
+
+// entity is the app id for deployed services but the sandbox id for addons,
+// which makes it useless as a row key. Grouping by it would silently merge every
+// sandbox of an app into one row.
+func TestQueriesNeverGroupByEntity(t *testing.T) {
+	r := require.New(t)
+
+	queries := []string{
+		cpuCoresQuery(labelSandbox, "", time.Minute, aggregateAvg),
+		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateMax),
+	}
+
+	for _, q := range queries {
+		r.NotContains(q, "by (entity)", "entity is not a usable grouping key: %s", q)
+	}
+}
+
+func TestCPUCoresQueryAggregates(t *testing.T) {
+	r := require.New(t)
+
+	// A rate over the whole window already is the window's average, so avg
+	// needs no subquery wrapper.
+	avg := cpuCoresQuery(labelSandbox, "", 5*time.Minute, aggregateAvg)
+	r.Equal("sum by (miren_sandbox) (rate(cpu_usage_seconds_total[300s]))", avg)
+
+	// max does need one, or a spike that has already passed averages away into
+	// nothing -- which is the entire reason to ask for max.
+	max := cpuCoresQuery(labelSandbox, "", time.Hour, aggregateMax)
+	r.True(strings.HasPrefix(max, "max_over_time("), "max must collapse a subquery: %s", max)
+	r.Contains(max, "[3600s:")
+}
+
+func TestCPUCoresQueryFloorsTheRateWindow(t *testing.T) {
+	// A one-second range holds at most one sample of a one-second counter, and
+	// a rate needs two. Asking for it returns nothing rather than erroring, so
+	// the floor is what keeps a short window from reading as an idle cluster.
+	q := cpuCoresQuery(labelSandbox, "", time.Second, aggregateAvg)
+	require.Contains(t, q, "[15s]")
+}
+
+func TestMemoryQueryCollapsesGauge(t *testing.T) {
+	r := require.New(t)
+
+	// Memory is a gauge, so unlike CPU every aggregate needs an explicit
+	// over_time; the bare selector would return one point, not a window.
+	r.Equal("avg_over_time(sum by (miren_sandbox) (memory_usage_bytes)[60s:3s])",
+		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateAvg))
+	r.Equal("max_over_time(sum by (miren_sandbox) (memory_usage_bytes)[60s:3s])",
+		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateMax))
+	r.Equal("sum by (miren_sandbox) (memory_usage_bytes)",
+		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateLast))
+}
+
+func TestLabelSelector(t *testing.T) {
+	r := require.New(t)
+
+	r.Equal("", labelSelector(nil))
+	r.Equal("", labelSelector(map[string]string{labelNode: ""}),
+		"an empty filter value means unconstrained, not match-the-empty-string")
+
+	r.Equal(`{miren_node="node/a"}`, labelSelector(map[string]string{labelNode: "node/a"}))
+
+	// Ordering is fixed so the same filters always produce the same query
+	// string, which is what makes these tests and any response cache work.
+	r.Equal(`{miren_node="node/a",miren_sandbox="sb_1"}`,
+		labelSelector(map[string]string{labelSandbox: "sb_1", labelNode: "node/a"}))
+}
+
+func TestLabelSelectorEscapesValues(t *testing.T) {
+	// Filter values arrive from a URL query string. A value carrying a quote
+	// must not be able to close the selector and append clauses of its own.
+	q := labelSelector(map[string]string{labelNode: `a" or foo!="`})
+	require.Equal(t, `{miren_node="a\" or foo!=\""}`, q)
+}
+
+func TestResolveAggregate(t *testing.T) {
+	r := require.New(t)
+
+	r.Equal(aggregateMax, resolveAggregate("MAX"))
+	r.Equal(aggregateMin, resolveAggregate(" min "))
+	r.Equal(aggregateLast, resolveAggregate("last"))
+
+	// A typo answers with the default rather than failing. This is a call
+	// someone makes when something is already wrong; refusing it over a
+	// misspelled flag helps no one.
+	r.Equal(aggregateAvg, resolveAggregate("maximum"))
+	r.Equal(aggregateAvg, resolveAggregate(""))
+}
+
+// A range applied to an expression rather than a bare metric is a subquery, and
+// a subquery with no resolution step returns an empty result and no error. That
+// failure is invisible: it reads downstream as a sandbox consuming nothing.
+func TestCollapsedQueriesAlwaysCarryASubqueryStep(t *testing.T) {
+	r := require.New(t)
+
+	collapsed := []string{
+		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateAvg),
+		memoryBytesQuery(labelNode, "", time.Hour, aggregateMax),
+		nodeGaugeQuery(metricNodeCPUCoresUsed, "", time.Minute, aggregateAvg),
+		cpuCoresQuery(labelSandbox, "", time.Hour, aggregateMax),
+	}
+
+	for _, q := range collapsed {
+		r.Contains(q, "_over_time(", "expected a collapsed query: %s", q)
+		r.Regexp(`\[\d+s:\d+s\]`, q, "subquery is missing its resolution step: %s", q)
+	}
+}
+
+// A max is asked for precisely to find a burst an average would hide. Taking
+// the rate over the whole window would flatten that burst into the window's
+// mean, making max and avg identical and the flag useless.
+func TestMaxUsesAShortRateWindowSteppedAcrossTheWindow(t *testing.T) {
+	r := require.New(t)
+
+	q := cpuCoresQuery(labelSandbox, "", time.Hour, aggregateMax)
+
+	r.Contains(q, "rate(cpu_usage_seconds_total[180s])",
+		"the rate must cover a slice of the window, not all of it: %s", q)
+	r.Contains(q, "[3600s:180s]", "the subquery must step across the window: %s", q)
+
+	// The average is the one case where a full-window rate is right, and it
+	// needs no subquery at all.
+	avg := cpuCoresQuery(labelSandbox, "", time.Hour, aggregateAvg)
+	r.Equal("sum by (miren_sandbox) (rate(cpu_usage_seconds_total[3600s]))", avg)
+}

--- a/servers/usage/sandbox.go
+++ b/servers/usage/sandbox.go
@@ -1,0 +1,374 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	computev1 "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// defaultSeriesPoints is how many points a history is rendered at when the
+// caller does not choose. It is a target, not a guarantee: the step is derived
+// from it so that a one-minute window and a one-day window both come back at a
+// resolution a chart can actually draw.
+const defaultSeriesPoints = 60
+
+// detailOptions is what a caller wants alongside one sandbox's current usage.
+type detailOptions struct {
+	series     bool
+	containers bool
+	step       time.Duration
+}
+
+// sandboxDetailResult is what the core produces, before either surface shapes
+// it into its own generated result type. Those types are write-only, so the
+// core cannot hand one to the other -- it returns plain values instead.
+type sandboxDetailResult struct {
+	usage         *usage_v1alpha.SandboxUsage
+	series        []*usage_v1alpha.UsageSeries
+	exit          *usage_v1alpha.SandboxExit
+	crashLoop     *usage_v1alpha.CrashLoopState
+	image         string
+	restartPolicy string
+	warnings      []string
+}
+
+// apply writes the result into an RPC results type. Both surfaces have the same
+// setters, so each passes its own and this stays the only place the mapping
+// lives.
+func (d *sandboxDetailResult) apply(set sandboxDetailSetter, w window) {
+	set.SetUsage(d.usage)
+	set.SetSeries(d.series)
+	if d.exit != nil {
+		set.SetExit(d.exit)
+	}
+	if d.crashLoop != nil {
+		set.SetCrashLoop(d.crashLoop)
+	}
+	set.SetImage(d.image)
+	set.SetRestartPolicy(d.restartPolicy)
+	set.SetWindow(w.encode())
+	set.SetWarnings(d.warnings)
+}
+
+// sandboxDetailSetter is the shape both surfaces' result types share.
+type sandboxDetailSetter interface {
+	SetUsage(*usage_v1alpha.SandboxUsage)
+	SetSeries([]*usage_v1alpha.UsageSeries)
+	SetExit(*usage_v1alpha.SandboxExit)
+	SetCrashLoop(*usage_v1alpha.CrashLoopState)
+	SetImage(string)
+	SetRestartPolicy(string)
+	SetWindow(*usage_v1alpha.UsageWindow)
+	SetWarnings([]string)
+}
+
+// sandboxDetail is the one implementation behind GetSandbox (RPC) and
+// HttpGetSandbox (REST).
+//
+// This is the third step of an investigation -- after finding the hot node and
+// the hot sandbox on it -- so it answers "why" rather than "how much". The exit
+// code and crash-loop state are the point; usage is context.
+func (s *Server) sandboxDetail(
+	ctx context.Context,
+	query string,
+	w window,
+	opts detailOptions,
+) (*sandboxDetailResult, error) {
+	if query == "" {
+		return nil, fmt.Errorf("a sandbox id is required")
+	}
+
+	// Resolve through the same directory the listing uses, so the identity
+	// shown here and the identity shown in a row cannot disagree.
+	dir, err := s.loadDirectory(ctx, filter{includeSystem: true})
+	if err != nil {
+		return nil, err
+	}
+
+	var found *sandboxRow
+	for i := range dir.sandboxes {
+		sb := &dir.sandboxes[i]
+		if sb.ref.Sandbox() == query || sb.ref.SandboxShortId() == query {
+			found = sb
+			break
+		}
+	}
+
+	if found == nil {
+		return nil, fmt.Errorf("sandbox %q not found, or it is not running", query)
+	}
+
+	out := &sandboxDetailResult{}
+
+	var row usage_v1alpha.SandboxUsage
+	row.SetRef(found.ref)
+	row.SetMeasuredAt(standard.ToTimestamp(w.end))
+
+	sel := labelSelector(map[string]string{labelSandbox: found.ref.Sandbox()})
+
+	cores, bytes, sampleWarnings := s.singleSandboxSamples(ctx, sel, w)
+	out.warnings = append(out.warnings, sampleWarnings...)
+
+	var cpu usage_v1alpha.CpuUsage
+	cpu.SetCores(cores)
+
+	// The share of the host is what says whether the absolute figure matters,
+	// so it is worth the extra query even for a single sandbox.
+	if nodeCores := s.nodeCoreCount(ctx, found.ref.Node(), w); nodeCores > 0 {
+		cpu.SetPercentOfNode(cores / nodeCores * 100)
+	}
+
+	row.SetCpu(&cpu)
+
+	var mem usage_v1alpha.MemoryUsage
+	mem.SetBytes(int64(bytes))
+	row.SetMemory(&mem)
+
+	row.SetStale(cores == 0 && bytes == 0)
+
+	if opts.series {
+		series, seriesWarnings := s.sandboxSeries(ctx, sel, w, opts.step)
+		out.warnings = append(out.warnings, seriesWarnings...)
+		out.series = series
+	}
+
+	if opts.containers {
+		// The stored series sum a sandbox's containers before they are written,
+		// so a per-container split cannot be recovered from them. Saying so
+		// beats returning an empty list that reads as "one container".
+		out.warnings = append(out.warnings,
+			"per-container usage is not available from stored metrics; it needs a live probe of the owning node")
+	}
+
+	// Exit and crash-loop state come from entities, not metrics: they are facts
+	// about what the platform decided, not measurements of the sandbox.
+	if err := s.decorateFromEntities(ctx, found, out); err != nil {
+		out.warnings = append(out.warnings, "sandbox detail incomplete: "+err.Error())
+	}
+
+	out.usage = &row
+
+	return out, nil
+}
+
+// GetSandbox is the RPC surface.
+func (s *Server) GetSandbox(ctx context.Context, state *usage_v1alpha.ResourceUsageGetSandbox) error {
+	args := state.Args()
+
+	opts := detailOptions{}
+	if o := args.Options(); o != nil {
+		opts.series = o.IncludeSeries()
+		opts.containers = o.IncludeContainers()
+		opts.step = time.Duration(o.StepSeconds()) * time.Second
+	}
+
+	w := windowFrom(args.Window())
+
+	detail, err := s.sandboxDetail(ctx, args.Sandbox(), w, opts)
+	if err != nil {
+		return err
+	}
+
+	detail.apply(state.Results(), w)
+
+	return nil
+}
+
+// HttpGetSandbox serves GET /api/v1/usage/sandboxes/{sandbox}.
+func (s *Server) HttpGetSandbox(ctx context.Context, state *usage_v1alpha.ResourceUsageHttpGetSandbox) error {
+	args := state.Args()
+
+	opts := detailOptions{series: args.Series(), containers: args.Containers()}
+	if d, ok := parseRESTDuration(args.Step()); ok {
+		opts.step = d
+	}
+
+	w := restWindow(args.Since(), args.Until(), args.Aggregate())
+
+	detail, err := s.sandboxDetail(ctx, args.Sandbox(), w, opts)
+	if err != nil {
+		return err
+	}
+
+	detail.apply(state.Results(), w)
+
+	return nil
+}
+
+func (s *Server) singleSandboxSamples(ctx context.Context, selector string, w window) (cores, bytes float64, warnings []string) {
+	if s.Reader == nil {
+		return 0, 0, []string{"no metrics backend configured; usage figures are unavailable"}
+	}
+
+	dur := w.duration()
+
+	if vals, err := s.instantByLabel(ctx, cpuCoresQuery(labelSandbox, selector, dur, w.aggregate), labelSandbox, w.end); err != nil {
+		warnings = append(warnings, "cpu usage unavailable: "+err.Error())
+	} else {
+		for _, v := range vals {
+			cores = v
+		}
+	}
+
+	if vals, err := s.instantByLabel(ctx, memoryBytesQuery(labelSandbox, selector, dur, w.aggregate), labelSandbox, w.end); err != nil {
+		warnings = append(warnings, "memory usage unavailable: "+err.Error())
+	} else {
+		for _, v := range vals {
+			bytes = v
+		}
+	}
+
+	return cores, bytes, warnings
+}
+
+// sandboxSeries fetches CPU and memory over time for charting.
+func (s *Server) sandboxSeries(ctx context.Context, selector string, w window, step time.Duration) ([]*usage_v1alpha.UsageSeries, []string) {
+	if s.Reader == nil {
+		return nil, nil
+	}
+
+	if step <= 0 {
+		// Derive a step that yields roughly defaultSeriesPoints points, so the
+		// resolution matches the window instead of returning either three
+		// points for an hour or thousands for a day.
+		step = w.duration() / defaultSeriesPoints
+	}
+	if step < time.Second {
+		step = time.Second
+	}
+
+	var out []*usage_v1alpha.UsageSeries
+	var warnings []string
+
+	queries := []struct {
+		metric string
+		query  string
+	}{
+		{"cpu_cores", cpuCoresQuery(labelSandbox, selector, step, aggregateAvg)},
+		{"memory_bytes", memoryBytesQuery(labelSandbox, selector, step, aggregateLast)},
+	}
+
+	for _, q := range queries {
+		result, err := s.Reader.RangeQuery(ctx, q.query, w.start, w.end, promDuration(step))
+		if err != nil {
+			warnings = append(warnings, q.metric+" history unavailable: "+err.Error())
+			continue
+		}
+
+		var series usage_v1alpha.UsageSeries
+		series.SetMetric(q.metric)
+
+		var points []*usage_v1alpha.UsagePoint
+		for _, r := range result.Data.Result {
+			for _, v := range r.Values {
+				if len(v) < 2 {
+					continue
+				}
+				ts, _ := v[0].(float64)
+				raw, ok := v[1].(string)
+				if !ok {
+					continue
+				}
+				val, err := strconv.ParseFloat(raw, 64)
+				if err != nil {
+					continue
+				}
+
+				var p usage_v1alpha.UsagePoint
+				p.SetAt(standard.ToTimestamp(time.Unix(int64(ts), 0)))
+				p.SetValue(val)
+				points = append(points, &p)
+			}
+		}
+
+		series.SetPoints(points)
+		out = append(out, &series)
+	}
+
+	return out, warnings
+}
+
+// decorateFromEntities adds the facts the metrics store does not hold: how the
+// sandbox exited, what image it runs, and whether its pool has given up
+// restarting it.
+func (s *Server) decorateFromEntities(
+	ctx context.Context,
+	row *sandboxRow,
+	out *sandboxDetailResult,
+) error {
+	var sb computev1.Sandbox
+	if err := s.EC.GetById(ctx, entity.Id(row.ref.Sandbox()), &sb); err != nil {
+		return err
+	}
+
+	out.restartPolicy = string(sb.Spec.RestartPolicy)
+
+	// The first non-pause container is the one an operator means by "the
+	// image"; the pause container is an implementation detail of the sandbox.
+	for _, c := range sb.Spec.Container {
+		if c.Image != "" {
+			out.image = c.Image
+			break
+		}
+	}
+
+	if sb.Exit.At.IsZero() && sb.Exit.Code == 0 && sb.Exit.Container == "" {
+		// Never exited; leaving the field unset says that more clearly than a
+		// zeroed exit record, which would read as a clean exit.
+		return s.decorateCrashLoop(ctx, row, out)
+	}
+
+	var exit usage_v1alpha.SandboxExit
+	exit.SetCode(int32(sb.Exit.Code))
+	exit.SetAt(standard.ToTimestamp(sb.Exit.At))
+	exit.SetContainer(sb.Exit.Container)
+	out.exit = &exit
+
+	return s.decorateCrashLoop(ctx, row, out)
+}
+
+func (s *Server) decorateCrashLoop(
+	ctx context.Context,
+	row *sandboxRow,
+	out *sandboxDetailResult,
+) error {
+	if row.poolID == "" {
+		return nil
+	}
+
+	var pool computev1.SandboxPool
+	if err := s.EC.GetById(ctx, entity.Id(row.poolID), &pool); err != nil {
+		return err
+	}
+
+	var cl usage_v1alpha.CrashLoopState
+	cl.SetConsecutiveCrashes(int32(pool.ConsecutiveCrashCount))
+	cl.SetLastCrashAt(standard.ToTimestamp(pool.LastCrashTime))
+	cl.SetCooldownUntil(standard.ToTimestamp(pool.CooldownUntil))
+	out.crashLoop = &cl
+
+	return nil
+}
+
+// nodeCoreCount reads how many cores the sandbox's host has, returning 0 when
+// that is unknown. Zero is the caller's signal to omit the share rather than
+// print a percentage of nothing.
+func (s *Server) nodeCoreCount(ctx context.Context, node string, w window) float64 {
+	if s.Reader == nil || node == "" {
+		return 0
+	}
+
+	sel := labelSelector(map[string]string{labelNode: node})
+	vals, err := s.instantByLabel(ctx, nodeGaugeQuery(metricNodeCPUCoresTotal, sel, w.duration(), aggregateLast), labelNode, w.end)
+	if err != nil {
+		return 0
+	}
+
+	return vals[node]
+}

--- a/servers/usage/sandbox.go
+++ b/servers/usage/sandbox.go
@@ -85,8 +85,10 @@ func (s *Server) sandboxDetail(
 	}
 
 	// Resolve through the same directory the listing uses, so the identity
-	// shown here and the identity shown in a row cannot disagree.
-	dir, err := s.loadDirectory(ctx, filter{includeSystem: true})
+	// shown here and the identity shown in a row cannot disagree. Unlike a
+	// listing this includes the dead: an exited sandbox is the one an operator
+	// most wants to inspect, and its exit is what decorateFromEntities reports.
+	dir, err := s.loadDirectory(ctx, filter{includeSystem: true, includeDead: true})
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +103,7 @@ func (s *Server) sandboxDetail(
 	}
 
 	if found == nil {
-		return nil, fmt.Errorf("sandbox %q not found, or it is not running", query)
+		return nil, fmt.Errorf("sandbox %q not found", query)
 	}
 
 	out := &sandboxDetailResult{}

--- a/servers/usage/usage.go
+++ b/servers/usage/usage.go
@@ -154,7 +154,7 @@ func (s *Server) listSandboxes(ctx context.Context, f filter, w window, ord orde
 	}
 
 	out.total = int32(len(rows))
-	sortSandboxes(rows, ord.sort, ord.order)
+	sortSandboxes(rows, ord)
 	out.rows = rows[:ord.truncate(len(rows))]
 
 	return out, nil
@@ -164,18 +164,19 @@ func (s *Server) listSandboxes(ctx context.Context, f filter, w window, ord orde
 func (s *Server) ListSandboxes(ctx context.Context, state *usage_v1alpha.ResourceUsageListSandboxes) error {
 	args := state.Args()
 
-	listing, err := s.listSandboxes(ctx,
-		selectorToFilter(args.Selector()),
-		windowFrom(args.Window()),
-		orderingFrom(args.Ordering()),
-	)
+	// Resolved once. An unset end means now, so calling windowFrom again for
+	// the response would resolve a later instant than the one the metrics were
+	// queried at, and the reported window would not be the measured one.
+	w := windowFrom(args.Window())
+
+	listing, err := s.listSandboxes(ctx, selectorToFilter(args.Selector()), w, orderingFrom(args.Ordering()))
 	if err != nil {
 		return err
 	}
 
 	res := state.Results()
 	res.SetSandboxes(listing.rows)
-	res.SetWindow(windowFrom(args.Window()).encode())
+	res.SetWindow(w.encode())
 	res.SetCluster(listing.cluster.encode())
 	res.SetTotalCount(listing.total)
 	res.SetCollectedAt(standard.ToTimestamp(time.Now()))
@@ -320,8 +321,9 @@ func (t totals) encode() *usage_v1alpha.ResourceTotals {
 // the client because a limit is only meaningful against a known order: taking
 // the first 20 of an unsorted listing returns 20 arbitrary sandboxes, not the
 // 20 busiest.
-func sortSandboxes(rows []*usage_v1alpha.SandboxUsage, key, order string) {
-	desc := !strings.EqualFold(order, "asc")
+func sortSandboxes(rows []*usage_v1alpha.SandboxUsage, ord ordering) {
+	key := ord.sort
+	desc := ord.descending()
 
 	less := func(a, b *usage_v1alpha.SandboxUsage) bool {
 		switch strings.ToLower(strings.TrimSpace(key)) {

--- a/servers/usage/usage.go
+++ b/servers/usage/usage.go
@@ -1,0 +1,347 @@
+// Package usage answers cluster-wide resource questions: which sandboxes are
+// consuming what, and which hosts are under pressure.
+//
+// It reads from VictoriaMetrics rather than probing runners directly. Every
+// runner already ships its sandbox metrics through the coordinator into one
+// store, so a single query here sees the whole cluster with no fan-out, no
+// per-node timeout budget, and no partial answer when a runner is unreachable.
+// It also means a window can be historical: the spike that caused the page an
+// hour ago is still there to be found, which no live probe could offer.
+package usage
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// Server answers resource usage queries. It belongs on the coordinator, which
+// is the only process holding both the entity store and a reader for the
+// cluster's metrics.
+type Server struct {
+	Log *slog.Logger
+
+	// EC resolves what a sandbox is: which app, service and node explain it.
+	EC *entityserver.Client
+
+	// Reader resolves what a sandbox is doing. Nil disables usage figures
+	// without disabling the listing, so a cluster with no metrics backend still
+	// answers "what is running where" instead of failing outright.
+	Reader *metrics.VictoriaMetricsReader
+}
+
+func NewServer(log *slog.Logger, ec *entityserver.Client, reader *metrics.VictoriaMetricsReader) *Server {
+	return &Server{Log: log, EC: ec, Reader: reader}
+}
+
+var _ usage_v1alpha.ResourceUsage = (*Server)(nil)
+
+// window is a resolved measurement span.
+type window struct {
+	start     time.Time
+	end       time.Time
+	aggregate string
+}
+
+func (w window) duration() time.Duration {
+	d := w.end.Sub(w.start)
+	if d <= 0 {
+		return defaultWindow
+	}
+	return d
+}
+
+func (w window) encode() *usage_v1alpha.UsageWindow {
+	var uw usage_v1alpha.UsageWindow
+	uw.SetStart(standard.ToTimestamp(w.start))
+	uw.SetEnd(standard.ToTimestamp(w.end))
+	uw.SetAggregate(w.aggregate)
+	return &uw
+}
+
+// resolveWindow turns a caller's bounds into a measured span.
+//
+// Both ends are optional and independent: an unset end means now, an unset (or
+// nonsensical) start means one minute before the end. There is exactly one way
+// to express a window, so there is no precedence rule to learn.
+func resolveWindow(start, end *standard.Timestamp, aggregate string) window {
+	endAt := time.Now()
+	if end != nil {
+		if t := standard.FromTimestamp(end); !t.IsZero() {
+			endAt = t
+		}
+	}
+
+	var startAt time.Time
+	if start != nil {
+		startAt = standard.FromTimestamp(start)
+	}
+
+	if startAt.IsZero() || !startAt.Before(endAt) {
+		startAt = endAt.Add(-defaultWindow)
+	}
+
+	return window{start: startAt, end: endAt, aggregate: resolveAggregate(aggregate)}
+}
+
+// sandboxListing is the answer both surfaces return, before either has shaped
+// it into its own result type.
+type sandboxListing struct {
+	rows     []*usage_v1alpha.SandboxUsage
+	cluster  totals
+	total    int32
+	warnings []string
+}
+
+// listSandboxes is the one implementation behind both ListSandboxes (RPC) and
+// HttpListSandboxes (REST). Neither surface holds logic of its own beyond
+// translating its arguments.
+func (s *Server) listSandboxes(ctx context.Context, f filter, w window, ord ordering) (*sandboxListing, error) {
+	dir, err := s.loadDirectory(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &sandboxListing{}
+
+	cpu, memory, nodeCores, warnings := s.sandboxSamples(ctx, f, w, dir)
+	out.warnings = warnings
+
+	rows := make([]*usage_v1alpha.SandboxUsage, 0, len(dir.sandboxes))
+
+	for _, sb := range dir.sandboxes {
+		if !f.matches(sb.ref) {
+			continue
+		}
+
+		id := sb.ref.Sandbox()
+		cores, haveCPU := cpu[id]
+		bytes, haveMem := memory[id]
+
+		var row usage_v1alpha.SandboxUsage
+		row.SetRef(sb.ref)
+		row.SetMeasuredAt(standard.ToTimestamp(w.end))
+
+		// A sandbox with no samples is reported as a row with blank usage and
+		// stale set, never dropped. A sandbox that is running but has stopped
+		// reporting is a finding in itself; omitting it would make a broken
+		// telemetry pipeline look like an idle cluster.
+		row.SetStale(!haveCPU && !haveMem)
+
+		var c usage_v1alpha.CpuUsage
+		c.SetCores(cores)
+		if total := nodeCores[sb.ref.Node()]; total > 0 {
+			c.SetPercentOfNode(cores / total * 100)
+		}
+		row.SetCpu(&c)
+
+		var m usage_v1alpha.MemoryUsage
+		m.SetBytes(int64(bytes))
+		row.SetMemory(&m)
+
+		out.cluster.cpuCores += cores
+		out.cluster.memoryBytes += int64(bytes)
+
+		rows = append(rows, &row)
+	}
+
+	out.total = int32(len(rows))
+	sortSandboxes(rows, ord.sort, ord.order)
+	out.rows = rows[:ord.truncate(len(rows))]
+
+	return out, nil
+}
+
+// ListSandboxes is the RPC surface: grouped arguments, no HTTP binding.
+func (s *Server) ListSandboxes(ctx context.Context, state *usage_v1alpha.ResourceUsageListSandboxes) error {
+	args := state.Args()
+
+	listing, err := s.listSandboxes(ctx,
+		selectorToFilter(args.Selector()),
+		windowFrom(args.Window()),
+		orderingFrom(args.Ordering()),
+	)
+	if err != nil {
+		return err
+	}
+
+	res := state.Results()
+	res.SetSandboxes(listing.rows)
+	res.SetWindow(windowFrom(args.Window()).encode())
+	res.SetCluster(listing.cluster.encode())
+	res.SetTotalCount(listing.total)
+	res.SetCollectedAt(standard.ToTimestamp(time.Now()))
+	res.SetWarnings(listing.warnings)
+
+	return nil
+}
+
+// HttpListSandboxes serves GET /api/v1/usage/sandboxes with flat query
+// parameters.
+func (s *Server) HttpListSandboxes(ctx context.Context, state *usage_v1alpha.ResourceUsageHttpListSandboxes) error {
+	args := state.Args()
+
+	f := filter{
+		app:           args.App(),
+		service:       args.Service(),
+		node:          args.Node(),
+		kind:          args.Kind(),
+		status:        args.Status(),
+		includeSystem: args.IncludeSystem(),
+		includeAddons: true,
+	}
+	w := restWindow(args.Since(), args.Until(), args.Aggregate())
+	ord := ordering{sort: args.Sort(), order: args.Order(), limit: int(args.Limit())}
+
+	listing, err := s.listSandboxes(ctx, f, w, ord)
+	if err != nil {
+		return err
+	}
+
+	res := state.Results()
+	res.SetSandboxes(listing.rows)
+	res.SetWindow(w.encode())
+	res.SetCluster(listing.cluster.encode())
+	res.SetTotalCount(listing.total)
+	res.SetCollectedAt(standard.ToTimestamp(time.Now()))
+	res.SetWarnings(listing.warnings)
+
+	return nil
+}
+
+// sandboxSamples runs the metric queries behind a listing.
+//
+// Two queries answer the whole cluster, not two per sandbox: grouping by
+// sandbox in the query means the cost of this call does not grow with the
+// number of sandboxes, which is what makes a refreshing view affordable.
+func (s *Server) sandboxSamples(
+	ctx context.Context,
+	f filter,
+	w window,
+	dir *directory,
+) (cpu, memory, nodeCores map[string]float64, warnings []string) {
+	cpu = map[string]float64{}
+	memory = map[string]float64{}
+	nodeCores = map[string]float64{}
+
+	if s.Reader == nil {
+		return cpu, memory, nodeCores, []string{"no metrics backend configured; usage figures are unavailable"}
+	}
+
+	selector := ""
+	if f.node != "" {
+		if n := matchNode(dir.nodes, f.node); n != nil {
+			selector = labelSelector(map[string]string{labelNode: string(n.id)})
+		}
+	}
+
+	dur := w.duration()
+
+	cpuQ := cpuCoresQuery(labelSandbox, selector, dur, w.aggregate)
+	if vals, err := s.instantByLabel(ctx, cpuQ, labelSandbox, w.end); err != nil {
+		warnings = append(warnings, "cpu usage unavailable: "+err.Error())
+	} else {
+		cpu = vals
+	}
+
+	memQ := memoryBytesQuery(labelSandbox, selector, dur, w.aggregate)
+	if vals, err := s.instantByLabel(ctx, memQ, labelSandbox, w.end); err != nil {
+		warnings = append(warnings, "memory usage unavailable: "+err.Error())
+	} else {
+		memory = vals
+	}
+
+	// Node capacity is what turns "2 cores" into "half the machine". Its
+	// absence degrades a column rather than the answer, so a failure here is a
+	// warning and the percentages simply stay zero.
+	capQ := nodeGaugeQuery(metricNodeCPUCoresTotal, selector, dur, aggregateLast)
+	if vals, err := s.instantByLabel(ctx, capQ, labelNode, w.end); err != nil {
+		warnings = append(warnings, "node capacity unavailable: "+err.Error())
+	} else {
+		nodeCores = vals
+	}
+
+	return cpu, memory, nodeCores, warnings
+}
+
+// instantByLabel runs one instant query and indexes the result by a label.
+func (s *Server) instantByLabel(ctx context.Context, query, label string, at time.Time) (map[string]float64, error) {
+	result, err := s.Reader.InstantQuery(ctx, query, at)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]float64, len(result.Data.Result))
+	for _, r := range result.Data.Result {
+		key := r.Metric[label]
+		if key == "" || len(r.Value) < 2 {
+			continue
+		}
+		raw, ok := r.Value[1].(string)
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			continue
+		}
+		out[key] = v
+	}
+
+	return out, nil
+}
+
+// totals accumulates a rolled-up slice of usage.
+type totals struct {
+	cpuCores    float64
+	memoryBytes int64
+	cpuPercent  float64
+	memPercent  float64
+}
+
+func (t totals) encode() *usage_v1alpha.ResourceTotals {
+	var rt usage_v1alpha.ResourceTotals
+	rt.SetCpuCores(t.cpuCores)
+	rt.SetCpuPercent(t.cpuPercent)
+	rt.SetMemoryBytes(t.memoryBytes)
+	rt.SetMemoryPercent(t.memPercent)
+	return &rt
+}
+
+// sortSandboxes orders rows server-side. This has to happen here rather than in
+// the client because a limit is only meaningful against a known order: taking
+// the first 20 of an unsorted listing returns 20 arbitrary sandboxes, not the
+// 20 busiest.
+func sortSandboxes(rows []*usage_v1alpha.SandboxUsage, key, order string) {
+	desc := !strings.EqualFold(order, "asc")
+
+	less := func(a, b *usage_v1alpha.SandboxUsage) bool {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "memory", "mem":
+			return a.Memory().Bytes() < b.Memory().Bytes()
+		case "app":
+			return a.Ref().App() < b.Ref().App()
+		case "service":
+			return a.Ref().Service() < b.Ref().Service()
+		case "node", "runner":
+			return a.Ref().NodeName() < b.Ref().NodeName()
+		default:
+			return a.Cpu().Cores() < b.Cpu().Cores()
+		}
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		if desc {
+			return less(rows[j], rows[i])
+		}
+		return less(rows[i], rows[j])
+	})
+}

--- a/servers/usage/usage.go
+++ b/servers/usage/usage.go
@@ -321,24 +321,39 @@ func (t totals) encode() *usage_v1alpha.ResourceTotals {
 // the client because a limit is only meaningful against a known order: taking
 // the first 20 of an unsorted listing returns 20 arbitrary sandboxes, not the
 // 20 busiest.
-func sortSandboxes(rows []*usage_v1alpha.SandboxUsage, ord ordering) {
-	key := ord.sort
-	desc := ord.descending()
-
-	less := func(a, b *usage_v1alpha.SandboxUsage) bool {
-		switch strings.ToLower(strings.TrimSpace(key)) {
-		case "memory", "mem":
-			return a.Memory().Bytes() < b.Memory().Bytes()
-		case "app":
-			return a.Ref().App() < b.Ref().App()
-		case "service":
-			return a.Ref().Service() < b.Ref().Service()
-		case "node", "runner":
-			return a.Ref().NodeName() < b.Ref().NodeName()
-		default:
-			return a.Cpu().Cores() < b.Cpu().Cores()
-		}
+// sandboxName is what a person calls a sandbox: the short id they type and see
+// in a listing, falling back to the full entity id for one too old to have one.
+func sandboxName(ref *usage_v1alpha.SandboxRef) string {
+	if short := ref.SandboxShortId(); short != "" {
+		return short
 	}
+	return ref.Sandbox()
+}
+
+func sortSandboxes(rows []*usage_v1alpha.SandboxUsage, ord ordering) {
+	// Each key states the direction that reads naturally for it, so a name
+	// never inherits a usage column's busiest-first default.
+	var (
+		less      func(a, b *usage_v1alpha.SandboxUsage) bool
+		ascending bool
+	)
+
+	switch strings.ToLower(strings.TrimSpace(ord.sort)) {
+	case "memory", "mem":
+		less = func(a, b *usage_v1alpha.SandboxUsage) bool { return a.Memory().Bytes() < b.Memory().Bytes() }
+	case "app":
+		less, ascending = func(a, b *usage_v1alpha.SandboxUsage) bool { return a.Ref().App() < b.Ref().App() }, true
+	case "service":
+		less, ascending = func(a, b *usage_v1alpha.SandboxUsage) bool { return a.Ref().Service() < b.Ref().Service() }, true
+	case "node", "runner":
+		less, ascending = func(a, b *usage_v1alpha.SandboxUsage) bool { return a.Ref().NodeName() < b.Ref().NodeName() }, true
+	case "name":
+		less, ascending = func(a, b *usage_v1alpha.SandboxUsage) bool { return sandboxName(a.Ref()) < sandboxName(b.Ref()) }, true
+	default:
+		less = func(a, b *usage_v1alpha.SandboxUsage) bool { return a.Cpu().Cores() < b.Cpu().Cores() }
+	}
+
+	desc := ord.direction(ascending)
 
 	sort.SliceStable(rows, func(i, j int) bool {
 		if desc {


### PR DESCRIPTION
There was no way to ask a Miren cluster what was using the CPU. To diagnose a busy cluster you'd list sandboxes, then dial one runner at a time with `miren sandbox metrics`, which dumped a raw Go struct of lifetime counters for a single sandbox. Nothing aggregated across runners, nothing gave you a rate, and nothing told you whether the load was somebody's app or Miren's own overhead.

This adds `miren top`, which answers the three questions an operator asks in order. `--nodes` says which machine is hot and splits it into sandbox versus platform use, `--apps` totals each app across everything it owns, and the default view lists sandboxes ordered by the busiest. `miren sandbox inspect` covers the last step: what one sandbox runs, how it exited, and whether its pool has given up replacing it.

The nice surprise was that most of the data was already there. Every runner ships its metrics through the coordinator into one store, so a single query sees the whole cluster with no fan-out and no partial answer when a runner is unreachable. It also means the window can be historical, which no live probe could offer, so `--since 1h --aggregate max` finds the spike that caused the page an hour ago.

What was missing was attribution. The metrics could say which sandbox but not which host, and app sandboxes couldn't be told apart from the addon servers and task runs sharing the machine. Two of the five commits are that groundwork: labelling sandbox series with their node, kind and app, and publishing host-level series so there's a capacity figure to divide by. That second one is also what makes the system-versus-sandbox split possible, since containerd, buildkit, the registry and miren itself all run outside every sandbox cgroup and are invisible in the per-sandbox view.

The first commit is a detour worth calling out. The API wants two shapes: a Go caller wants grouped arguments it can't transpose, and a URL can only carry flat scalars. Offering both from one interface meant the URL-shaped method was also a second, worse way for a program to ask the same thing, with thirteen positional arguments including six consecutive strings. So `rest_only: true` is now a thing rpcgen understands. It keeps the HTTP route and withdraws the method from everything else, so reaching for it from Go is a compile error rather than a runtime one.

A couple of decisions that might read as omissions. There's no restart column, because Miren replaces a failed sandbox rather than restarting it, so no single sandbox accumulates a count; repeated failure is a pool-level crash loop, which `inspect` reports. And network, disk IO and PSI aren't here at all. They need new collection rather than new queries, so rather than ship fields that always read zero and can't be told apart from a genuinely idle sandbox, the API only carries what it measures. Adding them later is backward compatible.

Closes MIR-1758
