### PR TITLE
Expose entity sync diagnostics through miren debug cloud-sync

### DIFF
--- a/api/debug/debug_v1alpha/rpc.gen.go
+++ b/api/debug/debug_v1alpha/rpc.gen.go
@@ -213,6 +213,367 @@ func (v *SubnetStatus) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type cloudSyncEventData struct {
+	Kind    *string             `cbor:"0,keyasint,omitempty" json:"kind,omitempty"`
+	At      *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"at,omitempty"`
+	Summary *string             `cbor:"2,keyasint,omitempty" json:"summary,omitempty"`
+}
+
+type CloudSyncEvent struct {
+	data cloudSyncEventData
+}
+
+func (v *CloudSyncEvent) HasKind() bool {
+	return v.data.Kind != nil
+}
+
+func (v *CloudSyncEvent) Kind() string {
+	if v.data.Kind == nil {
+		return ""
+	}
+	return *v.data.Kind
+}
+
+func (v *CloudSyncEvent) SetKind(kind string) {
+	v.data.Kind = &kind
+}
+
+func (v *CloudSyncEvent) HasAt() bool {
+	return v.data.At != nil
+}
+
+func (v *CloudSyncEvent) At() *standard.Timestamp {
+	return v.data.At
+}
+
+func (v *CloudSyncEvent) SetAt(at *standard.Timestamp) {
+	v.data.At = at
+}
+
+func (v *CloudSyncEvent) HasSummary() bool {
+	return v.data.Summary != nil
+}
+
+func (v *CloudSyncEvent) Summary() string {
+	if v.data.Summary == nil {
+		return ""
+	}
+	return *v.data.Summary
+}
+
+func (v *CloudSyncEvent) SetSummary(summary string) {
+	v.data.Summary = &summary
+}
+
+func (v *CloudSyncEvent) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CloudSyncEvent) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CloudSyncEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CloudSyncEvent) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type cloudSyncFactData struct {
+	Name  *string `cbor:"0,keyasint,omitempty" json:"name,omitempty"`
+	Value *string `cbor:"1,keyasint,omitempty" json:"value,omitempty"`
+}
+
+type CloudSyncFact struct {
+	data cloudSyncFactData
+}
+
+func (v *CloudSyncFact) HasName() bool {
+	return v.data.Name != nil
+}
+
+func (v *CloudSyncFact) Name() string {
+	if v.data.Name == nil {
+		return ""
+	}
+	return *v.data.Name
+}
+
+func (v *CloudSyncFact) SetName(name string) {
+	v.data.Name = &name
+}
+
+func (v *CloudSyncFact) HasValue() bool {
+	return v.data.Value != nil
+}
+
+func (v *CloudSyncFact) Value() string {
+	if v.data.Value == nil {
+		return ""
+	}
+	return *v.data.Value
+}
+
+func (v *CloudSyncFact) SetValue(value string) {
+	v.data.Value = &value
+}
+
+func (v *CloudSyncFact) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CloudSyncFact) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CloudSyncFact) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CloudSyncFact) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type cloudSyncReportData struct {
+	State   *string            `cbor:"0,keyasint,omitempty" json:"state,omitempty"`
+	Summary *string            `cbor:"1,keyasint,omitempty" json:"summary,omitempty"`
+	Facts   *[]*CloudSyncFact  `cbor:"2,keyasint,omitempty" json:"facts,omitempty"`
+	Events  *[]*CloudSyncEvent `cbor:"3,keyasint,omitempty" json:"events,omitempty"`
+}
+
+type CloudSyncReport struct {
+	data cloudSyncReportData
+}
+
+func (v *CloudSyncReport) HasState() bool {
+	return v.data.State != nil
+}
+
+func (v *CloudSyncReport) State() string {
+	if v.data.State == nil {
+		return ""
+	}
+	return *v.data.State
+}
+
+func (v *CloudSyncReport) SetState(state string) {
+	v.data.State = &state
+}
+
+func (v *CloudSyncReport) HasSummary() bool {
+	return v.data.Summary != nil
+}
+
+func (v *CloudSyncReport) Summary() string {
+	if v.data.Summary == nil {
+		return ""
+	}
+	return *v.data.Summary
+}
+
+func (v *CloudSyncReport) SetSummary(summary string) {
+	v.data.Summary = &summary
+}
+
+func (v *CloudSyncReport) HasFacts() bool {
+	return v.data.Facts != nil
+}
+
+func (v *CloudSyncReport) Facts() []*CloudSyncFact {
+	if v.data.Facts == nil {
+		return nil
+	}
+	return *v.data.Facts
+}
+
+func (v *CloudSyncReport) SetFacts(facts []*CloudSyncFact) {
+	x := slices.Clone(facts)
+	v.data.Facts = &x
+}
+
+func (v *CloudSyncReport) HasEvents() bool {
+	return v.data.Events != nil
+}
+
+func (v *CloudSyncReport) Events() []*CloudSyncEvent {
+	if v.data.Events == nil {
+		return nil
+	}
+	return *v.data.Events
+}
+
+func (v *CloudSyncReport) SetEvents(events []*CloudSyncEvent) {
+	x := slices.Clone(events)
+	v.data.Events = &x
+}
+
+func (v *CloudSyncReport) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CloudSyncReport) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CloudSyncReport) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CloudSyncReport) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type cloudSyncGetStatusArgsData struct{}
+
+type CloudSyncGetStatusArgs struct {
+	call rpc.Call
+	data cloudSyncGetStatusArgsData
+}
+
+func (v *CloudSyncGetStatusArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CloudSyncGetStatusArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CloudSyncGetStatusArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CloudSyncGetStatusArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type cloudSyncGetStatusResultsData struct {
+	Report *CloudSyncReport `cbor:"0,keyasint,omitempty" json:"report,omitempty"`
+}
+
+type CloudSyncGetStatusResults struct {
+	call rpc.Call
+	data cloudSyncGetStatusResultsData
+}
+
+func (v *CloudSyncGetStatusResults) SetReport(report *CloudSyncReport) {
+	v.data.Report = report
+}
+
+func (v *CloudSyncGetStatusResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CloudSyncGetStatusResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CloudSyncGetStatusResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CloudSyncGetStatusResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type CloudSyncGetStatus struct {
+	rpc.Call
+	args    CloudSyncGetStatusArgs
+	results CloudSyncGetStatusResults
+}
+
+func (t *CloudSyncGetStatus) Args() *CloudSyncGetStatusArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *CloudSyncGetStatus) Results() *CloudSyncGetStatusResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type CloudSync interface {
+	GetStatus(ctx context.Context, state *CloudSyncGetStatus) error
+}
+
+type reexportCloudSync struct {
+	client rpc.Client
+}
+
+func (reexportCloudSync) GetStatus(ctx context.Context, state *CloudSyncGetStatus) error {
+	panic("not implemented")
+}
+
+func (t reexportCloudSync) CapabilityClient() rpc.Client {
+	return t.client
+}
+
+func AdaptCloudSync(t CloudSync) *rpc.Interface {
+	methods := []rpc.Method{
+		{
+			Name:          "getStatus",
+			InterfaceName: "CloudSync",
+			Index:         0,
+			Public:        false,
+			Params:        []string{},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.GetStatus(ctx, &CloudSyncGetStatus{Call: call})
+			},
+		},
+	}
+
+	return rpc.NewInterface(methods, t)
+}
+
+type CloudSyncClient struct {
+	rpc.Client
+}
+
+func NewCloudSyncClient(client rpc.Client) *CloudSyncClient {
+	return &CloudSyncClient{Client: client}
+}
+
+func (c CloudSyncClient) Export() CloudSync {
+	return reexportCloudSync{client: c.Client}
+}
+
+type CloudSyncClientGetStatusResults struct {
+	client rpc.Client
+	data   cloudSyncGetStatusResultsData
+}
+
+func (v *CloudSyncClientGetStatusResults) HasReport() bool {
+	return v.data.Report != nil
+}
+
+func (v *CloudSyncClientGetStatusResults) Report() *CloudSyncReport {
+	return v.data.Report
+}
+
+func (v CloudSyncClient) GetStatus(ctx context.Context) (*CloudSyncClientGetStatusResults, error) {
+	args := CloudSyncGetStatusArgs{}
+
+	var ret cloudSyncGetStatusResultsData
+
+	err := v.Call(ctx, "getStatus", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CloudSyncClientGetStatusResults{client: v.Client, data: ret}, nil
+}
+
 type netDBListLeasesArgsData struct {
 	Subnet       *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
 	ReservedOnly *bool   `cbor:"1,keyasint,omitempty" json:"reserved_only,omitempty"`

--- a/api/debug/rpc.yml
+++ b/api/debug/rpc.yml
@@ -52,7 +52,58 @@ types:
         index: 4
         doc: Total capacity of subnet
 
+  - type: CloudSyncEvent
+    doc: A recent event worth showing in an entity sync diagnostic report
+    fields:
+      - name: kind
+        type: string
+        index: 0
+      - name: at
+        type: standard.Timestamp
+        index: 1
+      - name: summary
+        type: string
+        index: 2
+
+  - type: CloudSyncFact
+    doc: One named value in an entity sync diagnostic report
+    fields:
+      - name: name
+        type: string
+        index: 0
+      - name: value
+        type: string
+        index: 1
+
+  - type: CloudSyncReport
+    doc: Extensible operator-facing entity sync diagnostics
+    fields:
+      - name: state
+        type: string
+        index: 0
+      - name: summary
+        type: string
+        index: 1
+      - name: facts
+        type: list
+        element: CloudSyncFact
+        index: 2
+      - name: events
+        type: list
+        element: CloudSyncEvent
+        index: 3
+
 interfaces:
+  - name: CloudSync
+    doc: Debug interface for runtime entity sync diagnostics
+    methods:
+      - name: getStatus
+        doc: Get current runtime-side entity sync status
+        results:
+          - name: report
+            type: CloudSyncReport
+            doc: Current entity sync diagnostic report
+
   - name: NetDB
     doc: Debug interface for network database inspection and management
     methods:

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -1231,6 +1231,7 @@ Warning: These commands are intended for advanced users and developers. They may
 	))
 	d.Dispatch("debug colors", Infer("debug colors", "Print some colors", Colors))
 	d.Dispatch("debug bundle", Infer("debug bundle", "Create a support bundle with system debug information", DebugBundle))
+	d.Dispatch("debug cloud-sync", Infer("debug cloud-sync", "Show runtime entity sync diagnostics", DebugCloudSync))
 
 	// Debug RBAC commands
 	d.Dispatch("debug rbac", Infer("debug rbac", "Fetch and display RBAC rules from miren.cloud", DebugRBAC))

--- a/cli/commands/debug_cloud_sync.go
+++ b/cli/commands/debug_cloud_sync.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/debug/debug_v1alpha"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// DebugCloudSync reports the runtime side of cloud entity synchronization.
+func DebugCloudSync(ctx *Context, opts struct {
+	FormatOptions
+	ConfigCentric
+}) error {
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-cloud-sync")
+	if err != nil {
+		return err
+	}
+	results, err := debug_v1alpha.NewCloudSyncClient(client).GetStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("get cloud sync status: %w", err)
+	}
+	if !results.HasReport() {
+		return errors.New("cloud sync status response did not include a report")
+	}
+	report := results.Report()
+	if opts.IsJSON() {
+		return PrintJSON(report)
+	}
+
+	ctx.Printf("Cloud entity sync\n")
+	ctx.Info("State: %s", report.State())
+	if report.Summary() != "" {
+		ctx.Info("Summary: %s", report.Summary())
+	}
+	for _, fact := range report.Facts() {
+		ctx.Info("%s: %s", cloudSyncLabel(fact.Name()), fact.Value())
+	}
+	for _, event := range report.Events() {
+		summary := event.Summary()
+		if event.HasAt() {
+			summary += ", " + standard.FromTimestamp(event.At()).Format(time.RFC3339)
+		}
+		ctx.Info("Last %s: %s", cloudSyncLabel(event.Kind()), summary)
+	}
+	return nil
+}
+
+func cloudSyncLabel(name string) string {
+	words := strings.FieldsFunc(name, func(r rune) bool { return r == '_' || r == '.' })
+	for i, word := range words {
+		if word == "id" {
+			words[i] = "ID"
+			continue
+		}
+		words[i] = strings.ToUpper(word[:1]) + word[1:]
+	}
+	return strings.Join(words, " ")
+}

--- a/components/coordinate/application_management.go
+++ b/components/coordinate/application_management.go
@@ -25,6 +25,7 @@ import (
 	"miren.dev/runtime/pkg/addon/rabbitmq"
 	addonsqlite "miren.dev/runtime/pkg/addon/sqlite"
 	"miren.dev/runtime/pkg/addon/valkey"
+	"miren.dev/runtime/pkg/entitysync"
 	"miren.dev/runtime/pkg/labs"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/saga"
@@ -40,22 +41,27 @@ import (
 
 // NewApplicationManagement constructs the application management plane on top
 // of cluster state and the secret store.
-func NewApplicationManagement(foundation *Foundation, secrets *SecretStore) *ApplicationManagement {
-	return &ApplicationManagement{Foundation: foundation, secrets: secrets}
+func NewApplicationManagement(foundation *Foundation, secrets *SecretStore, diagnostics ...*entitysync.Diagnostics) *ApplicationManagement {
+	var entitySyncDiagnostics *entitysync.Diagnostics
+	if len(diagnostics) > 0 {
+		entitySyncDiagnostics = diagnostics[0]
+	}
+	return &ApplicationManagement{Foundation: foundation, secrets: secrets, entitySyncDiagnostics: entitySyncDiagnostics}
 }
 
 // ApplicationManagement owns the durable app, addon, and run management surface.
 // WorkloadControl realizes that intent as running workloads.
 type ApplicationManagement struct {
 	*Foundation
-	secrets           *SecretStore
-	addonRegistry     *addon.Registry
-	addonFramework    *addon.ProviderFramework
-	appInfo           *app.AppInfo
-	debugServer       *debugsrv.Server
-	sagaBuilder       *build.SagaBuilder
-	buildHandler      *rpc.Interface
-	deploymentHandler *rpc.Interface
+	secrets               *SecretStore
+	addonRegistry         *addon.Registry
+	addonFramework        *addon.ProviderFramework
+	appInfo               *app.AppInfo
+	debugServer           *debugsrv.Server
+	entitySyncDiagnostics *entitysync.Diagnostics
+	sagaBuilder           *build.SagaBuilder
+	buildHandler          *rpc.Interface
+	deploymentHandler     *rpc.Interface
 }
 
 // Start initializes the durable application-management objects and exposes their
@@ -173,7 +179,9 @@ func (c *ApplicationManagement) exposeManagementAPIs(ctx context.Context) error 
 	if err != nil {
 		return err
 	}
+	c.debugServer.CloudSync = c.entitySyncDiagnostics
 	server.ExposeValue("dev.miren.runtime/debug-netdb", debug_v1alpha.AdaptNetDB(c.debugServer))
+	server.ExposeValue("dev.miren.runtime/debug-cloud-sync", debug_v1alpha.AdaptCloudSync(c.debugServer))
 	return nil
 }
 

--- a/components/coordinate/cloud_control.go
+++ b/components/coordinate/cloud_control.go
@@ -30,19 +30,29 @@ import (
 
 // NewCloudControl constructs cloud status, identity publication, and uplink
 // integration on top of cluster state.
-func NewCloudControl(foundation *Foundation, applications *ApplicationManagement) *CloudControl {
-	return &CloudControl{Foundation: foundation, applications: applications}
+func NewCloudControl(foundation *Foundation, applications *ApplicationManagement, diagnostics ...*entitysync.Diagnostics) *CloudControl {
+	var entitySyncDiagnostics *entitysync.Diagnostics
+	if len(diagnostics) > 0 {
+		entitySyncDiagnostics = diagnostics[0]
+	}
+	if entitySyncDiagnostics == nil {
+		entitySyncDiagnostics = entitysync.NewDiagnostics(core_v1alpha.CloudExportContract.Digest())
+	}
+	return &CloudControl{
+		Foundation: foundation, applications: applications,
+		entitySyncDiagnostics: entitySyncDiagnostics,
+	}
 }
 
 // CloudControl owns cloud status, identity publication, and uplink integration.
 type CloudControl struct {
 	*Foundation
-
 	// applications supplies the health classification the uplink reports. It is
 	// the same AppInfo backing the app RPC surface, so the console cannot
 	// disagree with `miren app list`.
 	applications *ApplicationManagement
 
+	entitySyncDiagnostics   *entitysync.Diagnostics
 	publishedKeysMu         sync.Mutex
 	publishedKeyFingerprint string
 	cancel                  context.CancelFunc
@@ -55,6 +65,11 @@ func (c *CloudControl) Stop() {
 		c.cancel()
 	}
 	c.wg.Wait()
+}
+
+// EntitySyncDiagnostics is the runtime-local view exposed by miren debug.
+func (c *CloudControl) EntitySyncDiagnostics() *entitysync.Diagnostics {
+	return c.entitySyncDiagnostics
 }
 
 // Start begins cloud-facing reporting. The uplink itself remains a separate
@@ -78,6 +93,7 @@ func (c *CloudControl) Start(ctx context.Context) error {
 // remain independent of that background migration.
 func (c *CloudControl) RunCloudUplink(ctx context.Context, ingress *httpingress.Server, entitySyncReady <-chan struct{}) error {
 	if !c.CloudAuth.Enabled || c.authClient == nil {
+		c.entitySyncDiagnostics.SetDisabled("cloud-auth-disabled")
 		return nil
 	}
 	cloudURL := c.CloudAuth.CloudURL
@@ -85,9 +101,11 @@ func (c *CloudControl) RunCloudUplink(ctx context.Context, ingress *httpingress.
 		cloudURL = DefaultCloudURL
 	}
 
-	var uplinkOptions []uplink.ClientOption
+	uplinkOptions := []uplink.ClientOption{uplink.WithStatus(c.entitySyncDiagnostics.ObserveUplink)}
 	if labs.AppVisibility() {
 		uplinkOptions = append(uplinkOptions, uplink.WithSession(version.GetInfo().Version))
+	} else {
+		c.entitySyncDiagnostics.SetCapabilityDisabled("app-visibility-disabled")
 	}
 	link := uplink.NewClient(
 		cloudURL,
@@ -100,6 +118,7 @@ func (c *CloudControl) RunCloudUplink(ctx context.Context, ingress *httpingress.
 		if err := entitysync.NewExporter(
 			c.Log.With("component", "entity-sync"), c.store, core_v1alpha.CloudExportContract,
 			entitysync.WithStartGate(entitySyncReady),
+			entitysync.WithDiagnostics(c.entitySyncDiagnostics),
 		).Register(ctx, link); err != nil {
 			// Entity visibility is additive. Local source metadata should not take
 			// Anywhere or cloud RPC off the shared link when it is unavailable.

--- a/components/coordinate/control_plane.go
+++ b/components/coordinate/control_plane.go
@@ -3,6 +3,9 @@ package coordinate
 import (
 	"context"
 	"time"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/entitysync"
 )
 
 type ControlPlaneParts struct {
@@ -22,6 +25,15 @@ func NewControlPlane(foundation *Foundation, supplied ...ControlPlaneParts) *Con
 	if len(supplied) > 0 {
 		parts = supplied[0]
 	}
+	diagnostics := entitysync.NewDiagnostics(core_v1alpha.CloudExportContract.Digest())
+	if parts.Cloud != nil {
+		diagnostics = parts.Cloud.EntitySyncDiagnostics()
+	} else if parts.Applications != nil && parts.Applications.entitySyncDiagnostics != nil {
+		diagnostics = parts.Applications.entitySyncDiagnostics
+	}
+	if parts.Applications != nil && parts.Applications.entitySyncDiagnostics == nil {
+		parts.Applications.entitySyncDiagnostics = diagnostics
+	}
 	if parts.Secrets == nil {
 		parts.Secrets = NewSecretStore(foundation)
 	}
@@ -29,7 +41,7 @@ func NewControlPlane(foundation *Foundation, supplied ...ControlPlaneParts) *Con
 		parts.RunnerEndpoints = NewRunnerEndpoints(foundation)
 	}
 	if parts.Applications == nil {
-		parts.Applications = NewApplicationManagement(foundation, parts.Secrets)
+		parts.Applications = NewApplicationManagement(foundation, parts.Secrets, diagnostics)
 	}
 	if parts.Workloads == nil {
 		parts.Workloads = NewWorkloadControl(foundation, parts.Applications)
@@ -38,7 +50,7 @@ func NewControlPlane(foundation *Foundation, supplied ...ControlPlaneParts) *Con
 		parts.Maintenance = NewEntityMaintenance(foundation)
 	}
 	if parts.Cloud == nil {
-		parts.Cloud = NewCloudControl(foundation, parts.Applications)
+		parts.Cloud = NewCloudControl(foundation, parts.Applications, diagnostics)
 	}
 	return &ControlPlane{
 		Foundation:      foundation,

--- a/components/coordinate/foundation.go
+++ b/components/coordinate/foundation.go
@@ -84,15 +84,14 @@ func (c *Foundation) NewDeploymentAttemptController() (*deploymentattemptsctrl.C
 // that no specialized migration covers. The deployment-attempt controller has
 // already marked the apps, app versions, and deployments in its clean sweep;
 // excluding deployments here preserves its ownership of validating old shapes.
-func (c *Foundation) BackfillCloudExportMarker(ctx context.Context) error {
+func (c *Foundation) BackfillCloudExportMarker(ctx context.Context) (entityexport.BackfillStats, error) {
 	if c.store == nil {
-		return errors.New("cluster foundation entity store is not ready")
+		return entityexport.BackfillStats{}, errors.New("cluster foundation entity store is not ready")
 	}
-	_, err := entityexport.BackfillMarker(
+	return entityexport.BackfillMarker(
 		ctx, c.Log, c.store, core_v1alpha.CloudExportContract, 0,
 		entityexport.ExcludingKinds(core_v1alpha.KindDeployment),
 	)
-	return err
 }
 
 // Stop drains RPC after all dependent components stop, then releases etcd.

--- a/components/server/boot_application_management.go
+++ b/components/server/boot_application_management.go
@@ -7,6 +7,7 @@ import (
 
 	"miren.dev/runtime/components/coordinate"
 	"miren.dev/runtime/pkg/boot"
+	"miren.dev/runtime/pkg/entitysync"
 )
 
 type applicationManagementBootOutput struct {
@@ -14,13 +15,14 @@ type applicationManagementBootOutput struct {
 }
 
 type applicationManagementBoot struct {
-	component *boot.Component
-	value     *coordinate.ApplicationManagement
-	output    boot.Output[applicationManagementBootOutput]
+	component   *boot.Component
+	value       *coordinate.ApplicationManagement
+	output      boot.Output[applicationManagementBootOutput]
+	diagnostics *entitysync.Diagnostics
 }
 
-func newApplicationManagementBoot(foundation boot.Output[foundationBootOutput], secrets boot.Output[secretStoreBootOutput], appData *boot.Component) *applicationManagementBoot {
-	b := &applicationManagementBoot{}
+func newApplicationManagementBoot(foundation boot.Output[foundationBootOutput], secrets boot.Output[secretStoreBootOutput], appData *boot.Component, diagnostics *entitysync.Diagnostics) *applicationManagementBoot {
+	b := &applicationManagementBoot{diagnostics: diagnostics}
 	b.component, b.output = boot.Provide2(
 		"application-management", foundation, secrets, b.start,
 		boot.DependsOn(appData),
@@ -30,7 +32,7 @@ func newApplicationManagementBoot(foundation boot.Output[foundationBootOutput], 
 }
 
 func (b *applicationManagementBoot) start(ctx context.Context, foundation foundationBootOutput, secrets secretStoreBootOutput) (applicationManagementBootOutput, error) {
-	b.value = coordinate.NewApplicationManagement(foundation.foundation, secrets.secretStore)
+	b.value = coordinate.NewApplicationManagement(foundation.foundation, secrets.secretStore, b.diagnostics)
 	if err := b.value.Start(ctx); err != nil {
 		return applicationManagementBootOutput{}, err
 	}

--- a/components/server/boot_cloud_control.go
+++ b/components/server/boot_cloud_control.go
@@ -7,6 +7,7 @@ import (
 
 	"miren.dev/runtime/components/coordinate"
 	"miren.dev/runtime/pkg/boot"
+	"miren.dev/runtime/pkg/entitysync"
 )
 
 type cloudControlBootOutput struct {
@@ -14,13 +15,14 @@ type cloudControlBootOutput struct {
 }
 
 type cloudControlBoot struct {
-	component *boot.Component
-	output    boot.Output[cloudControlBootOutput]
-	value     *coordinate.CloudControl
+	component   *boot.Component
+	output      boot.Output[cloudControlBootOutput]
+	value       *coordinate.CloudControl
+	diagnostics *entitysync.Diagnostics
 }
 
-func newCloudControlBoot(foundation boot.Output[foundationBootOutput], applications boot.Output[applicationManagementBootOutput], maintenance, workloads *boot.Component) *cloudControlBoot {
-	b := &cloudControlBoot{}
+func newCloudControlBoot(foundation boot.Output[foundationBootOutput], applications boot.Output[applicationManagementBootOutput], maintenance, workloads *boot.Component, diagnostics *entitysync.Diagnostics) *cloudControlBoot {
+	b := &cloudControlBoot{diagnostics: diagnostics}
 	b.component, b.output = boot.Provide2(
 		"cloud-control", foundation, applications, b.start,
 		// Cloud startup status means the management, maintenance, and workload
@@ -35,7 +37,7 @@ func newCloudControlBoot(foundation boot.Output[foundationBootOutput], applicati
 }
 
 func (b *cloudControlBoot) start(ctx context.Context, foundation foundationBootOutput, applications applicationManagementBootOutput) (cloudControlBootOutput, error) {
-	cloud := coordinate.NewCloudControl(foundation.foundation, applications.applications)
+	cloud := coordinate.NewCloudControl(foundation.foundation, applications.applications, b.diagnostics)
 	if err := cloud.Start(ctx); err != nil {
 		return cloudControlBootOutput{}, err
 	}

--- a/components/server/boot_deployment_attempt_migration.go
+++ b/components/server/boot_deployment_attempt_migration.go
@@ -4,18 +4,21 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	deploymentattemptsctrl "miren.dev/runtime/controllers/deploymentattempts"
 	"miren.dev/runtime/pkg/boot"
+	"miren.dev/runtime/pkg/entitysync"
 	"miren.dev/runtime/pkg/labs"
 )
 
 // deploymentAttemptMigrationBoot owns the controller's background lifecycle.
 type deploymentAttemptMigrationBoot struct {
-	component  *boot.Component
-	controller *deploymentattemptsctrl.Controller
-	output     boot.Output[deploymentAttemptMigrationBootOutput]
+	component   *boot.Component
+	controller  *deploymentattemptsctrl.Controller
+	output      boot.Output[deploymentAttemptMigrationBootOutput]
+	diagnostics *entitysync.Diagnostics
 }
 
 type deploymentAttemptMigrationBootOutput struct {
@@ -24,8 +27,8 @@ type deploymentAttemptMigrationBootOutput struct {
 
 const markerBackfillRetryInterval = 10 * time.Second
 
-func newDeploymentAttemptMigrationBoot(foundation boot.Output[foundationBootOutput], appData *boot.Component) *deploymentAttemptMigrationBoot {
-	b := &deploymentAttemptMigrationBoot{}
+func newDeploymentAttemptMigrationBoot(foundation boot.Output[foundationBootOutput], appData *boot.Component, diagnostics *entitysync.Diagnostics) *deploymentAttemptMigrationBoot {
+	b := &deploymentAttemptMigrationBoot{diagnostics: diagnostics}
 	// Both startup migrations update AppVersions. The order-only edge prevents
 	// this controller's patches from racing the older whole-entity rewrite.
 	b.component, b.output = boot.Provide1("deployment-attempt-migration", foundation, b.start,
@@ -41,9 +44,34 @@ func (b *deploymentAttemptMigrationBoot) start(ctx context.Context, foundation f
 		return deploymentAttemptMigrationBootOutput{}, err
 	}
 	b.controller = controller
+	diagnostics := b.diagnostics
+	if labs.AppVisibility() {
+		diagnostics.SetPreparation("deployment-migration", "waiting for the first clean migration and reconciliation sweep")
+		b.controller.SetProgressReporter(func(progress deploymentattemptsctrl.Progress) {
+			if progress.Ready {
+				return
+			}
+			state := "deployment-migration"
+			detail := fmt.Sprintf("phase %s", progress.Phase)
+			if progress.Cursor != "" {
+				detail += ", cursor " + progress.Cursor
+			}
+			if progress.PassFailed {
+				detail += ", current sweep has failures"
+			}
+			if progress.LastError != "" {
+				state = "deployment-migration-retrying"
+				detail += ": " + progress.LastError
+				diagnostics.SetPreparationFailure(state, detail)
+				return
+			}
+			diagnostics.SetPreparation(state, detail)
+		})
+	}
 	b.controller.Start(ctx)
 	ready := make(chan struct{})
 	if !labs.AppVisibility() {
+		diagnostics.SetPreparation("disabled", "app visibility is disabled")
 		close(ready)
 		return deploymentAttemptMigrationBootOutput{entitySyncReady: ready}, nil
 	}
@@ -57,13 +85,20 @@ func (b *deploymentAttemptMigrationBoot) prepareEntitySync(ctx context.Context, 
 		return
 	case <-b.controller.Ready():
 	}
+	diagnostics := b.diagnostics
+	diagnostics.SetPreparation("marker-backfill", "backfilling the cloud export marker")
 
 	for {
-		if err := foundation.foundation.BackfillCloudExportMarker(ctx); err == nil {
+		if stats, err := foundation.foundation.BackfillCloudExportMarker(ctx); err == nil {
+			diagnostics.SetPreparation("ready", fmt.Sprintf(
+				"marker backfill scanned %d entities, marked %d, already marked %d",
+				stats.Scanned, stats.Marked, stats.AlreadyMarked,
+			))
 			close(ready)
 			foundation.foundation.Log.Info("entity sync source preparation complete")
 			return
 		} else if ctx.Err() == nil {
+			diagnostics.SetPreparationFailure("marker-backfill-retrying", err.Error())
 			foundation.foundation.Log.Warn("cloud export marker backfill failed; retrying", "error", err)
 		}
 

--- a/components/server/startup.go
+++ b/components/server/startup.go
@@ -8,9 +8,11 @@ import (
 	"path/filepath"
 
 	"golang.org/x/sync/errgroup"
+	"miren.dev/runtime/api/core/core_v1alpha"
 	containerdcomp "miren.dev/runtime/components/containerd"
 	"miren.dev/runtime/components/netresolve"
 	runnercomp "miren.dev/runtime/components/runner"
+	"miren.dev/runtime/pkg/entitysync"
 	"miren.dev/runtime/pkg/secret"
 	"miren.dev/runtime/pkg/serverconfig"
 )
@@ -74,6 +76,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 	// the components that share it.
 	resolver, hostMapper := netresolve.NewLocalResolver()
 	secretRegistry := secret.NewRegistry()
+	entitySyncDiagnostics := entitysync.NewDiagnostics(core_v1alpha.CloudExportContract.Digest())
 	address := NormalizeServerAddress(options.Log, options.Config.Server.GetAddress())
 
 	// This is where we wire up the boot graph. Each component lives in a sibling
@@ -107,7 +110,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 	appData := newAppDataBoot(foundation.output)
 	secretStore := newSecretStoreBoot(foundation.output)
 	runnerEndpoints := newRunnerEndpointsBoot(foundation.output, secretStore.component)
-	deploymentAttempts := newDeploymentAttemptMigrationBoot(foundation.output, appData.component)
+	deploymentAttempts := newDeploymentAttemptMigrationBoot(foundation.output, appData.component, entitySyncDiagnostics)
 	entityAccess := newEntityAccessBoot(entityAccessInputs(options), foundation.output, observability.output)
 	appMetrics := newAppMetricsBoot(
 		appMetricsInputs(options),
@@ -135,12 +138,12 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 		observability.output,
 	)
 	storageAgent := runnercomp.NewStorageAgentBoot(nodeStorage.output, sandboxHost.component, componentStopTimeout)
-	applicationManagement := newApplicationManagementBoot(foundation.output, secretStore.output, appData.component)
+	applicationManagement := newApplicationManagementBoot(foundation.output, secretStore.output, appData.component, entitySyncDiagnostics)
 	workloadControl := newWorkloadControlBoot(foundation.output, applicationManagement.output, sandboxHost.component)
 	sandboxAgent := runnercomp.NewSandboxAgentBoot(sandboxHost.output, componentStopTimeout, workloadControl.component)
 	nodePresence := runnercomp.NewNodePresenceBoot(sandboxHost.output, storageAgent.Component, sandboxAgent.Component, componentStopTimeout)
 	maintenance := newEntityMaintenanceBoot(foundation.output, appData.component)
-	cloudControl := newCloudControlBoot(foundation.output, applicationManagement.output, maintenance.component, workloadControl.component)
+	cloudControl := newCloudControlBoot(foundation.output, applicationManagement.output, maintenance.component, workloadControl.component, entitySyncDiagnostics)
 	ingress := newIngressBoot(ingressInputs(options), workloadControl.output, nodePresence.Component, workloadIdentity.output, entityAccess.output, observability.output)
 	adminAPI := newAdminBoot(foundation.output, entityAccess.output, ingress.output, observability.output)
 	cloudUplink := newCloudUplinkBoot(cloudControl.output, deploymentAttempts.output, ingress.output)

--- a/controllers/deploymentattempts/controller.go
+++ b/controllers/deploymentattempts/controller.go
@@ -35,6 +35,15 @@ type Config struct {
 	BatchSize int64
 }
 
+// Progress reports the controller's current migration scan position.
+type Progress struct {
+	Phase      string
+	Cursor     string
+	PassFailed bool
+	Ready      bool
+	LastError  string
+}
+
 func DefaultConfig() Config {
 	return Config{Interval: 10 * time.Second, BatchSize: 200}
 }
@@ -54,6 +63,7 @@ type Controller struct {
 	passFailed          bool
 	firstCleanSweepOnce sync.Once
 	ready               chan struct{}
+	reportProgress      func(Progress)
 }
 
 func New(log *slog.Logger, store entity.Store, eac *entityserver_v1alpha.EntityAccessClient) *Controller {
@@ -69,6 +79,11 @@ func New(log *slog.Logger, store entity.Store, eac *entityserver_v1alpha.EntityA
 // wait on it without making the controller's ongoing repair loop part of their
 // own lifecycle.
 func (c *Controller) Ready() <-chan struct{} { return c.ready }
+
+// SetProgressReporter attaches runtime diagnostics before Start is called.
+func (c *Controller) SetProgressReporter(report func(Progress)) {
+	c.reportProgress = report
+}
 
 func (c *Controller) Start(ctx context.Context) {
 	if c.Config.Interval <= 0 {
@@ -89,7 +104,9 @@ func (c *Controller) Stop() {
 
 func (c *Controller) run(ctx context.Context) {
 	for {
-		if err := c.Step(ctx); err != nil && ctx.Err() == nil {
+		err := c.Step(ctx)
+		c.publishProgress(err)
+		if err != nil && ctx.Err() == nil {
 			c.Log.Warn("deployment-attempt migration pass failed", "error", err)
 		}
 		select {
@@ -98,6 +115,22 @@ func (c *Controller) run(ctx context.Context) {
 		case <-time.After(c.Config.Interval):
 		}
 	}
+}
+
+func (c *Controller) publishProgress(err error) {
+	if c.reportProgress == nil {
+		return
+	}
+	progress := Progress{Phase: c.phase, Cursor: c.cursor, PassFailed: c.passFailed}
+	if err != nil {
+		progress.LastError = err.Error()
+	}
+	select {
+	case <-c.ready:
+		progress.Ready = true
+	default:
+	}
+	c.reportProgress(progress)
 }
 
 // Step processes one bounded page. It is public so tests and operators can

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -118,6 +118,7 @@
     "items": [
       "command/debug-advertise",
       "command/debug-bundle",
+      "command/debug-cloud-sync",
       "command/debug-colors",
       "command/debug-connection",
       "command/debug-ctr",

--- a/docs/docs/command/debug-cloud-sync.md
+++ b/docs/docs/command/debug-cloud-sync.md
@@ -1,0 +1,32 @@
+---
+title: "miren debug cloud-sync"
+sidebar_label: "debug cloud-sync"
+description: "Show runtime entity sync diagnostics"
+---
+
+# miren debug cloud-sync
+
+Show runtime entity sync diagnostics
+
+## Usage
+
+```bash
+miren debug cloud-sync [flags]
+```
+
+## Flags
+
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--format` — Output format (text, json) (default: `text`)
+- `--json` — Shorthand for --format json
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## See also
+
+- [`miren debug`](./debug.md)

--- a/docs/docs/command/debug.md
+++ b/docs/docs/command/debug.md
@@ -18,6 +18,7 @@ miren debug [flags]
 
 - [`miren debug advertise`](./debug-advertise.md) — Show which addresses the server would advertise and why
 - [`miren debug bundle`](./debug-bundle.md) — Create a support bundle with system debug information
+- [`miren debug cloud-sync`](./debug-cloud-sync.md) — Show runtime entity sync diagnostics
 - [`miren debug colors`](./debug-colors.md) — Print some colors
 - [`miren debug connection`](./debug-connection.md) — Test connectivity and authentication with a server
 - [`miren debug ctr`](./debug-ctr.md) — Run ctr with miren defaults

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -307,6 +307,7 @@ These commands are intended for advanced debugging and troubleshooting. They may
 | [`miren debug`](./command/debug.md) | Debug and troubleshooting commands |
 | [`miren debug advertise`](./command/debug-advertise.md) | Show which addresses the server would advertise and why |
 | [`miren debug bundle`](./command/debug-bundle.md) | Create a support bundle with system debug information |
+| [`miren debug cloud-sync`](./command/debug-cloud-sync.md) | Show runtime entity sync diagnostics |
 | [`miren debug colors`](./command/debug-colors.md) | Print some colors |
 | [`miren debug connection`](./command/debug-connection.md) | Test connectivity and authentication with a server |
 | [`miren debug ctr`](./command/debug-ctr.md) | Run ctr with miren defaults |

--- a/pkg/entitysync/diagnostics.go
+++ b/pkg/entitysync/diagnostics.go
@@ -1,0 +1,241 @@
+package entitysync
+
+import (
+	"maps"
+	"sync"
+	"time"
+
+	"miren.dev/runtime/pkg/uplink"
+)
+
+// Event records the most recent acknowledgement or failure.
+type Event struct {
+	At        time.Time
+	Stage     string
+	Message   string
+	MessageID string
+	Cursor    int64
+}
+
+// SnapshotProgress describes the snapshot currently being transmitted.
+type SnapshotProgress struct {
+	ID           string
+	HeadRevision int64
+	NextRevision int64
+	PagesSent    int64
+	EntitiesSent int64
+	CountsByKind map[string]int64
+}
+
+// Status is a point-in-time view of runtime entity sync.
+type Status struct {
+	UplinkState        string
+	SessionID          string
+	HandshakeVersion   uint
+	CapabilityState    string
+	CapabilityVersion  uint
+	PreparationState   string
+	PreparationDetail  string
+	SourceEpoch        string
+	SchemaDigest       string
+	Mode               string
+	WaitReason         string
+	CloudCursor        int64
+	NextWatchRevision  int64
+	Snapshot           *SnapshotProgress
+	LastAcknowledgment *Event
+	LastError          *Event
+	RetryAt            time.Time
+}
+
+// Diagnostics collects transient state for the local debug interface.
+type Diagnostics struct {
+	mu                 sync.RWMutex
+	status             Status
+	capabilityDisabled string
+}
+
+func NewDiagnostics(schemaDigest string) *Diagnostics {
+	return &Diagnostics{status: Status{
+		UplinkState:      "not-started",
+		CapabilityState:  "not-negotiated",
+		PreparationState: "not-started",
+		SchemaDigest:     schemaDigest,
+		Mode:             "waiting",
+		WaitReason:       "uplink-not-connected",
+	}}
+}
+
+func (d *Diagnostics) SnapshotStatus() Status {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	status := d.status
+	if status.Snapshot != nil {
+		progress := *status.Snapshot
+		progress.CountsByKind = maps.Clone(progress.CountsByKind)
+		status.Snapshot = &progress
+	}
+	if status.LastAcknowledgment != nil {
+		event := *status.LastAcknowledgment
+		status.LastAcknowledgment = &event
+	}
+	if status.LastError != nil {
+		event := *status.LastError
+		status.LastError = &event
+	}
+	return status
+}
+
+func (d *Diagnostics) ObserveUplink(status uplink.Status) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.UplinkState = status.State
+	d.status.RetryAt = status.RetryAt
+	if status.LastError != "" {
+		d.status.LastError = &Event{At: time.Now().UTC(), Stage: "uplink", Message: status.LastError}
+	}
+	if status.Session == nil {
+		d.status.SessionID = ""
+		d.status.HandshakeVersion = 0
+		if d.capabilityDisabled != "" {
+			d.status.CapabilityState = "disabled"
+			d.status.Mode = "waiting"
+			d.status.WaitReason = d.capabilityDisabled
+		} else if status.State != "connected" {
+			d.status.CapabilityState = "not-negotiated"
+			d.status.CapabilityVersion = 0
+			d.status.Mode = "waiting"
+			d.status.WaitReason = "uplink-" + status.State
+		}
+		return
+	}
+	d.status.SessionID = status.Session.ID
+	d.status.HandshakeVersion = status.Session.HandshakeVersion
+	if d.capabilityDisabled != "" {
+		d.status.CapabilityState = "disabled"
+		d.status.CapabilityVersion = 0
+		d.status.Mode = "waiting"
+		d.status.WaitReason = d.capabilityDisabled
+		return
+	}
+	selection, selected := status.Session.Capability(uplink.CapabilityEntitySync)
+	if selected {
+		d.status.CapabilityState = "selected"
+		d.status.CapabilityVersion = selection.Version
+	} else {
+		d.status.CapabilityState = "not-selected"
+		d.status.CapabilityVersion = 0
+		d.status.Mode = "waiting"
+		d.status.WaitReason = "capability-not-selected"
+	}
+}
+
+func (d *Diagnostics) SetDisabled(reason string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.UplinkState = "disabled"
+	d.status.CapabilityState = "disabled"
+	d.status.Mode = "waiting"
+	d.status.WaitReason = reason
+}
+
+func (d *Diagnostics) SetCapabilityDisabled(reason string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.capabilityDisabled = reason
+	d.status.CapabilityState = "disabled"
+	d.status.Mode = "waiting"
+	d.status.WaitReason = reason
+}
+
+func (d *Diagnostics) SetPreparation(state, detail string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.PreparationState = state
+	d.status.PreparationDetail = detail
+}
+
+func (d *Diagnostics) SetPreparationFailure(state, message string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.PreparationState = state
+	d.status.PreparationDetail = message
+	d.status.LastError = &Event{At: time.Now().UTC(), Stage: "source-preparation", Message: message}
+}
+
+func (d *Diagnostics) setSource(sourceEpoch string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.SourceEpoch = sourceEpoch
+}
+
+func (d *Diagnostics) setMode(mode, waitReason string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.Mode = mode
+	d.status.WaitReason = waitReason
+}
+
+func (d *Diagnostics) setCursor(cursor int64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.CloudCursor = cursor
+}
+
+func (d *Diagnostics) setNextWatchRevision(revision int64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.NextWatchRevision = revision
+	if d.status.Snapshot != nil {
+		d.status.Snapshot.NextRevision = revision
+	}
+}
+
+func (d *Diagnostics) beginSnapshot(id string, head, next int64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.Snapshot = &SnapshotProgress{
+		ID: id, HeadRevision: head, NextRevision: next, CountsByKind: make(map[string]int64),
+	}
+}
+
+func (d *Diagnostics) addSnapshotPage(entities int, counts map[string]int64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.status.Snapshot == nil {
+		return
+	}
+	d.status.Snapshot.PagesSent++
+	d.status.Snapshot.EntitiesSent += int64(entities)
+	d.status.Snapshot.CountsByKind = maps.Clone(counts)
+}
+
+func (d *Diagnostics) finishSnapshot(cursor int64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.CloudCursor = cursor
+	d.status.Snapshot = nil
+}
+
+func (d *Diagnostics) abortSnapshot() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.Snapshot = nil
+}
+
+func (d *Diagnostics) acknowledge(stage string, ack Ack) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.LastAcknowledgment = &Event{
+		At: time.Now().UTC(), Stage: stage, MessageID: ack.MessageID, Cursor: ack.Cursor,
+	}
+}
+
+func (d *Diagnostics) fail(stage string, err error) {
+	if err == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.status.LastError = &Event{At: time.Now().UTC(), Stage: stage, Message: err.Error()}
+}

