### PR TITLE
Make stale pool drains converge after node removal

### DIFF
--- a/components/coordinate/workload_control.go
+++ b/components/coordinate/workload_control.go
@@ -208,11 +208,13 @@ func (c *WorkloadControl) Start(ctx context.Context) error {
 	if err := nodeHealth.Init(ctx); err != nil {
 		return fmt.Errorf("initializing node health controller: %w", err)
 	}
-	cm.AddController(controller.NewReconcileController(
+	nodeHealthReconciler := controller.NewReconcileController(
 		"nodehealth", c.Log,
 		entity.Ref(entity.EntityKind, compute_v1alpha.KindNode), eac,
 		controller.AdaptReconcileController[compute_v1alpha.Node](nodeHealth), 30*time.Second, 1,
-	))
+	)
+	nodeHealthReconciler.SetPeriodic(time.Minute, nodeHealth.SweepOrphanedSandboxes)
+	cm.AddController(nodeHealthReconciler)
 
 	// Default routes are cluster-global derived state, not runner-local work.
 	defaultRouteApp := ingressctrl.NewDefaultRouteAppController(c.Log, eac)

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -246,11 +246,18 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 		// use leases), so the old sandbox must release the disk before the
 		// new one can mount it.
 		if serviceHasDisks(spec, svc.Name) {
-			if err := l.drainStaleDiskPools(ctx, app, &ver, spec, svc.Name); err != nil {
+			drained, err := l.drainStaleDiskPools(ctx, app, &ver, spec, svc.Name)
+			if err != nil {
 				l.Log.Error("failed to drain old disk pools, skipping service",
 					"app", app.ID,
 					"service", svc.Name,
 					"error", err)
+				continue
+			}
+			if !drained {
+				l.Log.Debug("stale disk pools are still draining, skipping service",
+					"app", app.ID,
+					"service", svc.Name)
 				continue
 			}
 		}
@@ -943,12 +950,6 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 	pool := poolWithEntity.Pool
 	ent := poolWithEntity.Entity
 
-	l.Log.Info("updating pool",
-		"pool", pool.ID,
-		"desired_instances", pool.DesiredInstances,
-		"references", pool.ReferencedByVersions,
-		"num_refs", len(pool.ReferencedByVersions))
-
 	// Build new attributes from the pool
 	newAttrs := pool.Encode()
 
@@ -1002,6 +1003,19 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 
 	// Add all new attrs (including multi-valued ReferencedByVersions from Encode())
 	finalAttrs = append(finalAttrs, newAttrs...)
+
+	// Direct EAC writes bypass ReconcileController's empty-diff guard. Keep this
+	// helper idempotent so a caller that asks for state already in the store does
+	// not advance UpdatedAt and wake every watcher again.
+	if entity.New(finalAttrs).Compare(&ent) == 0 {
+		return nil
+	}
+
+	l.Log.Info("updating pool",
+		"pool", pool.ID,
+		"desired_instances", pool.DesiredInstances,
+		"references", pool.ReferencedByVersions,
+		"num_refs", len(pool.ReferencedByVersions))
 
 	// Use Replace with the combined attributes (preserves metadata)
 	_, err := l.EAC.Replace(ctx, finalAttrs, 0)
@@ -1422,7 +1436,7 @@ func (l *Launcher) drainStaleDiskPools(
 	ver *core_v1alpha.AppVersion,
 	cfgSpec *core_v1alpha.ConfigSpec,
 	serviceName string,
-) error {
+) (bool, error) {
 	// Determine which image to use (same logic as ensurePoolForService)
 	image := ver.ImageUrl
 	for _, svc := range cfgSpec.Services {
@@ -1434,25 +1448,32 @@ func (l *Launcher) drainStaleDiskPools(
 
 	desiredSpec, err := l.buildSandboxSpec(ctx, app, ver, cfgSpec, serviceName, image)
 	if err != nil {
-		return fmt.Errorf("build sandbox spec: %w", err)
+		return false, fmt.Errorf("build sandbox spec: %w", err)
 	}
 
 	stalePools, err := l.findStalePoolsForService(ctx, app.ID, serviceName, desiredSpec)
 	if err != nil {
-		return fmt.Errorf("find stale pools: %w", err)
+		return false, fmt.Errorf("find stale pools: %w", err)
 	}
 
 	if len(stalePools) == 0 {
-		return nil
+		return true, nil
 	}
 
-	l.Log.Info("draining stale disk pools before creating new pool",
-		"app", app.ID,
-		"service", serviceName,
-		"stale_pools", len(stalePools))
+	newDrains := 0
 
 	for _, pwe := range stalePools {
 		pool := pwe.Pool
+		if pool.DesiredInstances == 0 && len(pool.ReferencedByVersions) == 0 {
+			continue
+		}
+
+		if newDrains == 0 {
+			l.Log.Info("draining stale disk pools before creating new pool",
+				"app", app.ID,
+				"service", serviceName,
+				"stale_pools", len(stalePools))
+		}
 
 		// Remove version references and scale to 0
 		pool.ReferencedByVersions = nil
@@ -1463,18 +1484,27 @@ func (l *Launcher) drainStaleDiskPools(
 			"service", pool.Service)
 
 		if err := l.updatePool(ctx, pwe); err != nil {
-			return fmt.Errorf("update pool %s: %w", pool.ID, err)
+			return false, fmt.Errorf("update pool %s: %w", pool.ID, err)
 		}
+		newDrains++
+	}
+
+	// The first pass waits so an ordinary disk deploy can start its replacement
+	// as soon as teardown finishes. Later resyncs observe the persisted drain
+	// request and return immediately instead of holding an app lock for a minute
+	// at a time when teardown cannot converge.
+	if newDrains == 0 {
+		return false, nil
 	}
 
 	// Wait for all stale pools to fully drain so disk leases are released.
 	for _, pwe := range stalePools {
 		if err := l.waitForPoolDrained(ctx, pwe.Pool.ID, pwe.Pool.Service, l.PoolReadyTimeout); err != nil {
-			return fmt.Errorf("waiting for pool %s to drain: %w", pwe.Pool.ID, err)
+			return false, fmt.Errorf("waiting for pool %s to drain: %w", pwe.Pool.ID, err)
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 // reapStaleStatelessPools scales to 0 any pool for a stateless service whose
@@ -1643,11 +1673,11 @@ func (l *Launcher) waitForPoolDrained(ctx context.Context, poolID entity.Id, ser
 	}
 }
 
-// hasActiveSandboxForPool returns true if any sandbox for the pool has not
-// reached DEAD. STOPPED is deliberately active here: the pool manager sets it
-// before the sandbox controller finishes graceful process shutdown and resource
-// cleanup, so starting a replacement at STOPPED can overlap access to a local
-// disk with the retiring process.
+// hasActiveSandboxForPool reports whether a pool still has a sandbox that can
+// conflict with a disk-backed replacement. STOPPED remains active when the old
+// sandbox mounted a volume: the pool manager sets STOPPED before the sandbox
+// controller finishes graceful process shutdown and resource cleanup. A stopped
+// diskless sandbox has no disk resource to release and cannot create that overlap.
 func (l *Launcher) hasActiveSandboxForPool(ctx context.Context, poolID entity.Id, service string) (bool, error) {
 	resp, err := l.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
 	if err != nil {
@@ -1658,8 +1688,11 @@ func (l *Launcher) hasActiveSandboxForPool(ctx context.Context, poolID entity.Id
 		var sb compute_v1alpha.Sandbox
 		sb.Decode(ent.Entity())
 
-		if sb.Status == compute_v1alpha.DEAD {
+		if sb.Status == compute_v1alpha.DEAD ||
+			(sb.Status == compute_v1alpha.STOPPED && len(sb.Spec.Volume) == 0) {
 			// DEAD is set after process shutdown and resource cleanup complete.
+			// A diskless STOPPED sandbox cannot conflict with the replacement's
+			// disk, so it need not hold a disk-aware deploy behind its teardown.
 			continue
 		}
 

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -726,6 +726,53 @@ func TestUpdatePoolPreservesMetadata(t *testing.T) {
 	assert.Empty(t, updatedPool.ReferencedByVersions, "should clear ReferencedByVersions")
 }
 
+func TestUpdatePoolSkipsUnchangedEntity(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 0,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("version-1"),
+		},
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	launcher := newTestLauncher(log, server.EAC)
+
+	// Normalize the explicit zero attributes that Encode omits. The second call
+	// then represents the minutely stale-drain retry from MIR-1780.
+	created, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+	require.NoError(t, launcher.updatePool(ctx, &PoolWithEntity{
+		Pool:   pool,
+		Entity: *created.Entity().Entity(),
+	}))
+
+	normalized, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+	var unchanged compute_v1alpha.SandboxPool
+	unchanged.Decode(normalized.Entity().Entity())
+	revision := normalized.Entity().Revision()
+	updatedAt := normalized.Entity().Entity().GetUpdatedAt()
+
+	require.NoError(t, launcher.updatePool(ctx, &PoolWithEntity{
+		Pool:   &unchanged,
+		Entity: *normalized.Entity().Entity(),
+	}))
+
+	after, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+	assert.Equal(t, revision, after.Entity().Revision(), "no-op update must not advance the revision")
+	assert.Equal(t, updatedAt, after.Entity().Entity().GetUpdatedAt(), "no-op update must not advance UpdatedAt")
+}
+
 // TestAutoModePoolReusePreservesDesiredInstances tests that when reusing a pool
 // for an auto mode service, the launcher does NOT reset desired_instances.
 // For auto mode, the activator manages desired_instances based on traffic,
@@ -3293,6 +3340,28 @@ func TestDiskPoolDrainedBeforeNewPoolCreated(t *testing.T) {
 	assert.Equal(t, "local", poolV2.SandboxSpec.Volume[0].Provider)
 }
 
+func TestStoppedDisklessSandboxDoesNotBlockDiskPoolDrain(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	poolID := entity.Id("pool/stale-diskless")
+	_, err := server.Client.Create(ctx, "stopped-diskless", &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.STOPPED,
+	}, apiserver.WithLabels(types.LabelSet(
+		"pool", poolID.String(),
+		"service", "web",
+	)))
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	active, err := launcher.hasActiveSandboxForPool(ctx, poolID, "web")
+	require.NoError(t, err)
+	assert.False(t, active, "a stopped diskless sandbox cannot conflict with a disk-backed replacement")
+}
+
 // TestDiskDrainWaitsForStoppedSandboxToDie verifies that STOPPED is only a
 // teardown request, not proof that the old process and its disk resources are
 // gone. The replacement pool must wait until the sandbox reaches DEAD.
@@ -3354,6 +3423,7 @@ func TestDiskDrainWaitsForStoppedSandboxToDie(t *testing.T) {
 	// finishes graceful shutdown and resource cleanup.
 	sb := &compute_v1alpha.Sandbox{
 		Status: compute_v1alpha.STOPPED,
+		Spec:   poolsV1[0].SandboxSpec,
 	}
 	sbID, err := server.Client.Create(ctx, "old-sandbox",
 		sb,
@@ -3416,6 +3486,22 @@ func TestDiskDrainWaitsForStoppedSandboxToDie(t *testing.T) {
 		"old pool should be scaled to 0")
 	assert.Empty(t, poolV1.ReferencedByVersions,
 		"old pool should have no version references")
+
+	// A periodic resync sees that the drain request is already persisted. It
+	// must neither rewrite the same pool nor wait for the full drain timeout.
+	firstDrainResp, err := server.EAC.Get(ctx, poolV1ID.String())
+	require.NoError(t, err)
+	firstDrainRevision := firstDrainResp.Entity().Revision()
+	launcher.PoolReadyTimeout = 2 * time.Second
+	started := time.Now()
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+	assert.Less(t, time.Since(started), 500*time.Millisecond,
+		"an already-requested drain should not occupy the launcher until timeout")
+
+	secondDrainResp, err := server.EAC.Get(ctx, poolV1ID.String())
+	require.NoError(t, err)
+	assert.Equal(t, firstDrainRevision, secondDrainResp.Entity().Revision(),
+		"an already-requested drain should not rewrite the pool")
 
 	// DEAD confirms shutdown and cleanup finished. The next reconcile may now
 	// create the replacement pool.

--- a/controllers/nodehealth/controller.go
+++ b/controllers/nodehealth/controller.go
@@ -3,6 +3,7 @@ package nodehealth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -109,6 +110,69 @@ func (c *Controller) Delete(ctx context.Context, id entity.Id) error {
 	return nil
 }
 
+// SweepOrphanedSandboxes deletes terminal sandboxes whose scheduled node no
+// longer exists. No node-scoped sandbox controller can finish or collect these
+// entities, so they otherwise keep stale pools alive indefinitely. The grace
+// period protects a freshly removed node from an immediate cleanup race.
+func (c *Controller) SweepOrphanedSandboxes(ctx context.Context) error {
+	nodes, err := c.eac.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindNode))
+	if err != nil {
+		return fmt.Errorf("listing nodes for orphaned sandbox sweep: %w", err)
+	}
+
+	knownNodes := make(map[entity.Id]bool, len(nodes.Values()))
+	for _, e := range nodes.Values() {
+		knownNodes[entity.Id(e.Id())] = true
+	}
+
+	sandboxes, err := c.eac.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return fmt.Errorf("listing sandboxes for orphaned sandbox sweep: %w", err)
+	}
+
+	cutoff := c.now().Add(-c.gracePeriod)
+	deleted := 0
+	var deleteErr error
+	for _, e := range sandboxes.Values() {
+		var schedule compute_v1alpha.Schedule
+		if !schedule.Is(e.Entity()) {
+			continue
+		}
+		schedule.Decode(e.Entity())
+		if schedule.Key.Node == "" || knownNodes[schedule.Key.Node] {
+			continue
+		}
+
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(e.Entity())
+		if sb.Status != compute_v1alpha.STOPPED && sb.Status != compute_v1alpha.DEAD {
+			continue
+		}
+		if time.UnixMilli(e.UpdatedAt()).After(cutoff) {
+			continue
+		}
+
+		c.log.Info("deleting terminal sandbox assigned to missing node",
+			"sandbox", sb.ID,
+			"node", schedule.Key.Node,
+			"status", sb.Status)
+		if _, err := c.eac.Delete(ctx, sb.ID.String()); err != nil {
+			c.log.Error("failed to delete sandbox assigned to missing node",
+				"sandbox", sb.ID,
+				"node", schedule.Key.Node,
+				"error", err)
+			deleteErr = errors.Join(deleteErr, err)
+			continue
+		}
+		deleted++
+	}
+
+	if deleted > 0 {
+		c.log.Warn("deleted terminal sandboxes assigned to missing nodes", "count", deleted)
+	}
+	return deleteErr
+}
+
 // clearTracking removes a node from all tracking maps (it recovered,
 // was removed, or entered a managed state like DISABLED).
 func (c *Controller) clearTracking(nodeID entity.Id) {
@@ -166,7 +230,10 @@ func (c *Controller) markNodeSandboxesDead(ctx context.Context, nodeID entity.Id
 		var sb compute_v1alpha.Sandbox
 		sb.Decode(e.Entity())
 
-		if sb.Status == compute_v1alpha.DEAD || sb.Status == compute_v1alpha.STOPPED {
+		// A STOPPED sandbox still needs its runner to release resources and mark
+		// it DEAD. Once that runner is unhealthy, nodehealth must finish the
+		// transition so a replacement can be scheduled.
+		if sb.Status == compute_v1alpha.DEAD {
 			continue
 		}
 

--- a/controllers/nodehealth/controller_test.go
+++ b/controllers/nodehealth/controller_test.go
@@ -215,7 +215,7 @@ func TestNodeRecoversWithinGracePeriod(t *testing.T) {
 		"sandbox should remain RUNNING after node recovered")
 }
 
-func TestSkipsAlreadyDeadAndStoppedSandboxes(t *testing.T) {
+func TestMarksStoppedSandboxDeadAfterGracePeriod(t *testing.T) {
 	ctx := context.Background()
 	server, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
@@ -236,10 +236,64 @@ func TestSkipsAlreadyDeadAndStoppedSandboxes(t *testing.T) {
 
 	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sbDead),
 		"already DEAD sandbox should stay DEAD")
-	assert.Equal(t, compute_v1alpha.STOPPED, getSandboxStatus(t, ctx, server, sbStopped),
-		"already STOPPED sandbox should stay STOPPED")
+	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sbStopped),
+		"STOPPED sandbox cannot finish cleanup after its node fails")
 	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sbRunning),
 		"RUNNING sandbox should be marked DEAD")
+}
+
+func TestSweepOrphanedSandboxes(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	missingNodeID := createReadyNode(t, ctx, server.Client, "missing-node", &compute_v1alpha.Node{
+		Status: compute_v1alpha.READY,
+	})
+	readyNodeID := createReadyNode(t, ctx, server.Client, "ready-node", &compute_v1alpha.Node{
+		Status: compute_v1alpha.READY,
+	})
+
+	oldTime := time.Now().Add(-10 * time.Minute)
+	server.Store.NowFunc = func() time.Time { return oldTime }
+	orphanStopped := createScheduledSandbox(t, ctx, server, "orphan-stopped", missingNodeID, compute_v1alpha.STOPPED)
+	orphanDead := createScheduledSandbox(t, ctx, server, "orphan-dead", missingNodeID, compute_v1alpha.DEAD)
+	ownedStopped := createScheduledSandbox(t, ctx, server, "owned-stopped", readyNodeID, compute_v1alpha.STOPPED)
+	server.Store.NowFunc = nil
+
+	_, err := server.EAC.Delete(ctx, missingNodeID.String())
+	require.NoError(t, err)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	require.NoError(t, ctrl.Init(ctx))
+	require.NoError(t, ctrl.SweepOrphanedSandboxes(ctx))
+
+	_, err = server.EAC.Get(ctx, orphanStopped.String())
+	assert.Error(t, err, "old STOPPED sandbox on a missing node should be deleted")
+	_, err = server.EAC.Get(ctx, orphanDead.String())
+	assert.Error(t, err, "old DEAD sandbox on a missing node should be deleted")
+	assert.Equal(t, compute_v1alpha.STOPPED, getSandboxStatus(t, ctx, server, ownedStopped),
+		"terminal sandbox on an existing node should be left for its owner")
+}
+
+func TestSweepOrphanedSandboxesHonorsGracePeriod(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	missingNodeID := createReadyNode(t, ctx, server.Client, "missing-node", &compute_v1alpha.Node{
+		Status: compute_v1alpha.READY,
+	})
+	freshOrphan := createScheduledSandbox(t, ctx, server, "fresh-orphan", missingNodeID, compute_v1alpha.STOPPED)
+	_, err := server.EAC.Delete(ctx, missingNodeID.String())
+	require.NoError(t, err)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	require.NoError(t, ctrl.Init(ctx))
+	require.NoError(t, ctrl.SweepOrphanedSandboxes(ctx))
+
+	assert.Equal(t, compute_v1alpha.STOPPED, getSandboxStatus(t, ctx, server, freshOrphan),
+		"a freshly orphaned sandbox should survive the node failure grace period")
 }
 
 func TestDisabledNodeSkipsGracePeriod(t *testing.T) {

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -573,6 +573,13 @@ func (m *Manager) checkAllPoolsForScaleDown(ctx context.Context) error {
 		var pool compute_v1alpha.SandboxPool
 		pool.Decode(ent.Entity())
 
+		// A decommissioned pool has no capacity to scale down. Avoid loading its
+		// baked AppVersion, which may already have been deleted while the empty
+		// pool waits for its final sandbox entities to be collected.
+		if pool.DesiredInstances == 0 && len(pool.ReferencedByVersions) == 0 {
+			continue
+		}
+
 		// Skip pools without a version (e.g. addon pools) — they don't use
 		// concurrency-based scale-down.
 		if pool.SandboxSpec.Version == "" {


### PR DESCRIPTION
Disk-aware deploys could wedge when a historical, diskless sandbox remained STOPPED on a node that no longer existed. Each resync rewrote the already-decommissioned pool, waited for the same timeout, and blocked the app from reconciling.

Make launcher drain updates idempotent and treat STOPPED diskless sandboxes as unable to conflict with a disk-backed replacement, while preserving the DEAD barrier for sandboxes that mounted volumes. Nodehealth now completes STOPPED to DEAD after the existing five-minute grace period and periodically collects terminal sandboxes whose scheduled node is gone, so old tombstones eventually disappear instead of pinning pools forever.

Closes MIR-1780