### PR TITLE
Keep sandbox inventory from exposing resolved secrets

### DIFF
--- a/api/compute/compute.go
+++ b/api/compute/compute.go
@@ -3,6 +3,7 @@ package compute
 import "miren.dev/runtime/api/compute/compute_v1alpha"
 
 //go:generate go run ../../pkg/entity/cmd/schemagen -input schema.yml -output compute_v1alpha/schema.gen.go -pkg compute_v1alpha
+//go:generate go run ../../pkg/rpc/cmd/rpcgen -pkg compute_v1alpha -input rpc.yml -output compute_v1alpha/rpc.gen.go
 
 // SandboxActive reports whether a sandbox status indicates the sandbox
 // may be actively running (PENDING, NOT_READY, or RUNNING).

--- a/api/compute/compute_v1alpha/rpc.gen.go
+++ b/api/compute/compute_v1alpha/rpc.gen.go
@@ -1,0 +1,394 @@
+package compute_v1alpha
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+
+	"github.com/fxamacker/cbor/v2"
+	rpc "miren.dev/runtime/pkg/rpc"
+)
+
+type sandboxInfoData struct {
+	Id             *string `cbor:"0,keyasint,omitempty" json:"id,omitempty"`
+	ShortId        *string `cbor:"1,keyasint,omitempty" json:"short_id,omitempty"`
+	App            *string `cbor:"2,keyasint,omitempty" json:"app,omitempty"`
+	Version        *string `cbor:"3,keyasint,omitempty" json:"version,omitempty"`
+	VersionShortId *string `cbor:"4,keyasint,omitempty" json:"version_short_id,omitempty"`
+	Service        *string `cbor:"5,keyasint,omitempty" json:"service,omitempty"`
+	Pool           *string `cbor:"6,keyasint,omitempty" json:"pool,omitempty"`
+	PoolShortId    *string `cbor:"7,keyasint,omitempty" json:"pool_short_id,omitempty"`
+	Address        *string `cbor:"8,keyasint,omitempty" json:"address,omitempty"`
+	Runner         *string `cbor:"9,keyasint,omitempty" json:"runner,omitempty"`
+	Status         *string `cbor:"10,keyasint,omitempty" json:"status,omitempty"`
+	CreatedAt      *int64  `cbor:"11,keyasint,omitempty" json:"created_at,omitempty"`
+	UpdatedAt      *int64  `cbor:"12,keyasint,omitempty" json:"updated_at,omitempty"`
+}
+
+type SandboxInfo struct {
+	data sandboxInfoData
+}
+
+func (v *SandboxInfo) HasId() bool {
+	return v.data.Id != nil
+}
+
+func (v *SandboxInfo) Id() string {
+	if v.data.Id == nil {
+		return ""
+	}
+	return *v.data.Id
+}
+
+func (v *SandboxInfo) SetId(id string) {
+	v.data.Id = &id
+}
+
+func (v *SandboxInfo) HasShortId() bool {
+	return v.data.ShortId != nil
+}
+
+func (v *SandboxInfo) ShortId() string {
+	if v.data.ShortId == nil {
+		return ""
+	}
+	return *v.data.ShortId
+}
+
+func (v *SandboxInfo) SetShortId(short_id string) {
+	v.data.ShortId = &short_id
+}
+
+func (v *SandboxInfo) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *SandboxInfo) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *SandboxInfo) SetApp(app string) {
+	v.data.App = &app
+}
+
+func (v *SandboxInfo) HasVersion() bool {
+	return v.data.Version != nil
+}
+
+func (v *SandboxInfo) Version() string {
+	if v.data.Version == nil {
+		return ""
+	}
+	return *v.data.Version
+}
+
+func (v *SandboxInfo) SetVersion(version string) {
+	v.data.Version = &version
+}
+
+func (v *SandboxInfo) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *SandboxInfo) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
+}
+
+func (v *SandboxInfo) SetVersionShortId(version_short_id string) {
+	v.data.VersionShortId = &version_short_id
+}
+
+func (v *SandboxInfo) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *SandboxInfo) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *SandboxInfo) SetService(service string) {
+	v.data.Service = &service
+}
+
+func (v *SandboxInfo) HasPool() bool {
+	return v.data.Pool != nil
+}
+
+func (v *SandboxInfo) Pool() string {
+	if v.data.Pool == nil {
+		return ""
+	}
+	return *v.data.Pool
+}
+
+func (v *SandboxInfo) SetPool(pool string) {
+	v.data.Pool = &pool
+}
+
+func (v *SandboxInfo) HasPoolShortId() bool {
+	return v.data.PoolShortId != nil
+}
+
+func (v *SandboxInfo) PoolShortId() string {
+	if v.data.PoolShortId == nil {
+		return ""
+	}
+	return *v.data.PoolShortId
+}
+
+func (v *SandboxInfo) SetPoolShortId(pool_short_id string) {
+	v.data.PoolShortId = &pool_short_id
+}
+
+func (v *SandboxInfo) HasAddress() bool {
+	return v.data.Address != nil
+}
+
+func (v *SandboxInfo) Address() string {
+	if v.data.Address == nil {
+		return ""
+	}
+	return *v.data.Address
+}
+
+func (v *SandboxInfo) SetAddress(address string) {
+	v.data.Address = &address
+}
+
+func (v *SandboxInfo) HasRunner() bool {
+	return v.data.Runner != nil
+}
+
+func (v *SandboxInfo) Runner() string {
+	if v.data.Runner == nil {
+		return ""
+	}
+	return *v.data.Runner
+}
+
+func (v *SandboxInfo) SetRunner(runner string) {
+	v.data.Runner = &runner
+}
+
+func (v *SandboxInfo) HasStatus() bool {
+	return v.data.Status != nil
+}
+
+func (v *SandboxInfo) Status() string {
+	if v.data.Status == nil {
+		return ""
+	}
+	return *v.data.Status
+}
+
+func (v *SandboxInfo) SetStatus(status string) {
+	v.data.Status = &status
+}
+
+func (v *SandboxInfo) HasCreatedAt() bool {
+	return v.data.CreatedAt != nil
+}
+
+func (v *SandboxInfo) CreatedAt() int64 {
+	if v.data.CreatedAt == nil {
+		return 0
+	}
+	return *v.data.CreatedAt
+}
+
+func (v *SandboxInfo) SetCreatedAt(created_at int64) {
+	v.data.CreatedAt = &created_at
+}
+
+func (v *SandboxInfo) HasUpdatedAt() bool {
+	return v.data.UpdatedAt != nil
+}
+
+func (v *SandboxInfo) UpdatedAt() int64 {
+	if v.data.UpdatedAt == nil {
+		return 0
+	}
+	return *v.data.UpdatedAt
+}
+
+func (v *SandboxInfo) SetUpdatedAt(updated_at int64) {
+	v.data.UpdatedAt = &updated_at
+}
+
+func (v *SandboxInfo) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SandboxInfo) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SandboxInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SandboxInfo) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type sandboxesListArgsData struct{}
+
+type SandboxesListArgs struct {
+	call rpc.Call
+	data sandboxesListArgsData
+}
+
+func (v *SandboxesListArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SandboxesListArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SandboxesListArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SandboxesListArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type sandboxesListResultsData struct {
+	Sandboxes *[]*SandboxInfo `cbor:"0,keyasint,omitempty" json:"sandboxes,omitempty"`
+}
+
+type SandboxesListResults struct {
+	call rpc.Call
+	data sandboxesListResultsData
+}
+
+func (v *SandboxesListResults) SetSandboxes(sandboxes []*SandboxInfo) {
+	x := slices.Clone(sandboxes)
+	v.data.Sandboxes = &x
+}
+
+func (v *SandboxesListResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SandboxesListResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SandboxesListResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SandboxesListResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type SandboxesList struct {
+	rpc.Call
+	args    SandboxesListArgs
+	results SandboxesListResults
+}
+
+func (t *SandboxesList) Args() *SandboxesListArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *SandboxesList) Results() *SandboxesListResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type Sandboxes interface {
+	List(ctx context.Context, state *SandboxesList) error
+}
+
+type reexportSandboxes struct {
+	client rpc.Client
+}
+
+func (reexportSandboxes) List(ctx context.Context, state *SandboxesList) error {
+	panic("not implemented")
+}
+
+func (t reexportSandboxes) CapabilityClient() rpc.Client {
+	return t.client
+}
+
+func AdaptSandboxes(t Sandboxes) *rpc.Interface {
+	methods := []rpc.Method{
+		{
+			Name:          "list",
+			InterfaceName: "Sandboxes",
+			Index:         0,
+			Public:        false,
+			Params:        []string{},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.List(ctx, &SandboxesList{Call: call})
+			},
+		},
+	}
+
+	return rpc.NewInterface(methods, t)
+}
+
+type SandboxesClient struct {
+	rpc.Client
+}
+
+func NewSandboxesClient(client rpc.Client) *SandboxesClient {
+	return &SandboxesClient{Client: client}
+}
+
+func (c SandboxesClient) Export() Sandboxes {
+	return reexportSandboxes{client: c.Client}
+}
+
+type SandboxesClientListResults struct {
+	client rpc.Client
+	data   sandboxesListResultsData
+}
+
+func (v *SandboxesClientListResults) HasSandboxes() bool {
+	return v.data.Sandboxes != nil
+}
+
+func (v *SandboxesClientListResults) Sandboxes() []*SandboxInfo {
+	if v.data.Sandboxes == nil {
+		return nil
+	}
+	return *v.data.Sandboxes
+}
+
+func (v SandboxesClient) List(ctx context.Context) (*SandboxesClientListResults, error) {
+	args := SandboxesListArgs{}
+
+	var ret sandboxesListResultsData
+
+	err := v.Call(ctx, "list", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SandboxesClientListResults{client: v.Client, data: ret}, nil
+}

--- a/api/compute/rpc.yml
+++ b/api/compute/rpc.yml
@@ -1,0 +1,59 @@
+apiVersion: miren.dev/rpc/v1
+kind: IDL
+
+types:
+  # SandboxInfo is the operator-facing inventory record. It deliberately does
+  # not contain a Sandbox or SandboxSpec: those carry resolved container
+  # environment values and belong on the internal entity plane.
+  - type: SandboxInfo
+    fields:
+      - name: id
+        type: string
+        index: 0
+      - name: short_id
+        type: string
+        index: 1
+      - name: app
+        type: string
+        index: 2
+      - name: version
+        type: string
+        index: 3
+      - name: version_short_id
+        type: string
+        index: 4
+      - name: service
+        type: string
+        index: 5
+      - name: pool
+        type: string
+        index: 6
+      - name: pool_short_id
+        type: string
+        index: 7
+      - name: address
+        type: string
+        index: 8
+      - name: runner
+        type: string
+        index: 9
+      - name: status
+        type: string
+        index: 10
+      - name: created_at
+        type: int64
+        index: 11
+        doc: Unix milliseconds
+      - name: updated_at
+        type: int64
+        index: 12
+        doc: Unix milliseconds
+
+interfaces:
+  - name: Sandboxes
+    methods:
+      - name: list
+        results:
+          - name: sandboxes
+            type: list
+            element: SandboxInfo

--- a/blackbox/harness/app.go
+++ b/blackbox/harness/app.go
@@ -96,18 +96,15 @@ func GetSandboxID(t *testing.T, m *Miren, appName string) string {
 	r := m.MustRun("sandbox", "list", "--format", "json")
 
 	var sandboxes []struct {
-		ID   string `json:"id"`
-		Spec struct {
-			Version string `json:"version"`
-		} `json:"spec"`
+		ID  string `json:"id"`
+		App string `json:"app"`
 	}
 	if err := json.Unmarshal([]byte(r.Stdout), &sandboxes); err != nil {
 		t.Fatalf("failed to parse sandbox list JSON: %v", err)
 	}
 
 	for _, sb := range sandboxes {
-		// Sandbox IDs and versions contain the app name
-		if strings.Contains(sb.ID, appName) || strings.Contains(sb.Spec.Version, appName) {
+		if sb.App == appName || strings.Contains(sb.ID, appName) {
 			return sb.ID
 		}
 	}

--- a/blackbox/image_source_test.go
+++ b/blackbox/image_source_test.go
@@ -45,20 +45,9 @@ func TestDeployImageOnlyNoDockerfile(t *testing.T) {
 	assert.Equal(t, "image", appStatus.Source.Kind)
 	assert.Equal(t, "docker.io/library/nginx:alpine", appStatus.Source.Value)
 
-	r := m.MustRun("sandbox", "list", "--format", "json")
-	var sandboxes []struct {
-		ID   string `json:"id"`
-		Spec struct {
-			Container []struct {
-				Image string `json:"image"`
-			} `json:"container"`
-		} `json:"spec"`
-	}
-	require.NoError(t, json.Unmarshal([]byte(r.Stdout), &sandboxes))
-
-	for _, sb := range sandboxes {
-		if len(sb.Spec.Container) > 0 && strings.HasPrefix(sb.Spec.Container[0].Image, "docker.io/library/nginx@sha256:") {
-			assert.Contains(t, sb.ID, name)
+	for _, doc := range listDocs(t, m, "sandbox") {
+		if image := sandboxSpecImage(doc); strings.HasPrefix(image, "docker.io/library/nginx@sha256:") {
+			assert.Contains(t, doc.Id, name)
 			return
 		}
 	}
@@ -118,21 +107,66 @@ func TestDeployImageInheritsMetadata(t *testing.T) {
 
 func sandboxForImageSource(t *testing.T, m *harness.Miren, appName string) (string, string) {
 	t.Helper()
-	r := m.MustRun("sandbox", "list", "--format", "json")
-	var sandboxes []struct {
-		ID   string `json:"id"`
-		Spec struct {
-			Container []struct {
-				Image string `json:"image"`
-			} `json:"container"`
-		} `json:"spec"`
-	}
-	require.NoError(t, json.Unmarshal([]byte(r.Stdout), &sandboxes))
-	for _, sb := range sandboxes {
-		if strings.Contains(sb.ID, appName) && len(sb.Spec.Container) > 0 {
-			return sb.ID, sb.Spec.Container[0].Image
+	for _, doc := range listDocs(t, m, "sandbox") {
+		if strings.Contains(doc.Id, appName) {
+			if image := sandboxSpecImage(doc); image != "" {
+				return doc.Id, image
+			}
 		}
 	}
 	t.Fatalf("no sandbox found for app %s", appName)
 	return "", ""
+}
+
+// sandboxSpecImage deliberately reads the raw debug-entity representation.
+// Image-source tests need execution detail; the public sandbox inventory does
+// not, and must never regain a SandboxSpec just to serve these assertions.
+func sandboxSpecImage(doc entityDoc) string {
+	for _, facet := range doc.Facets {
+		for _, field := range facet.Fields {
+			if field.Name == "spec" {
+				if image, ok := findNestedString(field.Value, "image"); ok {
+					return image
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func findNestedString(value any, name string) (string, bool) {
+	switch value := value.(type) {
+	case map[string]any:
+		for key, nested := range value {
+			if key == name {
+				if text, ok := nested.(string); ok {
+					return text, true
+				}
+			}
+			if text, ok := findNestedString(nested, name); ok {
+				return text, true
+			}
+		}
+	case []any:
+		for _, nested := range value {
+			if text, ok := findNestedString(nested, name); ok {
+				return text, true
+			}
+		}
+	}
+	return "", false
+}
+
+func TestSandboxSpecImageFromEntityDocument(t *testing.T) {
+	var doc entityDoc
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"facets": [{
+			"fields": [{
+				"name": "spec",
+				"value": {"container": [{"name": "app", "image": "registry.test/app@sha256:abc"}]}
+			}]
+		}]
+	}`), &doc))
+
+	assert.Equal(t, "registry.test/app@sha256:abc", sandboxSpecImage(doc))
 }

--- a/blackbox/sandbox_test.go
+++ b/blackbox/sandbox_test.go
@@ -13,14 +13,22 @@ func TestSandboxList(t *testing.T) {
 	c := harness.NewCluster(t)
 	m := harness.NewMiren(t, c)
 
+	const envCanary = "mir1765-must-not-appear-in-sandbox-inventory"
 	name := harness.DeployApp(t, m, harness.AppOptions{
 		Testdata: "go-server",
+		Env:      []string{"MIR1765_CANARY=" + envCanary},
 	})
 
 	// List sandboxes — our app's sandbox should appear in the output.
 	// Use JSON format since the table view shows short IDs, not app names.
 	r := m.MustRun("sandbox", "list", "--format", "json")
 	r.RequireContains(t, name)
+	if strings.Contains(r.Stdout, envCanary) {
+		t.Fatalf("sandbox inventory leaked a resolved environment value:\n%s", r.Stdout)
+	}
+	if strings.Contains(r.Stdout, `"spec"`) {
+		t.Fatalf("sandbox inventory exposed the raw execution spec:\n%s", r.Stdout)
+	}
 
 	t.Run("app-filter", func(t *testing.T) {
 		r := m.MustRun("sandbox", "list", "--app", name)

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -355,6 +355,7 @@ miren deploy --analyze
 	// Sandbox commands
 	d.Dispatch("sandbox", Section("sandbox", "Sandbox management commands", "", WithSectionDescription(sandboxSectionDescription), WithSectionGroup(GroupMonitoring)))
 	d.Dispatch("sandbox list", Infer("sandbox list", "List sandboxes (excludes dead by default)", SandboxList,
+		WithDescription(sandboxListDescription),
 		WithExample(mflags.Example{
 			Name: "List running sandboxes",
 			Body: "miren sandbox list",

--- a/cli/commands/sandbox_doc.go
+++ b/cli/commands/sandbox_doc.go
@@ -2,6 +2,10 @@ package commands
 
 const sandboxSectionDescription = `Sandboxes are the underlying execution environments for your applications. Most of the time you'll work with apps directly, but these commands are useful for debugging and advanced use cases.`
 
+const sandboxListDescription = `List the sandboxes currently known to the cluster. Dead sandboxes are hidden unless you pass ` + "`" + `--all` + "`" + ` or ask for the ` + "`" + `dead` + "`" + ` status explicitly.
+
+The JSON form is a stable inventory view with the same operational fields as the table. It deliberately excludes the raw sandbox execution spec, which contains resolved environment values and may include secrets. For low-level inspection, use the explicitly privileged ` + "`" + `miren debug entity list -k sandbox` + "`" + ` command.`
+
 const sandboxExecDescription = `This command connects to an existing sandbox and runs a command inside it. Unlike ` + "`" + `miren app run` + "`" + ` which creates a new ephemeral sandbox, this connects to a sandbox that's already running (typically one serving production traffic).
 
 ## Letting miren pick the sandbox

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -1,36 +1,27 @@
 package commands
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"miren.dev/runtime/api/compute"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/ui"
 )
 
-// sandboxFilter narrows a sandbox listing to one app and/or service. Both
-// match against the values shown in the APP and SERVICE columns, so what you
-// filter on is what you see — including the "-" cases, which simply match
-// nothing rather than matching everything.
+// sandboxFilter owns the CLI's presentation policy. The inventory RPC returns
+// every safe summary; flags decide which of those records this invocation
+// shows and which terminal records count as hidden.
 type sandboxFilter struct {
-	app     string
-	service string
-}
-
-func (f sandboxFilter) keep(app, service string) bool {
-	if f.app != "" && app != f.app {
-		return false
-	}
-
-	if f.service != "" && service != f.service {
-		return false
-	}
-
-	return true
+	includeDead bool
+	status      string
+	app         string
+	service     string
 }
 
 func (f sandboxFilter) describe() string {
@@ -46,6 +37,58 @@ func (f sandboxFilter) describe() string {
 	}
 }
 
+func (f sandboxFilter) apply(entries []sandboxListEntry) ([]sandboxListEntry, int64) {
+	filtered := make([]sandboxListEntry, 0, len(entries))
+	var hiddenDead int64
+
+	for _, entry := range entries {
+		if f.app != "" && entry.App != f.app {
+			continue
+		}
+		if f.service != "" && entry.Service != f.service {
+			continue
+		}
+
+		if !f.includeDead && f.status == "" && sandboxTerminal(entry.Status) {
+			hiddenDead++
+			continue
+		}
+		if f.status != "" && entry.Status != f.status {
+			continue
+		}
+
+		filtered = append(filtered, entry)
+	}
+
+	return filtered, hiddenDead
+}
+
+func sandboxTerminal(status string) bool {
+	return status == "stopped" || status == "dead"
+}
+
+// sandboxListEntry is the complete public contract of `sandbox list --json`.
+// Keep this an allow-list. In particular, never embed compute_v1alpha.Sandbox:
+// its execution spec contains resolved container environment values.
+type sandboxListEntry struct {
+	ID        string `json:"id"`
+	App       string `json:"app,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Service   string `json:"service,omitempty"`
+	Pool      string `json:"pool,omitempty"`
+	Address   string `json:"address,omitempty"`
+	Runner    string `json:"runner,omitempty"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+
+	shortID        string
+	versionShortID string
+	poolShortID    string
+	createdAt      time.Time
+	updatedAt      time.Time
+}
+
 func SandboxList(ctx *Context, opts struct {
 	All     bool   `short:"a" long:"all" description:"Include dead sandboxes (excluded by default)"`
 	Status  string `short:"s" long:"status" description:"Filter by status (pending, not_ready, running, stopped, dead)"`
@@ -54,284 +97,85 @@ func SandboxList(ctx *Context, opts struct {
 	FormatOptions
 	ConfigCentric
 }) error {
-	filter := sandboxFilter{app: opts.App, service: opts.Service}
-
-	client, err := ctx.RPCClient("entities")
-	if err != nil {
-		return err
+	filter := sandboxFilter{
+		includeDead: opts.All,
+		status:      opts.Status,
+		app:         opts.App,
+		service:     opts.Service,
 	}
 
-	eac := entityserver_v1alpha.NewEntityAccessClient(client)
-
-	// Get the sandbox kind attribute
-	kindRes, err := eac.LookupKind(ctx, "sandbox")
+	entries, err := listSandboxesRPC(ctx)
 	if err != nil {
-		return err
-	}
-
-	// List all sandboxes
-	res, err := eac.List(ctx, kindRes.Attr())
-	if err != nil {
-		return err
-	}
-
-	// Get all sandbox pools to map pool ID -> service
-	poolKindRes, err := eac.LookupKind(ctx, "sandbox_pool")
-	if err != nil {
-		return err
-	}
-	poolsRes, err := eac.List(ctx, poolKindRes.Attr())
-	if err != nil {
-		return err
-	}
-
-	// Create maps of pool ID -> service and pool ID -> short ID
-	poolServiceMap := make(map[string]string)
-	poolShortIdMap := make(map[string]string)
-	for _, e := range poolsRes.Values() {
-		var pool compute_v1alpha.SandboxPool
-		pool.Decode(e.Entity())
-		poolServiceMap[pool.ID.String()] = pool.Service
-		if sid := e.Entity().ShortId(); sid != "" {
-			poolShortIdMap[pool.ID.String()] = sid
+		if !serverPredatesSandboxInventory(err) {
+			return err
+		}
+		entries, err = listSandboxesLegacy(ctx)
+		if err != nil {
+			return err
 		}
 	}
+	entries, deadCount := filter.apply(entries)
 
-	// Build maps of version ID -> short ID and version ID -> app name (best-effort for display)
-	versionShortIdMap := make(map[string]string)
-	versionAppMap := make(map[string]string)
-	if versionKindRes, err := eac.LookupKind(ctx, "app_version"); err == nil {
-		if versionsRes, err := eac.List(ctx, versionKindRes.Attr()); err == nil {
-			for _, e := range versionsRes.Values() {
-				var v core_v1alpha.AppVersion
-				v.Decode(e.Entity())
-				if sid := e.Entity().ShortId(); sid != "" {
-					versionShortIdMap[v.ID.String()] = sid
-				}
-				if !entity.Empty(v.App) {
-					versionAppMap[v.ID.String()] = v.App.String()
-				}
-			}
-		}
-	}
-
-	// Build a map of node entity ID -> human-readable name
-	nodeKindRes, err := eac.LookupKind(ctx, "node")
-	if err != nil {
-		return err
-	}
-	nodesRes, err := eac.List(ctx, nodeKindRes.Attr())
-	if err != nil {
-		return err
-	}
-	nodeNameMap := make(map[entity.Id]string)
-	for _, e := range nodesRes.Values() {
-		var node compute_v1alpha.Node
-		node.Decode(e.Entity())
-		name := node.Name
-		if name == "" {
-			name = node.RunnerId
-			if len(name) > 12 {
-				name = name[:12]
-			}
-		}
-		if name != "" {
-			nodeNameMap[node.ID] = name
-		}
-	}
-
-	// Determine whether to exclude dead sandboxes.
-	// Dead sandboxes are excluded by default unless --all is passed
-	// or --status explicitly requests a dead state.
-	excludeDead := !opts.All && opts.Status == ""
-
-	// For JSON output, just filter and return the raw sandbox structs with pool info
 	if opts.IsJSON() {
-		var sandboxes []struct {
-			compute_v1alpha.Sandbox
-			App     string `json:"app,omitempty"`
-			Pool    string `json:"pool,omitempty"`
-			Service string `json:"service,omitempty"`
-			Address string `json:"address,omitempty"`
-			Runner  string `json:"runner,omitempty"`
-		}
-
-		for _, e := range res.Values() {
-			var sandbox compute_v1alpha.Sandbox
-			sandbox.Decode(e.Entity())
-
-			// Extract pool label from metadata
-			var md core_v1alpha.Metadata
-			md.Decode(e.Entity())
-			poolLabel, _ := md.Labels.Get("pool")
-
-			// Get service from pool
-			service := poolServiceMap[poolLabel]
-
-			if !filter.keep(ui.CleanEntityID(versionAppMap[sandbox.Spec.Version.String()]), service) {
-				continue
-			}
-
-			if excludeDead && compute.SandboxDead(sandbox.Status) {
-				continue
-			}
-
-			// Apply status filter if specified
-			if opts.Status != "" {
-				status := string(sandbox.Status)
-				cleanStatus := ui.CleanStatus(status)
-				if cleanStatus != opts.Status {
-					continue
-				}
-			}
-
-			// Get network address
-			address := ""
-			if len(sandbox.Network) > 0 && sandbox.Network[0].Address != "" {
-				address = sandbox.Network[0].Address
-			}
-
-			// Resolve runner from schedule
-			var sch compute_v1alpha.Schedule
-			sch.Decode(e.Entity())
-			runner := ""
-			if !entity.Empty(sch.Key.Node) {
-				runner = nodeNameMap[sch.Key.Node]
-			}
-
-			// Resolve app name from version
-			appName := ""
-			if name, ok := versionAppMap[sandbox.Spec.Version.String()]; ok {
-				appName = name
-			}
-
-			entry := struct {
-				compute_v1alpha.Sandbox
-				App     string `json:"app,omitempty"`
-				Pool    string `json:"pool,omitempty"`
-				Service string `json:"service,omitempty"`
-				Address string `json:"address,omitempty"`
-				Runner  string `json:"runner,omitempty"`
-			}{
-				Sandbox: sandbox,
-				App:     appName,
-				Pool:    poolLabel,
-				Service: service,
-				Address: address,
-				Runner:  runner,
-			}
-			sandboxes = append(sandboxes, entry)
-		}
-
-		return PrintJSON(sandboxes)
+		return PrintJSONTo(ctx.Stdout, entries)
 	}
 
-	// Table output - all the UI formatting logic
-	var rows []ui.Row
-	var deadCount int
+	rows := make([]ui.Row, 0, len(entries))
 	headers := []string{"ID", "APP", "VERSION", "SERVICE", "POOL", "ADDRESS", "RUNNER", "STATUS", "CREATED", "UPDATED"}
 
-	for _, e := range res.Values() {
-		// Decode the sandbox entity
-		var sandbox compute_v1alpha.Sandbox
-		sandbox.Decode(e.Entity())
-
-		// Extract pool label from metadata
-		var md core_v1alpha.Metadata
-		md.Decode(e.Entity())
-		poolLabel, _ := md.Labels.Get("pool")
-
-		// Resolve app name from version
-		appName := ui.CleanEntityID(versionAppMap[sandbox.Spec.Version.String()])
-
-		// Narrowing comes before the dead check so that the "N dead hidden"
-		// tally counts what this listing is actually about. Reporting the
-		// cluster's dead sandboxes under `--app foo` would be a non-sequitur.
-		if !filter.keep(appName, poolServiceMap[poolLabel]) {
-			continue
-		}
-
-		if excludeDead && compute.SandboxDead(sandbox.Status) {
-			deadCount++
-			continue
-		}
-
-		// Get status string
-		status := string(sandbox.Status)
-		if status == "" {
-			status = "unknown"
-		}
-
-		// Clean status for filtering (removes "status." prefix)
-		cleanStatus := ui.CleanStatus(status)
-
-		// Filter by status if specified
-		if opts.Status != "" && cleanStatus != opts.Status {
-			continue
-		}
-
-		poolLabelDisplay := poolLabel
+	for _, entry := range entries {
+		poolLabelDisplay := entry.Pool
 		if poolLabelDisplay == "" {
 			poolLabelDisplay = "-"
 		} else {
 			poolLabelDisplay = ui.CleanEntityID(poolLabelDisplay)
 		}
 
-		// Get service from pool
-		service := poolServiceMap[poolLabel]
+		service := entry.Service
 		if service == "" {
 			service = "-"
 		}
 
-		// Get network address
-		address := "-"
-		if len(sandbox.Network) > 0 && sandbox.Network[0].Address != "" {
-			address = sandbox.Network[0].Address
+		address := entry.Address
+		if address == "" {
+			address = "-"
 		}
 
-		// Resolve runner from schedule
-		var sch compute_v1alpha.Schedule
-		sch.Decode(e.Entity())
-		runnerName := "-"
-		if !entity.Empty(sch.Key.Node) {
-			if name, ok := nodeNameMap[sch.Key.Node]; ok {
-				runnerName = name
-			}
+		runnerName := entry.Runner
+		if runnerName == "" {
+			runnerName = "-"
 		}
 
-		// Apply all UI formatting for table display
-		sandboxId := ui.CleanEntityID(sandbox.ID.String())
-		if !ctx.Verbose() {
-			sandboxId = ui.BriefId(e.Entity())
+		sandboxID := ui.CleanEntityID(entry.ID)
+		if !ctx.Verbose() && entry.shortID != "" {
+			sandboxID = entry.shortID
 		}
 
-		// Resolve version display: prefer short ID
-		versionDisplay := ui.DisplayAppVersion(sandbox.Spec.Version.String())
-		if shortId, ok := versionShortIdMap[sandbox.Spec.Version.String()]; ok {
-			versionDisplay = shortId
+		versionDisplay := ui.DisplayAppVersion(entry.Version)
+		if entry.versionShortID != "" {
+			versionDisplay = entry.versionShortID
 		}
 
-		// Resolve pool display: prefer short ID
-		if shortId, ok := poolShortIdMap[poolLabel]; ok {
-			poolLabelDisplay = shortId
+		if entry.poolShortID != "" {
+			poolLabelDisplay = entry.poolShortID
 		}
 
-		appDisplay := appName
+		appDisplay := entry.App
 		if appDisplay == "" {
 			appDisplay = "-"
 		}
 
 		rows = append(rows, ui.Row{
-			sandboxId,
+			sandboxID,
 			appDisplay,
 			versionDisplay,
 			service,
 			poolLabelDisplay,
 			address,
 			runnerName,
-			ui.DisplayStatus(status),
-			humanFriendlyTimestamp(time.UnixMilli(e.CreatedAt())),
-			humanFriendlyTimestamp(time.UnixMilli(e.UpdatedAt())),
+			ui.DisplayStatus(entry.Status),
+			humanFriendlyTimestamp(entry.createdAt),
+			humanFriendlyTimestamp(entry.updatedAt),
 		})
 	}
 
@@ -360,6 +204,187 @@ func SandboxList(ctx *Context, opts struct {
 	}
 
 	return nil
+}
+
+// serverPredatesSandboxInventory distinguishes an old server from a current
+// server refusing or failing the request. Falling back after an authorization
+// error would turn the raw entity API into a privilege bypass.
+func serverPredatesSandboxInventory(err error) bool {
+	return errors.Is(err, rpc.ErrResolveLookup)
+}
+
+func listSandboxesRPC(ctx *Context) ([]sandboxListEntry, error) {
+	client, err := ctx.RPCClient("dev.miren.runtime/sandboxes")
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	result, err := compute_v1alpha.NewSandboxesClient(client).List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]sandboxListEntry, 0, len(result.Sandboxes()))
+	for _, sb := range result.Sandboxes() {
+		entries = append(entries, newSandboxListEntry(
+			sb.Id(), sb.ShortId(), sb.App(), sb.Version(), sb.VersionShortId(),
+			sb.Service(), sb.Pool(), sb.PoolShortId(), sb.Address(), sb.Runner(),
+			sb.Status(), sb.CreatedAt(), sb.UpdatedAt(),
+		))
+	}
+
+	return entries, nil
+}
+
+// listSandboxesLegacy keeps a current CLI useful against a server from before
+// the sandbox inventory capability. Although it must read raw entities, it
+// converts each one into the allow-listed entry immediately; rendering never
+// receives the Sandbox and therefore cannot serialize its execution spec.
+func listSandboxesLegacy(ctx *Context) ([]sandboxListEntry, error) {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	return listSandboxesFromEntities(ctx, entityserver_v1alpha.NewEntityAccessClient(client))
+}
+
+func listSandboxesFromEntities(
+	ctx context.Context,
+	eac *entityserver_v1alpha.EntityAccessClient,
+) ([]sandboxListEntry, error) {
+	kindRes, err := eac.LookupKind(ctx, "sandbox")
+	if err != nil {
+		return nil, err
+	}
+	res, err := eac.List(ctx, kindRes.Attr())
+	if err != nil {
+		return nil, err
+	}
+
+	poolKindRes, err := eac.LookupKind(ctx, "sandbox_pool")
+	if err != nil {
+		return nil, err
+	}
+	poolsRes, err := eac.List(ctx, poolKindRes.Attr())
+	if err != nil {
+		return nil, err
+	}
+	poolServices := make(map[string]string)
+	poolShortIDs := make(map[string]string)
+	for _, e := range poolsRes.Values() {
+		var pool compute_v1alpha.SandboxPool
+		pool.Decode(e.Entity())
+		poolServices[pool.ID.String()] = pool.Service
+		if shortID := e.Entity().ShortId(); shortID != "" {
+			poolShortIDs[pool.ID.String()] = shortID
+		}
+	}
+
+	versionShortIDs := make(map[string]string)
+	versionApps := make(map[string]string)
+	if versionKindRes, err := eac.LookupKind(ctx, "app_version"); err == nil {
+		if versionsRes, err := eac.List(ctx, versionKindRes.Attr()); err == nil {
+			for _, e := range versionsRes.Values() {
+				var version core_v1alpha.AppVersion
+				version.Decode(e.Entity())
+				if shortID := e.Entity().ShortId(); shortID != "" {
+					versionShortIDs[version.ID.String()] = shortID
+				}
+				if !entity.Empty(version.App) {
+					versionApps[version.ID.String()] = ui.CleanEntityID(version.App.String())
+				}
+			}
+		}
+	}
+
+	nodeKindRes, err := eac.LookupKind(ctx, "node")
+	if err != nil {
+		return nil, err
+	}
+	nodesRes, err := eac.List(ctx, nodeKindRes.Attr())
+	if err != nil {
+		return nil, err
+	}
+	nodeNames := make(map[entity.Id]string)
+	for _, e := range nodesRes.Values() {
+		var node compute_v1alpha.Node
+		node.Decode(e.Entity())
+		name := node.Name
+		if name == "" {
+			name = node.RunnerId
+			if len(name) > 12 {
+				name = name[:12]
+			}
+		}
+		if name != "" {
+			nodeNames[node.ID] = name
+		}
+	}
+
+	entries := make([]sandboxListEntry, 0, len(res.Values()))
+	for _, e := range res.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(e.Entity())
+
+		var metadata core_v1alpha.Metadata
+		metadata.Decode(e.Entity())
+		pool, _ := metadata.Labels.Get("pool")
+		service := poolServices[pool]
+		app := versionApps[sb.Spec.Version.String()]
+
+		address := ""
+		if len(sb.Network) > 0 {
+			address = sb.Network[0].Address
+		}
+
+		var schedule compute_v1alpha.Schedule
+		schedule.Decode(e.Entity())
+		runner := ""
+		if !entity.Empty(schedule.Key.Node) {
+			runner = nodeNames[schedule.Key.Node]
+		}
+
+		entries = append(entries, newSandboxListEntry(
+			sb.ID.String(), e.Entity().ShortId(), app, sb.Spec.Version.String(),
+			versionShortIDs[sb.Spec.Version.String()], service, pool, poolShortIDs[pool],
+			address, runner, string(sb.Status), e.CreatedAt(), e.UpdatedAt(),
+		))
+	}
+
+	return entries, nil
+}
+
+func newSandboxListEntry(
+	id, shortID, app, version, versionShortID, service, pool, poolShortID,
+	address, runner, status string,
+	createdAtMillis, updatedAtMillis int64,
+) sandboxListEntry {
+	createdAt := time.UnixMilli(createdAtMillis)
+	updatedAt := time.UnixMilli(updatedAtMillis)
+	status = ui.CleanStatus(status)
+	if status == "" {
+		status = "unknown"
+	}
+	return sandboxListEntry{
+		ID:             id,
+		App:            app,
+		Version:        version,
+		Service:        service,
+		Pool:           pool,
+		Address:        address,
+		Runner:         runner,
+		Status:         status,
+		CreatedAt:      createdAt.UTC().Format(time.RFC3339),
+		UpdatedAt:      updatedAt.UTC().Format(time.RFC3339),
+		shortID:        shortID,
+		versionShortID: versionShortID,
+		poolShortID:    poolShortID,
+		createdAt:      createdAt,
+		updatedAt:      updatedAt,
+	}
 }
 
 // humanFriendlyTimestamp formats a timestamp into a human-friendly format like Docker's

--- a/cli/commands/sandbox_list_test.go
+++ b/cli/commands/sandbox_list_test.go
@@ -1,61 +1,24 @@
 package commands
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/ui"
 )
-
-func TestSandboxFilterKeep(t *testing.T) {
-	tests := []struct {
-		name    string
-		filter  sandboxFilter
-		app     string
-		service string
-		want    bool
-	}{
-		{name: "no filter keeps everything", app: "myapp", service: "web", want: true},
-		{
-			name:   "app matches",
-			filter: sandboxFilter{app: "myapp"},
-			app:    "myapp", service: "worker", want: true,
-		},
-		{
-			name:   "another app is dropped",
-			filter: sandboxFilter{app: "myapp"},
-			app:    "otherapp", service: "web", want: false,
-		},
-		{
-			name:   "service matches",
-			filter: sandboxFilter{service: "worker"},
-			app:    "myapp", service: "worker", want: true,
-		},
-		{
-			name:   "app and service must both match",
-			filter: sandboxFilter{app: "myapp", service: "worker"},
-			app:    "myapp", service: "web", want: false,
-		},
-		{
-			// A sandbox with no pool has no service to speak of, and the table
-			// renders that as "-". Asking for a service should exclude it
-			// rather than sweep it in.
-			name:   "a sandbox with no service is dropped by a service filter",
-			filter: sandboxFilter{service: "web"},
-			app:    "myapp", service: "", want: false,
-		},
-		{
-			name:   "a sandbox with no app is dropped by an app filter",
-			filter: sandboxFilter{app: "myapp"},
-			app:    "", service: "web", want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.filter.keep(tt.app, tt.service))
-		})
-	}
-}
 
 func TestSandboxFilterDescribe(t *testing.T) {
 	require.Empty(t, sandboxFilter{}.describe())
@@ -64,4 +27,159 @@ func TestSandboxFilterDescribe(t *testing.T) {
 	require.Equal(t,
 		` for app "myapp", service "web"`,
 		sandboxFilter{app: "myapp", service: "web"}.describe())
+}
+
+func TestSandboxFilterApply(t *testing.T) {
+	entries := []sandboxListEntry{
+		{ID: "running", App: "shop", Service: "web", Status: "running"},
+		{ID: "stopped", App: "shop", Service: "worker", Status: "stopped"},
+		{ID: "dead", App: "other", Service: "web", Status: "dead"},
+	}
+
+	tests := []struct {
+		name       string
+		filter     sandboxFilter
+		wantIDs    []string
+		wantHidden int64
+	}{
+		{name: "default hides terminal sandboxes", wantIDs: []string{"running"}, wantHidden: 2},
+		{name: "all includes terminal sandboxes", filter: sandboxFilter{includeDead: true}, wantIDs: []string{"running", "stopped", "dead"}},
+		{name: "explicit status overrides default", filter: sandboxFilter{status: "dead"}, wantIDs: []string{"dead"}},
+		{name: "app filtering precedes hidden count", filter: sandboxFilter{app: "shop"}, wantIDs: []string{"running"}, wantHidden: 1},
+		{name: "service filter", filter: sandboxFilter{includeDead: true, service: "worker"}, wantIDs: []string{"stopped"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, hidden := test.filter.apply(entries)
+			ids := make([]string, 0, len(got))
+			for _, entry := range got {
+				ids = append(ids, entry.ID)
+			}
+			require.Equal(t, test.wantIDs, ids)
+			require.Equal(t, test.wantHidden, hidden)
+		})
+	}
+}
+
+func TestSandboxListEntryJSONIsInventoryOnly(t *testing.T) {
+	entry := newSandboxListEntry(
+		"sandbox/shop-web-abc", "sb-abc", "shop", "app_version/shop-v1", "v1",
+		"web", "pool/shop-web", "sp-web", "10.0.0.4", "runner-1", "status.running",
+		1_725_000_000_000, 1_725_000_060_000,
+	)
+
+	var out bytes.Buffer
+	require.NoError(t, PrintJSONTo(&out, []sandboxListEntry{entry}))
+	assert.JSONEq(t, `[
+		{
+			"id": "sandbox/shop-web-abc",
+			"app": "shop",
+			"version": "app_version/shop-v1",
+			"service": "web",
+			"pool": "pool/shop-web",
+			"address": "10.0.0.4",
+			"runner": "runner-1",
+			"status": "running",
+			"created_at": "2024-08-30T06:40:00Z",
+			"updated_at": "2024-08-30T06:41:00Z"
+		}
+	]`, out.String())
+	assert.NotContains(t, out.String(), "spec")
+	assert.NotContains(t, out.String(), "container")
+	assert.NotContains(t, out.String(), "env")
+	assert.NotContains(t, out.String(), "short_id")
+}
+
+func TestSandboxListEmptyJSONIsArray(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, PrintJSONTo(&out, make([]sandboxListEntry, 0)))
+	assert.JSONEq(t, `[]`, out.String())
+}
+
+func TestLegacySandboxListDropsExecutionSpec(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	r := require.New(t)
+	// The mock schema loader stores these aliases as untyped strings, while the
+	// production store validates them into keywords. Seed the validated form so
+	// this test drives LookupKind exactly as an old server does.
+	_, err := inmem.Store.UpdateEntity(ctx, compute_v1alpha.Schema, entity.New(
+		entity.Keyword(entity.SchemaKind, "sandbox"),
+		entity.Keyword(entity.SchemaKind, "sandbox_pool"),
+		entity.Keyword(entity.SchemaKind, "node"),
+	))
+	r.NoError(err)
+	_, err = inmem.Store.UpdateEntity(ctx, core_v1alpha.Schema, entity.New(
+		entity.Keyword(entity.SchemaKind, "app_version"),
+	))
+	r.NoError(err)
+
+	versionID, err := inmem.Client.Create(ctx, "shop-v1", &core_v1alpha.AppVersion{
+		App: entity.Id("app/shop"),
+	})
+	r.NoError(err)
+	poolID, err := inmem.Client.Create(ctx, "shop-web", &compute_v1alpha.SandboxPool{Service: "web"})
+	r.NoError(err)
+
+	const canary = "mir1765-legacy-fallback-must-not-return-this"
+	_, err = inmem.Client.Create(ctx, "shop-web-running", &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Spec: compute_v1alpha.SandboxSpec{
+			Version: versionID,
+			Container: []compute_v1alpha.SandboxSpecContainer{{
+				Name: "app",
+				Env:  []string{"DATABASE_URL=" + canary},
+			}},
+		},
+	}, entityserver.WithLabels(types.LabelSet("pool", poolID.String())))
+	r.NoError(err)
+	_, err = inmem.Client.Create(ctx, "shop-web-dead", &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.DEAD,
+		Spec: compute_v1alpha.SandboxSpec{
+			Version: versionID,
+			Container: []compute_v1alpha.SandboxSpecContainer{{
+				Name: "app",
+				Env:  []string{"DATABASE_URL=" + canary},
+			}},
+		},
+	}, entityserver.WithLabels(types.LabelSet("pool", poolID.String())))
+	r.NoError(err)
+
+	entries, err := listSandboxesFromEntities(ctx, inmem.EAC)
+	r.NoError(err)
+	r.Len(entries, 2)
+	visible, hidden := (sandboxFilter{}).apply(entries)
+	r.Len(visible, 1)
+	r.Equal(int64(1), hidden)
+	r.Equal("running", visible[0].Status)
+	r.Equal("shop", visible[0].App)
+	r.Equal("web", visible[0].Service)
+
+	wire, err := json.Marshal(entries)
+	r.NoError(err)
+	assert.NotContains(t, string(wire), canary)
+	assert.NotContains(t, string(wire), `"spec"`)
+	assert.NotContains(t, string(wire), `"env"`)
+}
+
+func TestServerPredatesSandboxInventoryOnlyForLookupFailures(t *testing.T) {
+	const capability = "dev.miren.runtime/sandboxes"
+	const remote = "prod:8443"
+
+	lookup := rpc.NewResolveLookupError(capability, remote, "unknown object: "+capability)
+	assert.True(t, serverPredatesSandboxInventory(lookup))
+	assert.True(t, serverPredatesSandboxInventory(&ui.Diagnostic{Summary: "old cluster", Cause: lookup}))
+
+	notOldServer := []error{
+		rpc.NewResolveUnreachableError(capability, remote, 5*time.Second, errors.New("dial")),
+		rpc.NewResolveWentSilentError(capability, remote, 30*time.Second, errors.New("reset")),
+		rpc.NewResolveNoAnswerError(capability, remote, 8*time.Second, errors.New("timeout")),
+		rpc.NewResolveStatusError(capability, remote, 401),
+		errors.New("boom"),
+	}
+	for _, err := range notOldServer {
+		assert.False(t, serverPredatesSandboxInventory(err), "%v must not activate the raw fallback", err)
+	}
 }

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -101,6 +101,7 @@ import (
 	routessrv "miren.dev/runtime/servers/routes"
 	runnerserver "miren.dev/runtime/servers/runner"
 	"miren.dev/runtime/servers/runnertelemetry"
+	sandboxserver "miren.dev/runtime/servers/sandbox"
 	secretsrv "miren.dev/runtime/servers/secret"
 	sqlitebackupsrv "miren.dev/runtime/servers/sqlitebackup"
 	telemetrysrv "miren.dev/runtime/servers/telemetry"
@@ -1575,6 +1576,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	server.ExposeValue("dev.miren.runtime/app", app_v1alpha.AdaptCrud(ai))
 	server.ExposeValue("dev.miren.runtime/app-status", app_v1alpha.AdaptAppStatus(ai))
 	server.ExposeValue("dev.miren.runtime/app-runs", app_v1alpha.AdaptRuns(ai))
+	server.ExposeValue("dev.miren.runtime/sandboxes", compute_v1alpha.AdaptSandboxes(sandboxserver.NewServer(c.Log, ec)))
 
 	addonsServer := app.NewAddonsServer(c.Log, ec, addonRegistry, addon.NewRegistryImageChecker())
 	server.ExposeValue("dev.miren.runtime/addons", app_v1alpha.AdaptAddons(addonsServer))

--- a/docs/docs/command/sandbox-list.md
+++ b/docs/docs/command/sandbox-list.md
@@ -8,6 +8,10 @@ description: "List sandboxes (excludes dead by default)"
 
 List sandboxes (excludes dead by default)
 
+List the sandboxes currently known to the cluster. Dead sandboxes are hidden unless you pass `--all` or ask for the `dead` status explicitly.
+
+The JSON form is a stable inventory view with the same operational fields as the table. It deliberately excludes the raw sandbox execution spec, which contains resolved environment values and may include secrets. For low-level inspection, use the explicitly privileged `miren debug entity list -k sandbox` command.
+
 ## Usage
 
 ```bash

--- a/pkg/workloadroles/roles.go
+++ b/pkg/workloadroles/roles.go
@@ -104,6 +104,7 @@ var (
 		"runnerregistration": set("listinvites", "listrunners", "workloadissuerinfo"),
 		"netdb":              set("listleases", "status"),
 		"sandboxmetrics":     set("snapshot"),
+		"sandboxes":          set("list"),
 		"outboardcontrol":    set("health"),
 		"userquery":          set("whoami"),
 		"builder":            set("analyzeapp"),

--- a/pkg/workloadroles/roles_test.go
+++ b/pkg/workloadroles/roles_test.go
@@ -149,6 +149,7 @@ func TestRoleMembershipSpotChecks(t *testing.T) {
 		{RoleAppAdmin, [2]string{"crud", "setenvvar"}, [2]string{"crud", "list"}},
 		{RoleAppAdmin, [2]string{"sandboxexec", "exec"}, [2]string{"crud", "destroy"}},
 		{RoleClusterReadonly, [2]string{"crud", "list"}, [2]string{"crud", "setenvvar"}},
+		{RoleClusterReadonly, [2]string{"sandboxes", "list"}, [2]string{"sandboxexec", "exec"}},
 		{RoleClusterReadonly, [2]string{"logs", "sandboxlogs"}, [2]string{"sandboxexec", "exec"}},
 		// cluster-deployer deploys/configures any app but does not do app
 		// lifecycle: crud.new/destroy are cluster-admin's.

--- a/servers/sandbox/server.go
+++ b/servers/sandbox/server.go
@@ -1,0 +1,144 @@
+// Package sandbox serves the operator-facing sandbox inventory.
+//
+// Sandbox entities are execution records and contain resolved container
+// environment values. This package is the boundary that turns those raw
+// records into a deliberately small, safe inventory response.
+package sandbox
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity"
+)
+
+type Server struct {
+	log *slog.Logger
+	ec  *entityserver.Client
+}
+
+func NewServer(log *slog.Logger, ec *entityserver.Client) *Server {
+	return &Server{log: log.With("module", "sandbox-inventory"), ec: ec}
+}
+
+var _ compute_v1alpha.Sandboxes = (*Server)(nil)
+
+func (s *Server) List(ctx context.Context, state *compute_v1alpha.SandboxesList) error {
+	pools, err := s.ec.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool))
+	if err != nil {
+		return err
+	}
+	poolServices := make(map[string]string)
+	poolShortIDs := make(map[string]string)
+	for pools.Next() {
+		var pool compute_v1alpha.SandboxPool
+		if err := pools.Read(&pool); err != nil {
+			return err
+		}
+		poolServices[pool.ID.String()] = pool.Service
+		if shortID := pools.Entity().ShortId(); shortID != "" {
+			poolShortIDs[pool.ID.String()] = shortID
+		}
+	}
+
+	// Version metadata is best-effort display enrichment. A missing version
+	// must not make the underlying sandbox disappear from an inventory query.
+	versionApps := make(map[string]string)
+	versionShortIDs := make(map[string]string)
+	if versions, listErr := s.ec.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion)); listErr != nil {
+		s.log.Warn("could not enrich sandbox inventory with app versions", "error", listErr)
+	} else {
+		for versions.Next() {
+			var version core_v1alpha.AppVersion
+			if err := versions.Read(&version); err != nil {
+				return err
+			}
+			versionApps[version.ID.String()] = strings.TrimPrefix(version.App.String(), "app/")
+			if shortID := versions.Entity().ShortId(); shortID != "" {
+				versionShortIDs[version.ID.String()] = shortID
+			}
+		}
+	}
+
+	nodes, err := s.ec.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindNode))
+	if err != nil {
+		return err
+	}
+	nodeNames := make(map[entity.Id]string)
+	for nodes.Next() {
+		var node compute_v1alpha.Node
+		if err := nodes.Read(&node); err != nil {
+			return err
+		}
+		name := node.Name
+		if name == "" {
+			name = node.RunnerId
+			if len(name) > 12 {
+				name = name[:12]
+			}
+		}
+		if name != "" {
+			nodeNames[node.ID] = name
+		}
+	}
+
+	sandboxes, err := s.ec.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return err
+	}
+
+	items := make([]*compute_v1alpha.SandboxInfo, 0, sandboxes.Length())
+	for sandboxes.Next() {
+		var sb compute_v1alpha.Sandbox
+		if err := sandboxes.Read(&sb); err != nil {
+			return err
+		}
+		ent := sandboxes.Entity()
+
+		var metadata core_v1alpha.Metadata
+		metadata.Decode(ent)
+		pool, _ := metadata.Labels.Get("pool")
+		service := poolServices[pool]
+		app := versionApps[sb.Spec.Version.String()]
+
+		address := ""
+		if len(sb.Network) > 0 {
+			address = sb.Network[0].Address
+		}
+
+		var schedule compute_v1alpha.Schedule
+		schedule.Decode(ent)
+		runner := ""
+		if !entity.Empty(schedule.Key.Node) {
+			runner = nodeNames[schedule.Key.Node]
+		}
+
+		status := strings.TrimPrefix(string(sb.Status), "status.")
+		if status == "" {
+			status = "unknown"
+		}
+
+		item := new(compute_v1alpha.SandboxInfo)
+		item.SetId(sb.ID.String())
+		item.SetShortId(ent.ShortId())
+		item.SetApp(app)
+		item.SetVersion(sb.Spec.Version.String())
+		item.SetVersionShortId(versionShortIDs[sb.Spec.Version.String()])
+		item.SetService(service)
+		item.SetPool(pool)
+		item.SetPoolShortId(poolShortIDs[pool])
+		item.SetAddress(address)
+		item.SetRunner(runner)
+		item.SetStatus(status)
+		item.SetCreatedAt(ent.GetCreatedAt().UnixMilli())
+		item.SetUpdatedAt(ent.GetUpdatedAt().UnixMilli())
+		items = append(items, item)
+	}
+
+	state.Results().SetSandboxes(items)
+	return nil
+}

--- a/servers/sandbox/server_test.go
+++ b/servers/sandbox/server_test.go
@@ -1,0 +1,95 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+func TestListReturnsCompleteSafeInventory(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	r := require.New(t)
+
+	appID, err := inmem.Client.Create(ctx, "shop", &core_v1alpha.App{})
+	r.NoError(err)
+	versionID, err := inmem.Client.Create(ctx, "shop-v1", &core_v1alpha.AppVersion{
+		App:     appID,
+		Version: "shop-v1",
+	})
+	r.NoError(err)
+	poolID, err := inmem.Client.Create(ctx, "shop-web", &compute_v1alpha.SandboxPool{
+		App:         appID,
+		Service:     "web",
+		SandboxSpec: compute_v1alpha.SandboxSpec{Version: versionID},
+	})
+	r.NoError(err)
+	nodeID, err := inmem.Client.Create(ctx, "runner-one", &compute_v1alpha.Node{Name: "runner-one"})
+	r.NoError(err)
+
+	const secretCanary = "mir1765-server-must-not-return-this"
+	runningID, err := inmem.Client.Create(ctx, "shop-web-running", &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Spec: compute_v1alpha.SandboxSpec{
+			Version: versionID,
+			Container: []compute_v1alpha.SandboxSpecContainer{{
+				Name:  "app",
+				Image: "example.test/shop@sha256:abc",
+				Env:   []string{"DATABASE_URL=" + secretCanary},
+			}},
+		},
+		Network: []compute_v1alpha.Network{{Address: "10.0.0.4"}},
+	}, entityserver.WithLabels(types.LabelSet("pool", poolID.String())))
+	r.NoError(err)
+	r.NoError(inmem.Client.UpdateAttrs(ctx, runningID,
+		(&compute_v1alpha.Schedule{Key: compute_v1alpha.Key{Node: nodeID}}).Encode()))
+
+	deadID, err := inmem.Client.Create(ctx, "shop-web-dead", &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.DEAD,
+		Spec:   compute_v1alpha.SandboxSpec{Version: versionID},
+	}, entityserver.WithLabels(types.LabelSet("pool", poolID.String())))
+	r.NoError(err)
+
+	server := NewServer(testutils.TestLogger(t), inmem.Client)
+	client := compute_v1alpha.NewSandboxesClient(rpc.LocalClient(compute_v1alpha.AdaptSandboxes(server)))
+
+	result, err := client.List(ctx)
+	r.NoError(err)
+	r.Len(result.Sandboxes(), 2)
+
+	byID := make(map[string]*compute_v1alpha.SandboxInfo)
+	for _, sandbox := range result.Sandboxes() {
+		byID[sandbox.Id()] = sandbox
+	}
+	got := byID[runningID.String()]
+	r.NotNil(got)
+	r.Equal(runningID.String(), got.Id())
+	r.Equal("shop", got.App())
+	r.Equal(versionID.String(), got.Version())
+	r.Equal("web", got.Service())
+	r.Equal(poolID.String(), got.Pool())
+	r.Equal("10.0.0.4", got.Address())
+	r.Equal("runner-one", got.Runner())
+	r.Equal("running", got.Status())
+	r.NotZero(got.CreatedAt())
+	r.NotZero(got.UpdatedAt())
+	dead := byID[deadID.String()]
+	r.NotNil(dead)
+	r.Equal("dead", dead.Status())
+
+	wire, err := json.Marshal(result.Sandboxes())
+	r.NoError(err)
+	assert.NotContains(t, string(wire), secretCanary)
+	assert.NotContains(t, string(wire), `"spec"`)
+	assert.NotContains(t, string(wire), `"env"`)
+}


### PR DESCRIPTION
`miren sandbox list --json` had a nasty surprise: it printed raw sandbox entities, including the resolved container environment. Secrets and all.

This gives sandbox listing its own RPC with a deliberately boring, allowlisted response. Table and JSON output now use the same safe inventory data. A new CLI only falls back to raw entities when it can tell that the server is too old to have the new RPC.

The projection is pretty bespoke, and I don’t think we should pretend it’s the final shape of this API. It fixes the real exposure without making us design generic filtered entity views at the same time. As more CLI commands move away from broad CRUD entity access, we can look for the common shape and add pagination where it actually becomes useful.

Compatibility also means carrying some of the old world for now. Older CLIs still use raw entities against new servers, and new CLIs use the raw fallback against old servers. Tightening broad entity access later may break that fallback, which feels like an acceptable way to finish the transition.

Closes MIR-1765