--- a/pkg/entitysync/diagnostics_test.go
+++ b/pkg/entitysync/diagnostics_test.go
@@ -1,0 +1,78 @@
+package entitysync
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/uplink"
+)
+
+func TestDiagnosticsTracksNegotiatedSessionAndExporterProgress(t *testing.T) {
+	diagnostics := NewDiagnostics("sha256:test")
+	diagnostics.SetPreparation("ready", "source prepared")
+	diagnostics.ObserveUplink(uplink.Status{State: "connected", Session: &uplink.Session{
+		ID: "session-1", HandshakeVersion: 1,
+		Capabilities: []uplink.CapabilitySelection{{Name: uplink.CapabilityEntitySync, Version: Version1}},
+	}})
+	diagnostics.setSource("epoch-1")
+	diagnostics.setCursor(40)
+	diagnostics.beginSnapshot("snapshot-1", 60, 61)
+	diagnostics.addSnapshotPage(3, map[string]int64{"app": 3})
+	diagnostics.setNextWatchRevision(65)
+	diagnostics.acknowledge(TypeChangeBatch, Ack{MessageID: "message-1", Cursor: 64})
+
+	status := diagnostics.SnapshotStatus()
+	require.Equal(t, "connected", status.UplinkState)
+	require.Equal(t, "session-1", status.SessionID)
+	require.Equal(t, "selected", status.CapabilityState)
+	require.Equal(t, uint(Version1), status.CapabilityVersion)
+	require.Equal(t, "ready", status.PreparationState)
+	require.Equal(t, "epoch-1", status.SourceEpoch)
+	require.Equal(t, "sha256:test", status.SchemaDigest)
+	require.Equal(t, int64(40), status.CloudCursor)
+	require.Equal(t, int64(65), status.NextWatchRevision)
+	require.Equal(t, int64(3), status.Snapshot.EntitiesSent)
+	require.Equal(t, int64(3), status.Snapshot.CountsByKind["app"])
+	require.Equal(t, "message-1", status.LastAcknowledgment.MessageID)
+
+	diagnostics.finishSnapshot(64)
+	status = diagnostics.SnapshotStatus()
+	require.Equal(t, int64(64), status.CloudCursor)
+	require.Nil(t, status.Snapshot)
+}
+
+func TestDiagnosticsSnapshotDoesNotAliasMutableState(t *testing.T) {
+	diagnostics := NewDiagnostics("schema")
+	diagnostics.beginSnapshot("snapshot-1", 10, 11)
+	diagnostics.addSnapshotPage(1, map[string]int64{"app": 1})
+	first := diagnostics.SnapshotStatus()
+	first.Snapshot.CountsByKind["app"] = 99
+
+	second := diagnostics.SnapshotStatus()
+	require.Equal(t, int64(1), second.Snapshot.CountsByKind["app"])
+}
+
+func TestDiagnosticsRecordsWaitAndFailure(t *testing.T) {
+	diagnostics := NewDiagnostics("schema")
+	diagnostics.ObserveUplink(uplink.Status{State: "connected", Session: &uplink.Session{ID: "session-1"}})
+	diagnostics.setMode("retrying", "start entity sync session")
+	diagnostics.fail("watch", errors.New("compacted"))
+
+	status := diagnostics.SnapshotStatus()
+	require.Equal(t, "not-selected", status.CapabilityState)
+	require.Equal(t, "retrying", status.Mode)
+	require.Equal(t, "start entity sync session", status.WaitReason)
+	require.Equal(t, "watch", status.LastError.Stage)
+	require.Equal(t, "compacted", status.LastError.Message)
+}
+
+func TestDiagnosticsRecordsPreparationFailure(t *testing.T) {
+	diagnostics := NewDiagnostics("schema")
+	diagnostics.SetPreparationFailure("marker-backfill-retrying", "etcd unavailable")
+
+	status := diagnostics.SnapshotStatus()
+	require.Equal(t, "marker-backfill-retrying", status.PreparationState)
+	require.Equal(t, "source-preparation", status.LastError.Stage)
+	require.Equal(t, "etcd unavailable", status.LastError.Message)
+}

