### PR TITLE
Preserve and repair entity creation metadata

### DIFF
--- a/api/core/cloud_export_test.go
+++ b/api/core/cloud_export_test.go
@@ -40,6 +40,9 @@ func TestCloudExportFiltersDeploymentCustodyFields(t *testing.T) {
 		deployment.Encode,
 		entity.Ref(entity.DBId, deployment.ID),
 		entity.String(entity.DBShortId, "dep-1"),
+		entity.Int64(entity.Revision, 42),
+		entity.Time(entity.CreatedAt, started),
+		entity.Time(entity.UpdatedAt, started.Add(time.Minute)),
 	)
 
 	marker, ok := source.Get(core_v1alpha.CloudExportContract.MarkerID())

--- a/controllers/deploymentattempts/controller.go
+++ b/controllers/deploymentattempts/controller.go
@@ -194,6 +194,16 @@ func (c *Controller) migrateDeployment(ctx context.Context, ent *entity.Entity) 
 
 	var dep core_v1alpha.Deployment
 	dep.Decode(ent)
+	preferredCreatedAt := dep.StartedAt
+	if preferredCreatedAt.IsZero() {
+		preferredCreatedAt, _ = time.Parse(time.RFC3339, dep.DeployedBy.Timestamp)
+	}
+	var err error
+	ent, err = c.repairExportTimestamps(ctx, ent, preferredCreatedAt)
+	if err != nil {
+		return err
+	}
+	dep.Decode(ent)
 	rec := &deploylifecycle.Record{Deployment: &dep}
 	if rec.Canonical() {
 		return nil
@@ -239,7 +249,7 @@ func (c *Controller) migrateDeployment(ctx context.Context, ent *entity.Entity) 
 	if started, err := time.Parse(time.RFC3339, dep.DeployedBy.Timestamp); err == nil {
 		attrs = append(attrs, entity.Time(core_v1alpha.DeploymentStartedAtId, started))
 	}
-	_, err := c.Store.PatchEntity(ctx, entity.New(attrs), entity.WithFromRevision(ent.GetRevision()))
+	_, err = c.Store.PatchEntity(ctx, entity.New(attrs), entity.WithFromRevision(ent.GetRevision()))
 	return err
 }
 