--- a/pkg/entitysync/exporter.go
+++ b/pkg/entitysync/exporter.go
@@ -49,6 +49,7 @@ type Exporter struct {
 	ackTimeout                time.Duration
 	snapshotAckTimeout        time.Duration
 	preparationLogInterval    time.Duration
+	diagnostics               *Diagnostics
 
 	mu     sync.Mutex
 	active *stream
@@ -72,6 +73,11 @@ func WithStartGate(ready <-chan struct{}) Option {
 	return func(exporter *Exporter) { exporter.startGate = ready }
 }
 
+// WithDiagnostics publishes exporter progress to the local debug interface.
+func WithDiagnostics(diagnostics *Diagnostics) Option {
+	return func(exporter *Exporter) { exporter.diagnostics = diagnostics }
+}
+
 func NewExporter(log *slog.Logger, store entity.Store, contract *entityexport.Contract, options ...Option) *Exporter {
 	exporter := &Exporter{
 		log: log, store: store, contract: contract,
@@ -90,8 +96,12 @@ func (t *Exporter) Register(_ context.Context, link Link) error {
 	link.OfferCapabilityFunc(uplink.CapabilityEntitySync, []uint{Version1}, func(ctx context.Context) (json.RawMessage, bool) {
 		sourceEpoch, err := t.readSourceEpoch(ctx)
 		if err != nil {
+			t.fail("read-source-epoch", err)
 			t.log.Warn("entity sync source epoch unavailable; omitting capability", "error", err)
 			return nil, false
+		}
+		if t.diagnostics != nil {
+			t.diagnostics.setSource(sourceEpoch)
 		}
 		return marshalOffer(t.contract.Digest(), sourceEpoch), true
 	})
@@ -105,35 +115,54 @@ func (t *Exporter) Register(_ context.Context, link Link) error {
 func (t *Exporter) runSession(ctx context.Context, session uplink.Session, link Link) {
 	selection, ok := session.Capability(uplink.CapabilityEntitySync)
 	if !ok {
+		t.setMode("waiting", "capability-not-selected")
 		return
 	}
 
 	var config Config
 	if err := json.Unmarshal(selection.Config, &config); err != nil {
+		t.fail("decode-session-config", err)
+		t.setMode("waiting", "invalid-session-config")
 		t.log.Warn("invalid entity sync session config", "error", err)
 		return
 	}
 	if config.ExportSchema != t.contract.Digest() {
+		err := fmt.Errorf("cloud selected schema %s; local schema is %s", config.ExportSchema, t.contract.Digest())
+		t.fail("validate-session-config", err)
+		t.setMode("waiting", "schema-mismatch")
 		t.log.Warn("cloud selected an unexpected entity export schema",
 			"selected", config.ExportSchema, "local", t.contract.Digest())
 		return
 	}
 	resnapshotInterval, nextSnapshot := t.resnapshotSchedule(config)
+	if t.diagnostics != nil {
+		t.diagnostics.setCursor(config.Cursor)
+		t.diagnostics.setNextWatchRevision(config.Cursor + 1)
+	}
+	t.setMode("waiting", "source-preparation")
 	if !t.waitForStartGate(ctx) {
 		return
 	}
 	sourceEpoch, err := t.readSourceEpoch(ctx)
 	if err != nil {
+		t.fail("read-source-epoch", err)
+		t.setMode("waiting", "source-epoch-unavailable")
 		t.log.Warn("entity sync source epoch unavailable for selected session", "error", err)
 		return
 	}
 	if config.SourceEpoch != sourceEpoch {
+		err := fmt.Errorf("cloud selected source epoch %s; local source epoch is %s", config.SourceEpoch, sourceEpoch)
+		t.fail("validate-session-config", err)
+		t.setMode("waiting", "source-epoch-mismatch")
 		t.log.Warn("cloud selected an unexpected entity source epoch",
 			"selected", config.SourceEpoch, "local", sourceEpoch)
 		return
 	}
 
 	s := &stream{exporter: t, ctx: ctx, sourceEpoch: sourceEpoch, waiters: make(map[string]chan Ack)}
+	if t.diagnostics != nil {
+		t.diagnostics.setSource(sourceEpoch)
+	}
 	t.mu.Lock()
 	t.active = s
 	t.mu.Unlock()
@@ -155,6 +184,9 @@ func (t *Exporter) runSession(ctx context.Context, session uplink.Session, link 
 		headPage, err := t.store.ListIndexPageAtRevision(ctx, t.marker(), "", 1, 0)
 		if err != nil {
 			cancelWatch()
+			if t.diagnostics != nil {
+				t.diagnostics.abortSnapshot()
+			}
 			if !s.retry(ctx, "read entity sync source head", err) {
 				return
 			}
@@ -165,6 +197,7 @@ func (t *Exporter) runSession(ctx context.Context, session uplink.Session, link 
 		var watcher clientv3.WatchChan
 		didSnapshot := false
 		if snapshotRequired || cursor > currentHead {
+			t.setMode("snapshotting", "")
 			var snapshotCursor int64
 			snapshotCursor, watcher, err = s.snapshot(watchCtx, link)
 			if err == nil {
@@ -172,6 +205,10 @@ func (t *Exporter) runSession(ctx context.Context, session uplink.Session, link 
 				didSnapshot = true
 			}
 		} else {
+			t.setMode("watching", "")
+			if t.diagnostics != nil {
+				t.diagnostics.setNextWatchRevision(cursor + 1)
+			}
 			watcher, err = t.store.WatchIndex(watchCtx, t.marker(), cursor+1)
 			if errors.Is(err, rpctypes.ErrCompacted) {
 				err = errCompacted
@@ -179,6 +216,9 @@ func (t *Exporter) runSession(ctx context.Context, session uplink.Session, link 
 		}
 		if err != nil {
 			cancelWatch()
+			if t.diagnostics != nil {
+				t.diagnostics.abortSnapshot()
+			}
 			if errors.Is(err, errCompacted) {
 				snapshotRequired = true
 				if !s.retry(ctx, "entity sync snapshot raced etcd compaction", err) {
@@ -196,6 +236,7 @@ func (t *Exporter) runSession(ctx context.Context, session uplink.Session, link 
 			nextSnapshot = time.Now().Add(resnapshotInterval)
 		}
 		snapshotRequired = false
+		t.setMode("watching", "")
 		cursor, err = s.tail(link, watcher, cursor, nextSnapshot)
 		cancelWatch()
 		if ctx.Err() != nil {
@@ -216,6 +257,18 @@ func (t *Exporter) runSession(ctx context.Context, session uplink.Session, link 
 		if !s.retry(ctx, "entity sync stream interrupted", err) {
 			return
 		}
+	}
+}
+
+func (t *Exporter) setMode(mode, reason string) {
+	if t.diagnostics != nil {
+		t.diagnostics.setMode(mode, reason)
+	}
+}
+
+func (t *Exporter) fail(stage string, err error) {
+	if t.diagnostics != nil {
+		t.diagnostics.fail(stage, err)
 	}
 }
 
@@ -249,8 +302,10 @@ func (s *stream) retry(ctx context.Context, message string, err error) bool {
 		return false
 	}
 	if err != nil {
+		s.exporter.fail(message, err)
 		s.exporter.log.Warn(message, "error", err, "retry_in", sessionRetryDelay)
 	}
+	s.exporter.setMode("retrying", message)
 	timer := time.NewTimer(sessionRetryDelay)
 	defer timer.Stop()
 	select {
@@ -334,6 +389,9 @@ func (s *stream) snapshot(watchCtx context.Context, link Link) (int64, clientv3.
 	}
 
 	snapshotID := uuid.NewString()
+	if s.exporter.diagnostics != nil {
+		s.exporter.diagnostics.beginSnapshot(snapshotID, head, head+1)
+	}
 	if err := link.SendMessageBlocking(s.ctx, TypeSnapshotBegin, SnapshotBegin{
 		SnapshotID: snapshotID, SourceHead: head, ExportSchemaDigest: s.exporter.contract.Digest(),
 		SourceEpoch: s.sourceEpoch,
@@ -376,6 +434,9 @@ func (s *stream) snapshot(watchCtx context.Context, link Link) (int64, clientv3.
 				return 0, nil, err
 			}
 		}
+		if s.exporter.diagnostics != nil {
+			s.exporter.diagnostics.addSnapshotPage(len(entities), counts)
+		}
 		tailCursor, err = s.drainLiveChanges(link, watcher, tailCursor)
 		if err != nil {
 			return 0, nil, err
@@ -405,6 +466,9 @@ func (s *stream) snapshot(watchCtx context.Context, link Link) (int64, clientv3.
 	if ack.Cursor != tailCursor {
 		return 0, nil, fmt.Errorf("snapshot ack cursor %d does not match committed tail %d", ack.Cursor, tailCursor)
 	}
+	if s.exporter.diagnostics != nil {
+		s.exporter.diagnostics.finishSnapshot(ack.Cursor)
+	}
 	return ack.Cursor, watcher, nil
 }
 
@@ -431,7 +495,7 @@ func (s *stream) tail(link Link, watcher clientv3.WatchChan, cursor int64, nextS
 				return cursor, errors.New("entity export watch closed")
 			}
 			var err error
-			cursor, err = s.sendWatchResponse(link, response, cursor)
+			cursor, err = s.sendWatchResponse(link, response, cursor, true)
 			if err != nil {
 				return cursor, err
 			}
@@ -449,7 +513,7 @@ func (s *stream) drainLiveChanges(link Link, watcher clientv3.WatchChan, cursor 
 				return cursor, errors.New("entity export watch closed")
 			}
 			var err error
-			cursor, err = s.sendWatchResponse(link, response, cursor)
+			cursor, err = s.sendWatchResponse(link, response, cursor, false)
 			if err != nil {
 				return cursor, err
 			}
@@ -460,7 +524,7 @@ func (s *stream) drainLiveChanges(link Link, watcher clientv3.WatchChan, cursor 
 	return cursor, nil
 }
 
-func (s *stream) sendWatchResponse(link Link, response clientv3.WatchResponse, cursor int64) (int64, error) {
+func (s *stream) sendWatchResponse(link Link, response clientv3.WatchResponse, cursor int64, committed bool) (int64, error) {
 	if response.CompactRevision > 0 || errors.Is(response.Err(), rpctypes.ErrCompacted) {
 		return cursor, errCompacted
 	}
@@ -496,6 +560,12 @@ func (s *stream) sendWatchResponse(link Link, response clientv3.WatchResponse, c
 	}
 	if ack.Cursor != to {
 		return cursor, fmt.Errorf("change ack cursor %d does not match batch end %d", ack.Cursor, to)
+	}
+	if s.exporter.diagnostics != nil {
+		s.exporter.diagnostics.setNextWatchRevision(to + 1)
+		if committed {
+			s.exporter.diagnostics.setCursor(to)
+		}
 	}
 	return to, nil
 }
@@ -585,6 +655,9 @@ func (s *stream) sendAndWait(link Link, messageType string, payload any, message
 	case ack := <-waiter:
 		if ack.Error != "" {
 			return Ack{}, fmt.Errorf("cloud rejected %s: %s", messageType, ack.Error)
+		}
+		if s.exporter.diagnostics != nil {
+			s.exporter.diagnostics.acknowledge(messageType, ack)
 		}
 		return ack, nil
 	}

--- a/pkg/entitysync/exporter_test.go
+++ b/pkg/entitysync/exporter_test.go
@@ -532,6 +532,7 @@ func TestLiveChangePreemptsArchiveSnapshot(t *testing.T) {
 	store.AddEntity(deployment.Id(), deployment)
 
 	tenant := testExporter(store)
+	tenant.diagnostics = NewDiagnostics(core_v1alpha.CloudExportContract.Digest())
 	s := &stream{exporter: tenant, ctx: ctx, sourceEpoch: "mock-source-epoch", waiters: make(map[string]chan Ack)}
 	tenant.active = s
 	link := newFakeLink()
@@ -552,6 +553,8 @@ func TestLiveChangePreemptsArchiveSnapshot(t *testing.T) {
 			batch := payload.(ChangeBatch)
 			s.deliver(Ack{MessageID: batch.MessageID, Cursor: batch.ToRevision})
 		case TypeSnapshotComplete:
+			require.Zero(t, tenant.diagnostics.SnapshotStatus().CloudCursor,
+				"snapshot catch-up remains provisional until the snapshot commits")
 			complete := payload.(SnapshotComplete)
 			s.deliver(Ack{MessageID: complete.MessageID, Cursor: 8})
 		}
@@ -560,6 +563,7 @@ func TestLiveChangePreemptsArchiveSnapshot(t *testing.T) {
 	cursor, _, err := s.snapshot(ctx, link)
 	require.NoError(t, err)
 	require.Equal(t, int64(8), cursor)
+	require.Equal(t, int64(8), tenant.diagnostics.SnapshotStatus().CloudCursor)
 	messages := link.sent()
 	require.Equal(t, []string{
 		TypeSnapshotBegin, TypeSnapshotBatch, TypeChangeBatch, TypeSnapshotComplete,
@@ -953,7 +957,7 @@ func TestWatchBatchStopsAtLastDeliveredEvent(t *testing.T) {
 			{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Value: []byte("deployment/a"), ModRevision: 10}},
 			{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Value: []byte("deployment/b"), ModRevision: 20}},
 		},
-	}, 0)
+	}, 0, true)
 	require.NoError(t, err)
 	require.Equal(t, int64(20), cursor)
 	require.Len(t, link.sent(), 1)
@@ -1046,6 +1050,7 @@ func TestSendAndWaitPreservesCancellationAndRejection(t *testing.T) {
 
 	t.Run("cloud rejection", func(t *testing.T) {
 		exporter := testExporter(entity.NewMockStore())
+		exporter.diagnostics = NewDiagnostics("schema")
 		exporter.ackTimeout = time.Hour
 		stream := &stream{exporter: exporter, ctx: t.Context(), waiters: make(map[string]chan Ack)}
 		link := newFakeLink()
@@ -1055,6 +1060,8 @@ func TestSendAndWaitPreservesCancellationAndRejection(t *testing.T) {
 
 		_, err := stream.sendAndWait(link, TypeChangeBatch, struct{}{}, "message-1")
 		require.ErrorContains(t, err, "cloud rejected entity.change.batch: not accepted")
+		require.Nil(t, exporter.diagnostics.SnapshotStatus().LastAcknowledgment,
+			"a rejected message was not acknowledged by cloud")
 	})
 }
 

--- a/pkg/uplink/client.go
+++ b/pkg/uplink/client.go
@@ -69,6 +69,7 @@ type Client struct {
 	onSession    []func(ctx context.Context, session Session)
 	capabilities []capabilityRegistration
 	session      *sessionConfig
+	reportStatus StatusFunc
 
 	// NewClient enables this for production's pre-handshake path. Keeping it
 	// explicit lets narrow package tests construct a Client without also having
@@ -83,6 +84,17 @@ type Client struct {
 type sessionConfig struct {
 	runtimeVersion string
 }
+
+// Status describes the current state of the reconnecting uplink client.
+type Status struct {
+	State     string
+	Session   *Session
+	LastError string
+	RetryAt   time.Time
+}
+
+// StatusFunc receives uplink lifecycle changes. Callbacks must return quickly.
+type StatusFunc func(Status)
 
 // CapabilityOfferFunc builds the connection-specific payload for an offered
 // capability. Returning false omits the capability from that connection.
@@ -104,6 +116,17 @@ type ClientOption func(*Client)
 func WithSession(runtimeVersion string) ClientOption {
 	return func(c *Client) {
 		c.session = &sessionConfig{runtimeVersion: runtimeVersion}
+	}
+}
+
+// WithStatus reports connection lifecycle changes for operator diagnostics.
+func WithStatus(report StatusFunc) ClientOption {
+	return func(c *Client) { c.reportStatus = report }
+}
+
+func (c *Client) setStatus(status Status) {
+	if c.reportStatus != nil {
+		c.reportStatus(status)
 	}
 }
 
@@ -407,8 +430,10 @@ func (c *Client) SendMessageBlocking(ctx context.Context, msgType string, data a
 // until the context is cancelled.
 func (c *Client) Run(ctx context.Context) error {
 	backoff := initialBackoff
+	defer c.setStatus(Status{State: "stopped"})
 
 	for {
+		c.setStatus(Status{State: "connecting"})
 		start := time.Now()
 		err := c.runOnce(ctx)
 		if ctx.Err() != nil {
@@ -422,6 +447,9 @@ func (c *Client) Run(ctx context.Context) error {
 		}
 
 		delay := jittered(backoff)
+		c.setStatus(Status{
+			State: "retrying", LastError: fmt.Sprint(err), RetryAt: time.Now().Add(delay),
+		})
 
 		c.log.Warn("websocket disconnected, reconnecting",
 			"error", err, "backoff", delay)
@@ -484,6 +512,7 @@ func (c *Client) runOnce(ctx context.Context) error {
 	c.drainOutbox()
 
 	if c.session != nil {
+		c.setStatus(Status{State: "negotiating"})
 		session, callbacks, err := c.establishSession(ctx, conn)
 		if err != nil {
 			return fmt.Errorf("establish session: %w", err)
@@ -494,11 +523,15 @@ func (c *Client) runOnce(ctx context.Context) error {
 			"handshake_version", session.HandshakeVersion,
 			"capabilities", len(session.Capabilities),
 			"clock_offset", session.ClockOffset)
+		c.setStatus(Status{State: "connected", Session: &session})
 		for _, fn := range callbacks {
 			fn(ctx, session)
 		}
 	} else if c.legacyBootstrap {
+		c.setStatus(Status{State: "connected"})
 		c.sendLegacyInitialRequests()
+	} else {
+		c.setStatus(Status{State: "connected"})
 	}
 
 	for _, fn := range c.connectCallbacks() {

--- a/servers/debug/cloud_sync.go
+++ b/servers/debug/cloud_sync.go
@@ -1,0 +1,145 @@
+package debug
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/debug/debug_v1alpha"
+	"miren.dev/runtime/pkg/entitysync"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+func (s *Server) GetStatus(_ context.Context, state *debug_v1alpha.CloudSyncGetStatus) error {
+	if s.CloudSync == nil {
+		return errors.New("cloud sync diagnostics not available")
+	}
+
+	state.Results().SetReport(cloudSyncReport(s.CloudSync.SnapshotStatus()))
+	return nil
+}
+
+func cloudSyncReport(status entitysync.Status) *debug_v1alpha.CloudSyncReport {
+	report := &debug_v1alpha.CloudSyncReport{}
+	report.SetState(cloudSyncState(status))
+	report.SetSummary(cloudSyncSummary(status))
+
+	facts := make([]*debug_v1alpha.CloudSyncFact, 0, 16)
+	addFact := func(name, value string) {
+		if value == "" {
+			return
+		}
+		fact := &debug_v1alpha.CloudSyncFact{}
+		fact.SetName(name)
+		fact.SetValue(value)
+		facts = append(facts, fact)
+	}
+	addFact("uplink_state", status.UplinkState)
+	addFact("session_id", status.SessionID)
+	if status.HandshakeVersion != 0 {
+		addFact("handshake_version", strconv.FormatUint(uint64(status.HandshakeVersion), 10))
+	}
+	addFact("capability_state", status.CapabilityState)
+	if status.CapabilityVersion != 0 {
+		addFact("capability_version", strconv.FormatUint(uint64(status.CapabilityVersion), 10))
+	}
+	addFact("preparation_state", status.PreparationState)
+	addFact("preparation_detail", status.PreparationDetail)
+	addFact("source_epoch", status.SourceEpoch)
+	addFact("schema_digest", status.SchemaDigest)
+	addFact("wait_reason", status.WaitReason)
+	addFact("cloud_committed_cursor", strconv.FormatInt(status.CloudCursor, 10))
+	if status.NextWatchRevision != 0 {
+		addFact("next_watched_revision", strconv.FormatInt(status.NextWatchRevision, 10))
+	}
+	if !status.RetryAt.IsZero() {
+		addFact("retry_at", status.RetryAt.Format(time.RFC3339))
+	}
+	if snapshot := status.Snapshot; snapshot != nil {
+		addFact("snapshot_id", snapshot.ID)
+		addFact("snapshot_head_revision", strconv.FormatInt(snapshot.HeadRevision, 10))
+		addFact("snapshot_next_revision", strconv.FormatInt(snapshot.NextRevision, 10))
+		addFact("snapshot_pages_sent", strconv.FormatInt(snapshot.PagesSent, 10))
+		addFact("snapshot_entities_sent", strconv.FormatInt(snapshot.EntitiesSent, 10))
+		for _, kind := range slices.Sorted(maps.Keys(snapshot.CountsByKind)) {
+			addFact("snapshot_count."+kind, strconv.FormatInt(snapshot.CountsByKind[kind], 10))
+		}
+	}
+	report.SetFacts(facts)
+
+	events := make([]*debug_v1alpha.CloudSyncEvent, 0, 2)
+	if status.LastAcknowledgment != nil {
+		events = append(events, cloudSyncEvent("acknowledgment", status.LastAcknowledgment))
+	}
+	if status.LastError != nil {
+		events = append(events, cloudSyncEvent("error", status.LastError))
+	}
+	report.SetEvents(events)
+	return report
+}
+
+func cloudSyncState(status entitysync.Status) string {
+	if status.UplinkState == "disabled" || status.CapabilityState == "disabled" {
+		return "disabled"
+	}
+	if status.Mode == "" {
+		return "unknown"
+	}
+	return status.Mode
+}
+
+func cloudSyncSummary(status entitysync.Status) string {
+	state := cloudSyncState(status)
+	switch state {
+	case "disabled":
+		return cloudSyncSummaryWithReason("entity sync is disabled", status.WaitReason)
+	case "waiting":
+		return cloudSyncSummaryWithReason("entity sync is waiting", status.WaitReason)
+	case "retrying":
+		return cloudSyncSummaryWithReason("entity sync will retry", status.WaitReason)
+	case "snapshotting":
+		if status.Snapshot != nil && status.Snapshot.ID != "" {
+			return "sending entity snapshot " + status.Snapshot.ID
+		}
+		return "sending a full entity snapshot"
+	case "watching":
+		return "watching for entity changes"
+	default:
+		return "entity sync state is " + state
+	}
+}
+
+func cloudSyncSummaryWithReason(summary, reason string) string {
+	if reason == "" {
+		return summary
+	}
+	return summary + ": " + reason
+}
+
+func cloudSyncEvent(kind string, event *entitysync.Event) *debug_v1alpha.CloudSyncEvent {
+	rpcEvent := &debug_v1alpha.CloudSyncEvent{}
+	rpcEvent.SetKind(kind)
+	if !event.At.IsZero() {
+		rpcEvent.SetAt(standard.ToTimestamp(event.At))
+	}
+	var parts []string
+	if event.Stage != "" {
+		parts = append(parts, event.Stage)
+	}
+	if event.Message != "" {
+		parts = append(parts, event.Message)
+	}
+	if event.MessageID != "" {
+		parts = append(parts, "message "+event.MessageID)
+	}
+	if event.Cursor != 0 {
+		parts = append(parts, fmt.Sprintf("cursor %d", event.Cursor))
+	}
+	rpcEvent.SetSummary(strings.Join(parts, ", "))
+	return rpcEvent
+}

--- a/servers/debug/cloud_sync_test.go
+++ b/servers/debug/cloud_sync_test.go
@@ -1,0 +1,56 @@
+package debug
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/debug/debug_v1alpha"
+	"miren.dev/runtime/pkg/entitysync"
+)
+
+func TestGetStatusWithoutCloudSyncDiagnostics(t *testing.T) {
+	server := &Server{}
+
+	err := server.GetStatus(context.Background(), &debug_v1alpha.CloudSyncGetStatus{})
+
+	require.EqualError(t, err, "cloud sync diagnostics not available")
+}
+
+func TestCloudSyncReportKeepsProtocolDetailsInExtensibleFacts(t *testing.T) {
+	at := time.Date(2026, time.September, 4, 12, 30, 0, 0, time.UTC)
+	report := cloudSyncReport(entitysync.Status{
+		UplinkState:       "connected",
+		SessionID:         "session-1",
+		HandshakeVersion:  1,
+		CapabilityState:   "selected",
+		CapabilityVersion: 1,
+		PreparationState:  "ready",
+		SourceEpoch:       "epoch-1",
+		SchemaDigest:      "sha256:test",
+		Mode:              "snapshotting",
+		CloudCursor:       40,
+		Snapshot: &entitysync.SnapshotProgress{
+			ID: "snapshot-1", HeadRevision: 60, NextRevision: 61,
+			PagesSent: 2, EntitiesSent: 3, CountsByKind: map[string]int64{"app": 3},
+		},
+		LastAcknowledgment: &entitysync.Event{
+			At: at, Stage: "snapshot-page", MessageID: "message-1", Cursor: 40,
+		},
+	})
+
+	require.Equal(t, "snapshotting", report.State())
+	require.Equal(t, "sending entity snapshot snapshot-1", report.Summary())
+	facts := make(map[string]string, len(report.Facts()))
+	for _, fact := range report.Facts() {
+		facts[fact.Name()] = fact.Value()
+	}
+	require.Equal(t, "session-1", facts["session_id"])
+	require.Equal(t, "40", facts["cloud_committed_cursor"])
+	require.Equal(t, "3", facts["snapshot_count.app"])
+	require.Len(t, report.Events(), 1)
+	require.Equal(t, "acknowledgment", report.Events()[0].Kind())
+	require.Equal(t, "snapshot-page, message message-1, cursor 40", report.Events()[0].Summary())
+}

--- a/servers/debug/server.go
+++ b/servers/debug/server.go
@@ -11,17 +11,20 @@ import (
 	"miren.dev/runtime/api/debug/debug_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entitysync"
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc/standard"
 )
 
 type Server struct {
-	Log   *slog.Logger
-	NetDB *netdb.NetDB
-	EAC   *entityserver_v1alpha.EntityAccessClient
+	Log       *slog.Logger
+	NetDB     *netdb.NetDB
+	EAC       *entityserver_v1alpha.EntityAccessClient
+	CloudSync *entitysync.Diagnostics
 }
 
 var _ debug_v1alpha.NetDB = &Server{}
+var _ debug_v1alpha.CloudSync = &Server{}
 
 func NewServer(log *slog.Logger, netdbPath string, eac *entityserver_v1alpha.EntityAccessClient) (*Server, error) {
 	ndb, err := netdb.New(netdbPath)


### PR DESCRIPTION
When entity sync stalls, runtime currently leaves operators piecing together uplink logs and guessing which phase is stuck. This adds `miren debug cloud-sync`, backed by the local debug API, so operators can see connection and capability state, source preparation, epoch and schema, the committed cursor and watch revision, snapshot progress, and the last acknowledgment or error.

The diagnostics follow uplink reconnects and exporter transitions without changing the sync protocol. Snapshot-tail acknowledgments stay provisional until the full snapshot commits, so the command does not overstate what cloud has durably accepted. The focused runtime suite, race tests, package compilation, vet, and lint pass.

Part of MIR-1711