@@ -257,6 +267,11 @@ func (c *Controller) legacyAppVersion(ctx context.Context, ref string) *entity.E
 }
 
 func (c *Controller) migrateVersion(ctx context.Context, ent *entity.Entity) error {
+	var err error
+	ent, err = c.repairExportTimestamps(ctx, ent, time.Time{})
+	if err != nil {
+		return err
+	}
 	var version core_v1alpha.AppVersion
 	version.Decode(ent)
 	if !version.Source.Empty() {
@@ -299,6 +314,11 @@ func (c *Controller) migrateVersion(ctx context.Context, ent *entity.Entity) err
 }
 
 func (c *Controller) migrateApp(ctx context.Context, ent *entity.Entity) error {
+	var err error
+	ent, err = c.repairExportTimestamps(ctx, ent, time.Time{})
+	if err != nil {
+		return err
+	}
 	var app core_v1alpha.App
 	app.Decode(ent)
 	if app.ActiveVersion == "" {
@@ -340,6 +360,37 @@ func (c *Controller) migrateApp(ctx context.Context, ent *entity.Entity) error {
 		entity.Ref(core_v1alpha.AppActiveDeploymentId, candidate),
 	), entity.WithFromRevision(ent.GetRevision()))
 	return err
+}
+
+// repairExportTimestamps closes holes left by historical write paths that
+// persisted records without store-managed timestamps. The export contract does
+// not permit that. A deployment's started_at is the best surviving creation
+// boundary; otherwise the earliest timestamp we still know is its last update.
+func (c *Controller) repairExportTimestamps(ctx context.Context, ent *entity.Entity, preferredCreatedAt time.Time) (*entity.Entity, error) {
+	createdAt := ent.GetCreatedAt()
+	updatedAt := ent.GetUpdatedAt()
+	if !createdAt.IsZero() && !updatedAt.IsZero() {
+		return ent, nil
+	}
+	if createdAt.IsZero() {
+		createdAt = preferredCreatedAt
+		if createdAt.IsZero() {
+			createdAt = updatedAt
+		}
+		if createdAt.IsZero() {
+			return nil, errors.New("entity has no timestamp from which to repair db/entity.created")
+		}
+	}
+
+	patch := entity.New(entity.Ref(entity.DBId, ent.Id()))
+	if ent.GetCreatedAt().IsZero() {
+		patch.SetCreatedAt(createdAt)
+	}
+	repaired, err := c.Store.PatchEntity(ctx, patch, entity.WithFromRevision(ent.GetRevision()))
+	if err != nil {
+		return nil, fmt.Errorf("repairing export timestamps: %w", err)
+	}
+	return repaired, nil
 }
 
 func (c *Controller) reconcileDeployment(ctx context.Context, ent *entity.Entity) error {

--- a/controllers/deploymentattempts/controller_test.go
+++ b/controllers/deploymentattempts/controller_test.go
@@ -188,6 +188,32 @@ func TestDeploymentMigrationRediscoversProgressAfterRestart(t *testing.T) {
 	assert.Equal(t, 2, canonical)
 }
 
+func TestDeploymentMigrationRepairsMissingCreationTime(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	started := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	dep := &core_v1alpha.Deployment{
+		ID: "deployment/missing-created-at", AppName: "web", Status: "failed",
+		Outcome: "failed", StartedAt: started,
+	}
+	raw := entity.New(entity.Ref(entity.DBId, dep.ID), dep.Encode())
+	raw.SetRevision(12)
+	raw.SetUpdatedAt(started.Add(time.Hour))
+	raw.Remove(entity.CreatedAt)
+	inmem.Store.AddEntity(dep.ID, raw)
+
+	controller := New(slog.New(slog.NewTextHandler(io.Discard, nil)), inmem.Store, inmem.EAC)
+	require.NoError(t, controller.Step(ctx))
+
+	repaired, err := inmem.Store.GetEntity(ctx, dep.ID)
+	require.NoError(t, err)
+	assert.Equal(t, started, repaired.GetCreatedAt())
+	assert.False(t, repaired.GetUpdatedAt().IsZero())
+	_, _, err = core_v1alpha.CloudExportContract.Filter(repaired)
+	require.NoError(t, err)
+}
+
 func TestVersionMigrationIgnoresDeploymentsWithoutProvenance(t *testing.T) {
 	ctx := context.Background()
 	inmem, cleanup := testutils.NewInMemEntityServer(t)

--- a/pkg/entity/export/contract.go
+++ b/pkg/entity/export/contract.go
@@ -202,15 +202,28 @@ func (c *Contract) Filter(source *entity.Entity) (*entity.Entity, *Policy, error
 		return nil, nil, ErrKindNotExported
 	}
 
-	mandatory := map[entity.Id]struct{}{
-		entity.DBId:      {},
-		entity.Revision:  {},
-		entity.CreatedAt: {},
-		entity.UpdatedAt: {},
+	mandatory := []struct {
+		id   entity.Id
+		kind entity.ValueKind
+	}{
+		{id: entity.DBId, kind: entity.KindId},
+		{id: entity.Revision, kind: entity.KindInt64},
+		{id: entity.CreatedAt, kind: entity.KindTime},
+		{id: entity.UpdatedAt, kind: entity.KindTime},
+	}
+	for _, required := range mandatory {
+		attr, found := source.Get(required.id)
+		if !found {
+			return nil, nil, fmt.Errorf("export entity %s is missing mandatory attribute %s", source.Id(), required.id)
+		}
+		if attr.Value.Kind() != required.kind {
+			return nil, nil, fmt.Errorf("export entity %s mandatory attribute %s has %s value, want %s",
+				source.Id(), required.id, attr.Value.Kind(), required.kind)
+		}
 	}
 	filtered := make([]entity.Attr, 0, len(source.Attrs()))
 	for _, attr := range source.Attrs() {
-		if _, ok := mandatory[attr.ID]; ok {
+		if attr.ID == entity.DBId || attr.ID == entity.Revision || attr.ID == entity.CreatedAt || attr.ID == entity.UpdatedAt {
 			filtered = append(filtered, attr.Clone())
 			continue
 		}

--- a/pkg/entity/export/contract_test.go
+++ b/pkg/entity/export/contract_test.go
@@ -2,15 +2,25 @@ package export
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/pkg/entity"
 )
 
+func exportSource(attrs ...entity.Attr) *entity.Entity {
+	metadata := []entity.Attr{
+		entity.Int64(entity.Revision, 42),
+		entity.Time(entity.CreatedAt, time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)),
+		entity.Time(entity.UpdatedAt, time.Date(2026, 1, 2, 3, 5, 5, 0, time.UTC)),
+	}
+	return entity.New(attrs, metadata)
+}
+
 func TestFilterDropsUnlistedAndNestedAttributes(t *testing.T) {
 	contract := MustParse([]byte(`{"version":1,"target":"cloud","marker":"test/cloud","kinds":[{"id":"test/kind.app","lifecycle":"mirror","attributes":[{"id":"test/app.name","type":"string"},{"id":"test/app.actor","type":"component"},{"id":"test/actor.subject","type":"string","parent":"test/app.actor"}]}]}`))
 
-	source := entity.New(
+	source := exportSource(
 		entity.Ref(entity.DBId, "app/web"),
 		entity.Ref(entity.EntityKind, "test/kind.app"),
 		entity.String("test/app.name", "web"),
@@ -38,7 +48,7 @@ func TestFilterDropsUnlistedAndNestedAttributes(t *testing.T) {
 
 func TestFilterEmitsOnlyTheSelectedExportedKind(t *testing.T) {
 	contract := MustParse([]byte(`{"version":1,"target":"cloud","marker":"test/cloud","kinds":[{"id":"test/kind.app","lifecycle":"mirror","attributes":[{"id":"test/app.name","type":"string"}]}]}`))
-	source := entity.New(
+	source := exportSource(
 		entity.Ref(entity.DBId, "app/web"),
 		entity.Ref(entity.EntityKind, "test/kind.app"),
 		entity.Ref(entity.EntityKind, "test/kind.metadata"),
@@ -55,7 +65,7 @@ func TestFilterEmitsOnlyTheSelectedExportedKind(t *testing.T) {
 
 func TestFilterRejectsMultipleExportedKinds(t *testing.T) {
 	contract := MustParse([]byte(`{"version":1,"target":"cloud","marker":"test/cloud","kinds":[{"id":"test/kind.app","lifecycle":"mirror","attributes":[]},{"id":"test/kind.other","lifecycle":"archive","attributes":[]}]}`))
-	source := entity.New(
+	source := exportSource(
 		entity.Ref(entity.DBId, "app/web"),
 		entity.Ref(entity.EntityKind, "test/kind.app"),
 		entity.Ref(entity.EntityKind, "test/kind.other"),
@@ -67,7 +77,7 @@ func TestFilterRejectsMultipleExportedKinds(t *testing.T) {
 
 func TestFilterRejectsWrongAllowedValueShape(t *testing.T) {
 	contract := MustParse([]byte(`{"version":1,"target":"cloud","marker":"test/cloud","kinds":[{"id":"test/kind.app","lifecycle":"mirror","attributes":[{"id":"test/app.name","type":"string"}]}]}`))
-	source := entity.New(
+	source := exportSource(
 		entity.Ref(entity.DBId, "app/web"),
 		entity.Ref(entity.EntityKind, "test/kind.app"),
 		entity.Int64("test/app.name", 42),
@@ -75,6 +85,18 @@ func TestFilterRejectsWrongAllowedValueShape(t *testing.T) {
 
 	_, _, err := contract.Filter(source)
 	require.ErrorContains(t, err, "want String")
+}
+
+func TestFilterRejectsMissingMandatoryMetadata(t *testing.T) {
+	contract := MustParse([]byte(`{"version":1,"target":"cloud","marker":"test/cloud","kinds":[{"id":"test/kind.app","lifecycle":"mirror","attributes":[]}]}`))
+	source := exportSource(
+		entity.Ref(entity.DBId, "app/web"),
+		entity.Ref(entity.EntityKind, "test/kind.app"),
+	)
+	source.Remove(entity.CreatedAt)
+
+	_, _, err := contract.Filter(source)
+	require.ErrorContains(t, err, "app/web is missing mandatory attribute db/entity.created")
 }
 
 func TestDigestUsesCanonicalOrdering(t *testing.T) {

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -1058,6 +1058,13 @@ func (s *EtcdStore) ReplaceEntity(
 		return nil, fmt.Errorf("db/id attribute does not match existing entity ID")
 	}
 
+	// CreatedAt is store-managed metadata and survives a full attribute
+	// replacement. This also lets callers atomically change an entity's kind,
+	// as deployment lock-owner publication does, without erasing its origin.
+	if createdAt := originalEntity.GetCreatedAt(); !createdAt.IsZero() {
+		repl.SetCreatedAt(createdAt)
+	}
+
 	if repl.GetRevision() == 0 {
 		repl.SetRevision(rev)
 	}

--- a/pkg/entity/store_conformance_test.go
+++ b/pkg/entity/store_conformance_test.go
@@ -340,6 +340,9 @@ func TestStoreConformance_EnsureAndReplaceKindedEntityCarriesShortID(t *testing.
 		), WithFromRevision(ent.GetRevision()))
 		require.NoError(t, err)
 		assert.Equal(t, shortID, replaced.ShortId())
+		assert.True(t, ent.GetCreatedAt().Equal(replaced.GetCreatedAt()),
+			"replacing a kinded reservation must preserve its creation time: before=%s after=%s",
+			ent.GetCreatedAt(), replaced.GetCreatedAt())
 		assert.False(t, Is(replaced, initialKind))
 		assert.True(t, Is(replaced, replacementKind))
 	})
@@ -375,6 +378,7 @@ func TestStoreConformance_ReplaceEntity(t *testing.T) {
 		))
 		require.NoError(t, err)
 		beforeRev := created.GetRevision()
+		beforeCreatedAt := created.GetCreatedAt()
 
 		replaced, err := store.ReplaceEntity(ctx, New(
 			Ref(DBId, id),
@@ -386,6 +390,9 @@ func TestStoreConformance_ReplaceEntity(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "after", doc.Value.String(), "replace must overwrite attributes")
 		assert.Greater(t, replaced.GetRevision(), beforeRev, "replace must bump revision")
+		assert.True(t, beforeCreatedAt.Equal(replaced.GetCreatedAt()),
+			"replace must preserve store-managed creation time: before=%s after=%s",
+			beforeCreatedAt, replaced.GetCreatedAt())
 
 		got, err := store.GetEntity(ctx, id)
 		require.NoError(t, err)

--- a/pkg/entitysync/exporter.go
+++ b/pkg/entitysync/exporter.go
@@ -26,6 +26,7 @@ const maxLiveBatchesBetweenSnapshotBatches = 8
 const sessionRetryDelay = time.Second
 const defaultMinimumResnapshotInterval = time.Hour
 const defaultAckTimeout = 30 * time.Second
+const defaultSnapshotAckTimeout = 5 * time.Minute
 const defaultPreparationLogInterval = time.Minute
 const sourceEpochTimeout = 5 * time.Second
 
@@ -46,6 +47,7 @@ type Exporter struct {
 	startGate                 <-chan struct{}
 	minimumResnapshotInterval time.Duration
 	ackTimeout                time.Duration
+	snapshotAckTimeout        time.Duration
 	preparationLogInterval    time.Duration
 
 	mu     sync.Mutex
@@ -75,6 +77,7 @@ func NewExporter(log *slog.Logger, store entity.Store, contract *entityexport.Co
 		log: log, store: store, contract: contract,
 		minimumResnapshotInterval: defaultMinimumResnapshotInterval,
 		ackTimeout:                defaultAckTimeout,
+		snapshotAckTimeout:        defaultSnapshotAckTimeout,
 		preparationLogInterval:    defaultPreparationLogInterval,
 	}
 	for _, option := range options {
@@ -570,7 +573,11 @@ func (s *stream) sendAndWait(link Link, messageType string, payload any, message
 	if err := link.SendMessageBlocking(s.ctx, messageType, payload); err != nil {
 		return Ack{}, err
 	}
-	waitCtx, cancelWait := context.WithTimeout(s.ctx, s.exporter.ackTimeout)
+	timeout := s.exporter.ackTimeout
+	if messageType == TypeSnapshotComplete {
+		timeout = s.exporter.snapshotAckTimeout
+	}
+	waitCtx, cancelWait := context.WithTimeout(s.ctx, timeout)
 	defer cancelWait()
 	select {
 	case <-waitCtx.Done():

--- a/pkg/entitysync/exporter_test.go
+++ b/pkg/entitysync/exporter_test.go
@@ -55,6 +55,13 @@ type lockedBuffer struct {
 	buf bytes.Buffer
 }
 
+func stampExportMetadata(ent *entity.Entity, revision int64) *entity.Entity {
+	ent.SetRevision(revision)
+	ent.SetCreatedAt(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+	ent.SetUpdatedAt(time.Date(2026, 1, 2, 3, 5, 5, 0, time.UTC))
+	return ent
+}
+
 func (b *lockedBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -391,14 +398,14 @@ func TestSnapshotFiltersEntities(t *testing.T) {
 		(&core_v1alpha.Metadata{Name: "web"}).Encode(),
 		entity.Bool(marker, true),
 	)
-	app.SetRevision(4)
+	stampExportMetadata(app, 4)
 	store.AddEntity(app.Id(), app)
 	deployment := entity.New(
 		entity.Ref(entity.DBId, "deployment/d1"),
 		(&core_v1alpha.Deployment{ID: "deployment/d1", AppName: "web", ErrorMessage: "token=super-secret"}).Encode(),
 		entity.Bool(marker, true),
 	)
-	deployment.SetRevision(7)
+	stampExportMetadata(deployment, 7)
 	store.AddEntity(deployment.Id(), deployment)
 
 	tenant := testExporter(store)
@@ -451,7 +458,7 @@ func TestSnapshotReadsAndSendsOnePinnedPageAtATime(t *testing.T) {
 			(&core_v1alpha.Deployment{ID: id, AppName: "marmalade"}).Encode(),
 			entity.Bool(marker, true),
 		)
-		deployment.SetRevision(int64(i + 1))
+		stampExportMetadata(deployment, int64(i+1))
 		store.AddEntity(id, deployment)
 	}
 
@@ -521,7 +528,7 @@ func TestLiveChangePreemptsArchiveSnapshot(t *testing.T) {
 		(&core_v1alpha.Deployment{ID: "deployment/d1", AppName: "web", Outcome: "in_progress"}).Encode(),
 		entity.Bool(marker, true),
 	)
-	deployment.SetRevision(7)
+	stampExportMetadata(deployment, 7)
 	store.AddEntity(deployment.Id(), deployment)
 
 	tenant := testExporter(store)
@@ -572,7 +579,7 @@ func TestDeleteCarriesFilteredLastEntityState(t *testing.T) {
 		(&core_v1alpha.Metadata{Name: "web"}).Encode(),
 		entity.Bool(marker, true),
 	)
-	app.SetRevision(4)
+	stampExportMetadata(app, 4)
 	store.AddEntity(app.Id(), app)
 	s := &stream{exporter: testExporter(store), ctx: t.Context()}
 
@@ -916,11 +923,15 @@ func TestWatchBatchStopsAtLastDeliveredEvent(t *testing.T) {
 	store := entity.NewMockStore()
 	marker := core_v1alpha.CloudExportContract.MarkerID()
 	for _, id := range []entity.Id{"deployment/a", "deployment/b"} {
-		store.AddEntity(id, entity.New(
+		revision := int64(10)
+		if id == "deployment/b" {
+			revision = 20
+		}
+		store.AddEntity(id, stampExportMetadata(entity.New(
 			entity.Ref(entity.DBId, id),
 			(&core_v1alpha.Deployment{ID: id, AppName: "web"}).Encode(),
 			entity.Bool(marker, true),
-		))
+		), revision))
 	}
 	exporter := testExporter(store)
 	stream := &stream{
@@ -953,11 +964,15 @@ func TestTailDeliversEveryCatchUpChunkBeforeStoreHead(t *testing.T) {
 	store := entity.NewMockStore()
 	marker := core_v1alpha.CloudExportContract.MarkerID()
 	for _, id := range []entity.Id{"deployment/a", "deployment/b"} {
-		store.AddEntity(id, entity.New(
+		revision := int64(10)
+		if id == "deployment/b" {
+			revision = 20
+		}
+		store.AddEntity(id, stampExportMetadata(entity.New(
 			entity.Ref(entity.DBId, id),
 			(&core_v1alpha.Deployment{ID: id, AppName: "web"}).Encode(),
 			entity.Bool(marker, true),
-		))
+		), revision))
 	}
 	exporter := testExporter(store)
 	stream := &stream{
@@ -1004,6 +1019,17 @@ func TestSendAndWaitTimesOutWithoutAcknowledgment(t *testing.T) {
 	_, err := stream.sendAndWait(newFakeLink(), TypeChangeBatch, struct{}{}, "message-1")
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.ErrorContains(t, err, "await entity.change.batch ack")
+}
+
+func TestSnapshotAcknowledgmentUsesItsLongerDeadline(t *testing.T) {
+	exporter := testExporter(entity.NewMockStore())
+	exporter.ackTimeout = time.Hour
+	exporter.snapshotAckTimeout = 10 * time.Millisecond
+	stream := &stream{exporter: exporter, ctx: t.Context(), waiters: make(map[string]chan Ack)}
+
+	_, err := stream.sendAndWait(newFakeLink(), TypeSnapshotComplete, struct{}{}, "snapshot-1")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, "await entity.snapshot.complete ack")
 }
 
 func TestSendAndWaitPreservesCancellationAndRejection(t *testing.T) {


### PR DESCRIPTION
Publishing a deployment lock reservation replaced the temporary entity without carrying its store-managed creation time. Garden currently has 17 deployments from this path with no `db/entity.created`, so Cloud rejects any snapshot batch containing one.

Replace now preserves creation time across the kind transition, with the behavior pinned against both MockStore and the production etcd store. The deployment migration repairs the existing cohort from `started_at` before opening entity sync, while export filtering rejects mandatory metadata gaps locally. Snapshot completion also gets a longer bounded acknowledgement window while live changes retain their existing deadline.

Part of MIR-1770