### PR TITLE
Report runtime-owned app health at cloud-requested cadences

### DIFF
--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -298,7 +298,7 @@ func TestApiAddresses(t *testing.T) {
 				},
 				Log:            slog.Default(),
 				netcheckResult: tt.netcheckResult,
-			})
+			}, nil)
 
 			got := c.apiAddresses()
 

--- a/components/coordinate/cloud_control.go
+++ b/components/coordinate/cloud_control.go
@@ -14,6 +14,7 @@ import (
 
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/pkg/anywhere"
+	"miren.dev/runtime/pkg/apphealthsync"
 	"miren.dev/runtime/pkg/cloudauth"
 	"miren.dev/runtime/pkg/cloudrpc"
 	"miren.dev/runtime/pkg/containerenv"
@@ -29,13 +30,19 @@ import (
 
 // NewCloudControl constructs cloud status, identity publication, and uplink
 // integration on top of cluster state.
-func NewCloudControl(foundation *Foundation) *CloudControl {
-	return &CloudControl{Foundation: foundation}
+func NewCloudControl(foundation *Foundation, applications *ApplicationManagement) *CloudControl {
+	return &CloudControl{Foundation: foundation, applications: applications}
 }
 
 // CloudControl owns cloud status, identity publication, and uplink integration.
 type CloudControl struct {
 	*Foundation
+
+	// applications supplies the health classification the uplink reports. It is
+	// the same AppInfo backing the app RPC surface, so the console cannot
+	// disagree with `miren app list`.
+	applications *ApplicationManagement
+
 	publishedKeysMu         sync.Mutex
 	publishedKeyFingerprint string
 	cancel                  context.CancelFunc
@@ -97,6 +104,15 @@ func (c *CloudControl) RunCloudUplink(ctx context.Context, ingress *httpingress.
 			// Entity visibility is additive. Local source metadata should not take
 			// Anywhere or cloud RPC off the shared link when it is unavailable.
 			c.Log.Warn("entity sync is unavailable for this uplink session", "error", err)
+		}
+	}
+	if labs.AppVisibility() && c.applications != nil && c.applications.appInfo != nil {
+		if err := apphealthsync.NewReporter(
+			c.Log.With("component", "app-health"), c.applications.appInfo,
+		).Register(ctx, link); err != nil {
+			// Health reporting is additive, like entity sync. It must not take
+			// Anywhere or cloud RPC off the shared link when it is unavailable.
+			c.Log.Warn("app health reporting is unavailable for this uplink session", "error", err)
 		}
 	}
 	anywhereConn := anywhere.New(anywhere.Config{

--- a/components/coordinate/control_plane.go
+++ b/components/coordinate/control_plane.go
@@ -38,7 +38,7 @@ func NewControlPlane(foundation *Foundation, supplied ...ControlPlaneParts) *Con
 		parts.Maintenance = NewEntityMaintenance(foundation)
 	}
 	if parts.Cloud == nil {
-		parts.Cloud = NewCloudControl(foundation)
+		parts.Cloud = NewCloudControl(foundation, parts.Applications)
 	}
 	return &ControlPlane{
 		Foundation:      foundation,

--- a/components/coordinate/record_anchor_test.go
+++ b/components/coordinate/record_anchor_test.go
@@ -24,7 +24,7 @@ func registeredCloudControl(t *testing.T, stored string) (*CloudControl, string)
 		PrivateKey:        "unused",
 	}))
 
-	c := NewCloudControl(&Foundation{Log: testLogger()})
+	c := NewCloudControl(&Foundation{Log: testLogger()}, nil)
 	c.DataPath = dataPath
 	c.CloudAuth = CloudAuthConfig{Enabled: true, ClusterID: "cluster-abc", IdentityIssuerURL: stored}
 	return c, dir
@@ -76,7 +76,7 @@ func TestRecordIdentityAnchorIgnoresNoOps(t *testing.T) {
 // An unregistered cluster has no file to write, and must not gain one.
 func TestRecordIdentityAnchorOnUnregisteredClusterIsInert(t *testing.T) {
 	dataPath := t.TempDir()
-	c := NewCloudControl(&Foundation{Log: testLogger()})
+	c := NewCloudControl(&Foundation{Log: testLogger()}, nil)
 	c.DataPath = dataPath
 
 	require.NotPanics(t, func() { c.recordIdentityAnchor(reportedAnchor) })

--- a/components/coordinate/workload_identity_publish_test.go
+++ b/components/coordinate/workload_identity_publish_test.go
@@ -98,7 +98,7 @@ func TestAnchoredAtCloud(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewCloudControl(new(Foundation))
+			c := NewCloudControl(new(Foundation), nil)
 			c.CloudAuth = tt.cloud
 			if !tt.noIssuer {
 				c.WorkloadIssuer = newTestIssuer(t, tt.issuerURL)
@@ -116,7 +116,7 @@ func TestAnchoredAtCloud(t *testing.T) {
 // including one with no cloud at all, where authClient is nil and touching it
 // would panic.
 func TestPublishSigningKeysIsInertWithoutCloudAnchor(t *testing.T) {
-	c := NewCloudControl(&Foundation{Log: testLogger()})
+	c := NewCloudControl(&Foundation{Log: testLogger()}, nil)
 	c.WorkloadIssuer = newTestIssuer(t, workloadidentity.LocalIssuerURL)
 
 	published, err := c.publishSigningKeys(context.Background())

--- a/components/server/boot_cloud_control.go
+++ b/components/server/boot_cloud_control.go
@@ -19,21 +19,23 @@ type cloudControlBoot struct {
 	value     *coordinate.CloudControl
 }
 
-func newCloudControlBoot(foundation boot.Output[foundationBootOutput], applications, maintenance, workloads *boot.Component) *cloudControlBoot {
+func newCloudControlBoot(foundation boot.Output[foundationBootOutput], applications boot.Output[applicationManagementBootOutput], maintenance, workloads *boot.Component) *cloudControlBoot {
 	b := &cloudControlBoot{}
-	b.component, b.output = boot.Provide1(
-		"cloud-control", foundation, b.start,
+	b.component, b.output = boot.Provide2(
+		"cloud-control", foundation, applications, b.start,
 		// Cloud startup status means the management, maintenance, and workload
 		// control planes are available. It does not promise ingress or build and
 		// deployment admission, which have their own readiness boundaries.
-		boot.DependsOn(applications, maintenance, workloads),
+		// Application management is an input rather than an ordering edge because
+		// the uplink reports the health it classifies.
+		boot.DependsOn(maintenance, workloads),
 		boot.WithStop(b.stop, componentStopTimeout),
 	)
 	return b
 }
 
-func (b *cloudControlBoot) start(ctx context.Context, foundation foundationBootOutput) (cloudControlBootOutput, error) {
-	cloud := coordinate.NewCloudControl(foundation.foundation)
+func (b *cloudControlBoot) start(ctx context.Context, foundation foundationBootOutput, applications applicationManagementBootOutput) (cloudControlBootOutput, error) {
+	cloud := coordinate.NewCloudControl(foundation.foundation, applications.applications)
 	if err := cloud.Start(ctx); err != nil {
 		return cloudControlBootOutput{}, err
 	}

--- a/components/server/startup.go
+++ b/components/server/startup.go
@@ -140,7 +140,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 	sandboxAgent := runnercomp.NewSandboxAgentBoot(sandboxHost.output, componentStopTimeout, workloadControl.component)
 	nodePresence := runnercomp.NewNodePresenceBoot(sandboxHost.output, storageAgent.Component, sandboxAgent.Component, componentStopTimeout)
 	maintenance := newEntityMaintenanceBoot(foundation.output, appData.component)
-	cloudControl := newCloudControlBoot(foundation.output, applicationManagement.component, maintenance.component, workloadControl.component)
+	cloudControl := newCloudControlBoot(foundation.output, applicationManagement.output, maintenance.component, workloadControl.component)
 	ingress := newIngressBoot(ingressInputs(options), workloadControl.output, nodePresence.Component, workloadIdentity.output, entityAccess.output, observability.output)
 	adminAPI := newAdminBoot(foundation.output, entityAccess.output, ingress.output, observability.output)
 	cloudUplink := newCloudUplinkBoot(cloudControl.output, deploymentAttempts.output, ingress.output)

--- a/pkg/apphealth/apphealth.go
+++ b/pkg/apphealth/apphealth.go
@@ -23,3 +23,29 @@ const (
 	// Unknown means there is no pool state to derive health from.
 	Unknown = "unknown"
 )
+
+// State is one app's health classification and the counts behind it.
+//
+// It lives here rather than beside the code that derives it so that both the
+// app RPC surface and the cloud health reporter can name the same value without
+// either depending on the other. The derivation itself stays in one place: see
+// AppInfo.ListAppHealth.
+type State struct {
+	Name   string
+	Health string
+
+	// Pooled reports whether the counts below came from real sandbox pools.
+	//
+	// It matters because an app with an active version but no pools yet reports
+	// zero instances, which is a different statement from an app whose instance
+	// counts do not apply at all, and only a pooled app has a scaling mode.
+	// Carried on the value so callers do not each re-derive it and drift.
+	Pooled           bool
+	ReadyInstances   int32
+	DesiredInstances int32
+	ScalingMode      string
+
+	InCooldown      bool
+	CrashCount      int64
+	CooldownSeconds int32
+}

--- a/pkg/apphealthsync/reporter.go
+++ b/pkg/apphealthsync/reporter.go
@@ -1,0 +1,192 @@
+// Package apphealthsync samples runtime-owned health for cloud's ephemeral cache.
+package apphealthsync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"miren.dev/runtime/pkg/apphealth"
+	"miren.dev/runtime/pkg/uplink"
+)
+
+const (
+	defaultBackground = 5 * time.Minute
+	minInterval       = time.Second
+	maxInterval       = time.Hour
+	maxLease          = time.Minute
+	maxBatch          = 100
+)
+
+// Source shares the classifier used by the app list.
+type Source interface {
+	ListAppHealth(context.Context) ([]apphealth.State, error)
+}
+
+type Link interface {
+	OfferCapability(uplink.CapabilityOffer)
+	OnSession(func(context.Context, uplink.Session))
+	Handle(string, uplink.MessageHandler)
+	SendMessageBlocking(context.Context, string, any) error
+}
+
+type samplingSession struct {
+	id     string
+	ctx    context.Context
+	demand chan Demand
+}
+
+type Reporter struct {
+	log     *slog.Logger
+	source  Source
+	mu      sync.Mutex
+	session *samplingSession
+}
+
+func NewReporter(log *slog.Logger, source Source) *Reporter {
+	return &Reporter{log: log, source: source}
+}
+
+func (r *Reporter) Register(_ context.Context, link Link) error {
+	link.OfferCapability(uplink.CapabilityOffer{Name: uplink.CapabilityAppHealth, Versions: []uint{Version1}})
+	link.Handle(TypeDemand, r.handleDemand)
+	link.OnSession(func(ctx context.Context, session uplink.Session) {
+		selection, ok := session.Capability(uplink.CapabilityAppHealth)
+		if !ok {
+			return
+		}
+		background := defaultBackground
+		var config Config
+		if len(selection.Config) > 0 {
+			if err := json.Unmarshal(selection.Config, &config); err != nil {
+				r.log.Warn("invalid app health configuration", "error", err)
+				return
+			}
+			if config.BackgroundSeconds > 0 {
+				seconds := min(config.BackgroundSeconds, int(maxInterval/time.Second))
+				background = max(minInterval, time.Duration(seconds)*time.Second)
+			}
+		}
+		active := &samplingSession{id: session.ID, ctx: ctx, demand: make(chan Demand, 1)}
+		r.mu.Lock()
+		r.session = active
+		r.mu.Unlock()
+		go r.run(active, link, background)
+	})
+	return nil
+}
+
+func (r *Reporter) handleDemand(_ context.Context, raw json.RawMessage) error {
+	var demand Demand
+	if err := json.Unmarshal(raw, &demand); err != nil {
+		return err
+	}
+	if demand.IntervalSeconds < 1 || demand.IntervalSeconds > int(maxInterval/time.Second) || demand.LeaseSeconds < 1 || demand.LeaseSeconds > int(maxLease/time.Second) {
+		return fmt.Errorf("invalid app health sampling demand")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	active := r.session
+	if active == nil || active.ctx.Err() != nil || active.id != demand.SessionID {
+		return nil
+	}
+	// Keep the latest request without blocking the shared uplink read loop.
+	select {
+	case <-active.demand:
+	default:
+	}
+	active.demand <- demand
+	return nil
+}
+
+func (r *Reporter) run(active *samplingSession, link Link, background time.Duration) {
+	ctx := active.ctx
+	r.log.Info("app health sampling started", "background_interval", background)
+	// Spread unsolicited connection samples; viewing a panel bypasses this wait.
+	next := time.Now().Add(uplink.SpreadOnConnect(time.Minute))
+	var last, until time.Time
+	derivationFailed := false
+	interval := background
+	timer := time.NewTimer(time.Until(next))
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case demand := <-active.demand:
+			now := time.Now()
+			wasActive := now.Before(until)
+			interval = min(background, time.Duration(demand.IntervalSeconds)*time.Second)
+			until = now.Add(time.Duration(demand.LeaseSeconds) * time.Second)
+			if !wasActive {
+				// A returning viewer gets a fresh sample, bounded even if short leases
+				// and many viewers repeatedly enter fast mode.
+				next = minTime(next, maxTime(now, last.Add(minInterval)))
+			} else {
+				next = minTime(next, last.Add(interval))
+			}
+		case <-timer.C:
+			now := time.Now()
+			if !until.IsZero() && !now.Before(until) {
+				until = time.Time{}
+				interval = background
+				next = last.Add(background)
+			}
+			if !now.Before(next) {
+				last = now
+				err := r.sample(ctx, link)
+				if ctx.Err() != nil {
+					return
+				}
+				if err != nil && !derivationFailed {
+					r.log.Warn("failed to derive app health", "error", err)
+				} else if err == nil && derivationFailed {
+					r.log.Info("app health derivation recovered")
+				}
+				derivationFailed = err != nil
+				next = time.Now().Add(interval)
+			}
+		}
+		wake := next
+		if !until.IsZero() {
+			wake = minTime(wake, until)
+		}
+		timer.Reset(time.Until(wake))
+	}
+}
+
+// sample returns derivation errors; transport failures are expected on disconnect.
+func (r *Reporter) sample(ctx context.Context, link Link) error {
+	observed := time.Now().UTC()
+	apps, err := r.source.ListAppHealth(ctx)
+	if err != nil {
+		return err
+	}
+	for start := 0; start < len(apps); start += maxBatch {
+		batch := SampleBatch{ObservedAt: observed, Apps: make([]Sample, 0, min(maxBatch, len(apps)-start))}
+		for _, app := range apps[start:min(start+maxBatch, len(apps))] {
+			batch.Apps = append(batch.Apps, Sample{Name: app.Name, Health: app.Health, ReadyInstances: app.ReadyInstances, DesiredInstances: app.DesiredInstances})
+		}
+		if err := link.SendMessageBlocking(ctx, TypeSamples, batch); err != nil {
+			r.log.Debug("failed to queue app health sample", "error", err)
+			return nil
+		}
+	}
+	return nil
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}
+func maxTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}

--- a/pkg/apphealthsync/reporter_test.go
+++ b/pkg/apphealthsync/reporter_test.go
@@ -1,0 +1,315 @@
+package apphealthsync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/apphealth"
+	"miren.dev/runtime/pkg/uplink"
+)
+
+type fakeLink struct {
+	mu       sync.Mutex
+	offers   []uplink.CapabilityOffer
+	sessions []func(context.Context, uplink.Session)
+	batches  []SampleBatch
+	sendErr  error
+	handler  uplink.MessageHandler
+}
+
+func newFakeLink() *fakeLink {
+	return &fakeLink{}
+}
+
+func (f *fakeLink) OfferCapability(offer uplink.CapabilityOffer) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.offers = append(f.offers, offer)
+}
+
+func (f *fakeLink) OnSession(fn func(context.Context, uplink.Session)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sessions = append(f.sessions, fn)
+}
+
+func (f *fakeLink) SendMessageBlocking(_ context.Context, msgType string, data any) error {
+	f.mu.Lock()
+	if f.sendErr != nil {
+		err := f.sendErr
+		f.mu.Unlock()
+		return err
+	}
+	if msgType != TypeSamples {
+		f.mu.Unlock()
+		return errors.New("unexpected message type " + msgType)
+	}
+	f.batches = append(f.batches, data.(SampleBatch))
+	f.mu.Unlock()
+
+	return nil
+}
+
+func (f *fakeLink) allBatches() []SampleBatch {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]SampleBatch(nil), f.batches...)
+}
+
+// appsIn flattens every batch the link received into one name-keyed map, which
+// is what a receiver that does not distinguish full from delta actually sees.
+func (f *fakeLink) appsIn() map[string]Sample {
+	out := map[string]Sample{}
+	for _, batch := range f.allBatches() {
+		for _, sample := range batch.Apps {
+			out[sample.Name] = sample
+		}
+	}
+	return out
+}
+
+func (f *fakeLink) sendCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.batches)
+}
+
+type fakeSource struct {
+	mu    sync.Mutex
+	apps  []apphealth.State
+	err   error
+	calls int
+}
+
+func (f *fakeSource) ListAppHealth(context.Context) ([]apphealth.State, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.apps, nil
+}
+
+func (f *fakeSource) set(apps ...apphealth.State) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.apps = apps
+}
+
+func (f *fakeSource) setErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+func (f *fakeSource) derivations() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakeLink) Handle(_ string, handler uplink.MessageHandler) { f.handler = handler }
+
+func startSampler(t *testing.T) (*Reporter, *fakeSource, *fakeLink, context.CancelFunc) {
+	t.Helper()
+	source := &fakeSource{apps: []apphealth.State{{Name: "web", Health: apphealth.Crashed, InCooldown: true, CooldownSeconds: 0}}}
+	link := newFakeLink()
+	reporter := NewReporter(slog.New(slog.DiscardHandler), source)
+	require.NoError(t, reporter.Register(context.Background(), link))
+	ctx, cancel := context.WithCancel(context.Background())
+	link.sessions[0](ctx, uplink.Session{ID: "s1", Capabilities: []uplink.CapabilitySelection{{Name: uplink.CapabilityAppHealth, Version: Version1, Config: json.RawMessage(`{"background_seconds":300}`)}}})
+	time.Sleep(time.Minute)
+	synctest.Wait()
+	require.Equal(t, 1, link.sendCount())
+	return reporter, source, link, cancel
+}
+
+func demand(t *testing.T, link *fakeLink, session string, interval, lease int) {
+	t.Helper()
+	raw, err := json.Marshal(Demand{SessionID: session, IntervalSeconds: interval, LeaseSeconds: lease})
+	require.NoError(t, err)
+	require.NoError(t, link.handler(context.Background(), raw))
+	synctest.Wait()
+}
+
+func TestSamplingFollowsDemandAndExpires(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		_, source, link, cancel := startSampler(t)
+		defer cancel()
+		source.set(apphealth.State{Name: "web", Health: apphealth.Starting})
+		demand(t, link, "s1", 5, 20)
+		require.Equal(t, 2, link.sendCount())
+		require.Equal(t, apphealth.Starting, link.appsIn()["web"].Health)
+		for range 12 {
+			time.Sleep(time.Second)
+			demand(t, link, "s1", 5, 20)
+		}
+		require.Equal(t, 4, link.sendCount(), "renewals neither derive nor postpone sampling")
+		time.Sleep(21 * time.Second)
+		synctest.Wait()
+		count := link.sendCount()
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		require.Equal(t, count, link.sendCount(), "expired interest returns to background cadence")
+		time.Sleep(5 * time.Minute)
+		synctest.Wait()
+		require.Greater(t, link.sendCount(), count, "background samples repair unchanged state")
+	})
+}
+
+func TestSessionFencingAndCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		_, source, link, cancel := startSampler(t)
+		demand(t, link, "old-session", 5, 20)
+		require.Equal(t, 1, link.sendCount())
+		cancel()
+		synctest.Wait()
+		before := source.derivations()
+		demand(t, link, "s1", 5, 20)
+		time.Sleep(10 * time.Minute)
+		synctest.Wait()
+		require.Equal(t, before, source.derivations())
+	})
+}
+
+func TestSamplesRecoverAfterReadAndSendFailures(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		_, source, link, cancel := startSampler(t)
+		defer cancel()
+		source.setErr(errors.New("unavailable"))
+		demand(t, link, "s1", 5, 20)
+		require.Equal(t, 1, link.sendCount())
+		source.setErr(nil)
+		link.mu.Lock()
+		link.sendErr = errors.New("full")
+		link.mu.Unlock()
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		require.Equal(t, 1, link.sendCount())
+		link.mu.Lock()
+		link.sendErr = nil
+		link.mu.Unlock()
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		require.Equal(t, 2, link.sendCount())
+	})
+}
+
+func TestBatchesShareObservationTime(t *testing.T) {
+	source := &fakeSource{apps: make([]apphealth.State, 205)}
+	link := newFakeLink()
+	require.NoError(t, NewReporter(slog.New(slog.DiscardHandler), source).sample(context.Background(), link))
+	batches := link.allBatches()
+	require.Len(t, batches, 3)
+	require.Len(t, batches[0].Apps, 100)
+	require.Len(t, batches[2].Apps, 5)
+	require.Equal(t, batches[0].ObservedAt, batches[2].ObservedAt)
+}
+
+func TestUnselectedCapabilityAndInvalidDemand(t *testing.T) {
+	source := &fakeSource{}
+	link := newFakeLink()
+	require.NoError(t, NewReporter(slog.New(slog.DiscardHandler), source).Register(context.Background(), link))
+	require.Equal(t, uplink.CapabilityAppHealth, link.offers[0].Name)
+	link.sessions[0](context.Background(), uplink.Session{ID: "s1"})
+	require.Zero(t, source.derivations())
+	for _, raw := range []string{`{`, `{"interval_seconds":0,"lease_seconds":20}`, `{"interval_seconds":5,"lease_seconds":61}`} {
+		require.Error(t, link.handler(context.Background(), json.RawMessage(raw)))
+	}
+}
+
+func TestDemandBypassesConnectSpreadAndReconnectDropsLease(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		source := &fakeSource{apps: []apphealth.State{{Name: "web", Health: apphealth.Healthy}}}
+		link := newFakeLink()
+		reporter := NewReporter(slog.New(slog.DiscardHandler), source)
+		require.NoError(t, reporter.Register(context.Background(), link))
+		ctx, cancel := context.WithCancel(context.Background())
+		session := uplink.Session{ID: "first", Capabilities: []uplink.CapabilitySelection{{Name: uplink.CapabilityAppHealth, Version: Version1}}}
+		link.sessions[0](ctx, session)
+		demand(t, link, "first", 5, 20)
+		require.Equal(t, 1, link.sendCount(), "a viewer does not wait for the connection spread")
+		cancel()
+		synctest.Wait()
+		ctx, cancel = context.WithCancel(context.Background())
+		defer cancel()
+		session.ID = "second"
+		link.sessions[0](ctx, session)
+		demand(t, link, "first", 5, 20)
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		require.Equal(t, 2, link.sendCount(), "new session only sends its opening sample")
+	})
+}
+
+func TestNegotiatedBackgroundCadence(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		source := &fakeSource{apps: []apphealth.State{{Name: "web"}}}
+		link := newFakeLink()
+		reporter := NewReporter(slog.New(slog.DiscardHandler), source)
+		require.NoError(t, reporter.Register(context.Background(), link))
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		link.sessions[0](ctx, uplink.Session{ID: "s1", Capabilities: []uplink.CapabilitySelection{{Name: uplink.CapabilityAppHealth, Version: Version1, Config: json.RawMessage(`{"background_seconds":120}`)}}})
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		require.Equal(t, 1, link.sendCount())
+		time.Sleep(2 * time.Minute)
+		synctest.Wait()
+		require.Equal(t, 2, link.sendCount())
+	})
+}
+
+func TestReturningViewerGetsFreshSample(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		_, _, link, cancel := startSampler(t)
+		defer cancel()
+		demand(t, link, "s1", 5, 6) // Sample now and at +5s; the lease ends at +6s.
+		time.Sleep(7 * time.Second)
+		synctest.Wait()
+		before := link.sendCount()
+		demand(t, link, "s1", 5, 20)
+		require.Equal(t, before+1, link.sendCount(), "a returning viewer gets a fresh reading")
+	})
+}
+
+func TestDerivationLogsOnlyFailureAndRecoveryTransitions(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		reporter, source, link, cancel := startSampler(t)
+		defer cancel()
+		var logs bytes.Buffer
+		reporter.log = slog.New(slog.NewTextHandler(&logs, nil))
+		source.setErr(errors.New("unavailable"))
+		demand(t, link, "s1", 1, 60)
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		require.Equal(t, 1, strings.Count(logs.String(), "level=WARN"))
+		require.Contains(t, logs.String(), "unavailable")
+
+		source.setErr(nil)
+		link.mu.Lock()
+		link.sendErr = errors.New("disconnected")
+		link.mu.Unlock()
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		require.Equal(t, 1, strings.Count(logs.String(), "app health derivation recovered"))
+		require.Equal(t, 1, strings.Count(logs.String(), "level=WARN"))
+		require.NotContains(t, logs.String(), "disconnected")
+
+		source.setErr(errors.New("unavailable again"))
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		require.Equal(t, 2, strings.Count(logs.String(), "level=WARN"))
+	})
+}

--- a/pkg/apphealthsync/wire.go
+++ b/pkg/apphealthsync/wire.go
@@ -1,0 +1,51 @@
+package apphealthsync
+
+import "time"
+
+const (
+	Version1 uint = 1
+
+	TypeSamples = "app.health.samples"
+	TypeDemand  = "app.health.demand"
+)
+
+// Sample is one app's health as the runtime classifies it.
+//
+// There is no cluster or organization field. Cloud derives both from the
+// authenticated identity on the socket: a cluster is never trusted to say
+// which tenant its data belongs to, only what its own apps are doing.
+type Sample struct {
+	Name string `json:"name"`
+
+	// Health is one of the apphealth values. It is computed by the same code
+	// that answers `miren app list`, so the CLI and the console cannot
+	// disagree about whether an app is fine.
+	Health string `json:"health"`
+
+	ReadyInstances   int32 `json:"ready_instances"`
+	DesiredInstances int32 `json:"desired_instances"`
+}
+
+// SampleBatch is one message's worth of samples.
+//
+// They share one ObservedAt because they come from a single derivation of the
+// cluster's state. Cloud applies last-writer-wins with it, so a message
+// delayed behind a fresher one cannot reinstate health that was already
+// corrected.
+type SampleBatch struct {
+	ObservedAt time.Time `json:"observed_at"`
+	Apps       []Sample  `json:"apps"`
+}
+
+// Config supplies the quiet-cluster cadence when the session opens.
+type Config struct {
+	BackgroundSeconds int `json:"background_seconds"`
+}
+
+// Demand temporarily accelerates sampling for a viewed cluster. SessionID
+// prevents a queued request from activating a replacement connection.
+type Demand struct {
+	SessionID       string `json:"session_id"`
+	IntervalSeconds int    `json:"interval_seconds"`
+	LeaseSeconds    int    `json:"lease_seconds"`
+}

--- a/pkg/uplink/session.go
+++ b/pkg/uplink/session.go
@@ -21,6 +21,7 @@ const (
 	CapabilityPopConnect = "pop-connect"
 	CapabilityRPCRelay   = "rpc-relay"
 	CapabilityEntitySync = "entity-sync"
+	CapabilityAppHealth  = "app-health"
 )
 
 // CapabilityOffer describes one protocol family the runtime can speak. The

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -149,30 +149,38 @@ func (r *AppInfo) List(ctx context.Context, state *app_v1alpha.CrudList) error {
 	return nil
 }
 
-// ListApps computes the current inventory of apps: identity, active version,
-// health, instance counts, scaling mode, and routes.
+// appEntry is one app with its active version and that version's entity
+// resolved, which is what both the health classification and the fuller
+// listing are built from.
+type appEntry struct {
+	name                string
+	app                 core_v1alpha.App
+	activeVersion       *core_v1alpha.AppVersion
+	activeVersionEntity *entityserver_v1alpha.Entity
+}
+
+// appHealthSource is everything a health classification is derived from: the
+// apps, their resolved config specs, and the aggregated pool state per app.
+type appHealthSource struct {
+	apps      []appEntry
+	specs     map[string]*core_v1alpha.ConfigSpec
+	poolState map[string]*poolHealth
+}
+
+// collectAppHealth reads what health is derived from, and nothing else.
 //
-// This is deliberately shared rather than duplicated. Health is a
-// classification over sandbox pool state, not a stored field, so any second
-// implementation would drift from this one and let `miren app list` and the
-// cloud dashboard disagree about whether an app is healthy. Both read from
-// here instead.
-func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) {
+// Kept separate from route lookup so periodic health samples do not pay for
+// an HttpRoute listing they will discard.
+func (r *AppInfo) collectAppHealth(ctx context.Context) (*appHealthSource, error) {
 	list, err := r.EC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindApp))
 	if err != nil {
 		return nil, err
 	}
 
-	// Collect apps and resolve their active versions
-	type appEntry struct {
-		name                string
-		app                 core_v1alpha.App
-		activeVersion       *core_v1alpha.AppVersion
-		activeVersionEntity *entityserver_v1alpha.Entity
+	src := &appHealthSource{
+		specs:     make(map[string]*core_v1alpha.ConfigSpec),
+		poolState: make(map[string]*poolHealth),
 	}
-
-	var apps []appEntry
-	specMap := make(map[string]*core_v1alpha.ConfigSpec)
 
 	for list.Next() {
 		var app core_v1alpha.App
@@ -186,17 +194,15 @@ func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) 
 			if verEnt, err := r.EC.GetByIdWithEntity(ctx, entity.Id(app.ActiveVersion), &appVer); err == nil {
 				entry.activeVersion = &appVer
 				entry.activeVersionEntity = verEnt
-				if resolvedCfg, err := coreutil.ResolveRuntimeConfig(ctx, r.EC.EAC(), &appVer); err == nil {
-					specMap[appVer.ID.String()] = resolvedCfg
+				// Health reads service concurrency and task presence, not addon variables or disks.
+				if resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer); err == nil {
+					src.specs[appVer.ID.String()] = resolvedCfg
 				}
 			}
 		}
 
-		apps = append(apps, entry)
+		src.apps = append(src.apps, entry)
 	}
-
-	// Aggregate sandbox pool state per app
-	poolStateMap := make(map[string]*poolHealth)
 
 	poolList, err := r.EC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool))
 	if err != nil {
@@ -209,19 +215,94 @@ func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) 
 		poolList.Read(&pool)
 
 		appName := ui.CleanEntityID(pool.App.String())
-		if poolStateMap[appName] == nil {
-			poolStateMap[appName] = &poolHealth{isAutoscale: true}
+		if src.poolState[appName] == nil {
+			src.poolState[appName] = &poolHealth{isAutoscale: true}
 		}
-		ps := poolStateMap[appName]
+		ps := src.poolState[appName]
 		ps.accumulate(&pool, now)
 
-		if spec, ok := specMap[pool.SandboxSpec.Version.String()]; ok {
+		if spec, ok := src.specs[pool.SandboxSpec.Version.String()]; ok {
 			for _, svc := range spec.Services {
 				if svc.Name == pool.Service && svc.Concurrency.Mode == "fixed" {
 					ps.isAutoscale = false
 				}
 			}
 		}
+	}
+
+	return src, nil
+}
+
+// healthOf classifies one app.
+//
+// This is the single implementation. `miren app list` and the cloud health feed
+// both arrive here, so they cannot drift into disagreeing about whether an app
+// is healthy.
+func (s *appHealthSource) healthOf(entry appEntry) apphealth.State {
+	out := apphealth.State{Name: entry.name}
+
+	if ps, ok := s.poolState[entry.name]; ok {
+		out.Pooled = true
+		out.ReadyInstances = int32(ps.ready)
+		out.DesiredInstances = int32(ps.desired)
+		if ps.isAutoscale {
+			out.ScalingMode = "auto"
+		} else {
+			out.ScalingMode = "fixed"
+		}
+		out.Health = ps.classify()
+		if ps.inCooldown {
+			out.InCooldown = true
+			out.CrashCount = ps.crashCount
+			out.CooldownSeconds = int32(ps.cooldownLeft.Seconds())
+		}
+		return out
+	}
+
+	if entry.activeVersion != nil {
+		// Active version but no pools yet. Mirror AppInfo so `m app list` and
+		// app-status/deploy agree: an autoscale app reads as idle (deliberately
+		// at zero), while a fixed service reads as starting (not up yet) rather
+		// than a misleading idle. Both classifiers have to agree, or `m app
+		// list` and the deploy poller disagree about the same app.
+		ps := poolHealth{
+			isAutoscale: specAllowsScaleToZero(s.specs[entry.activeVersion.ID.String()]),
+			isTaskOnly:  specIsTaskOnly(s.specs[entry.activeVersion.ID.String()]),
+		}
+		out.Health = ps.classify()
+		return out
+	}
+
+	out.Health = apphealth.Unknown
+	return out
+}
+
+// ListAppHealth returns the health classification for every app and nothing
+// else. See collectAppHealth for why this exists alongside ListApps.
+func (r *AppInfo) ListAppHealth(ctx context.Context) ([]apphealth.State, error) {
+	src, err := r.collectAppHealth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]apphealth.State, 0, len(src.apps))
+	for _, entry := range src.apps {
+		results = append(results, src.healthOf(entry))
+	}
+	return results, nil
+}
+
+// ListApps computes the current inventory of apps: identity, active version,
+// health, instance counts, scaling mode, and routes.
+//
+// Health comes from healthOf, the same classifier the cloud health feed uses.
+// Health is a classification over sandbox pool state rather than a stored
+// field, so a second implementation would drift from this one and let `miren
+// app list` and the cloud dashboard disagree about whether an app is healthy.
+func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) {
+	src, err := r.collectAppHealth(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Collect routes per app
@@ -253,7 +334,7 @@ func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) 
 	// Build response
 	var results []*app_v1alpha.AppInfo
 
-	for _, entry := range apps {
+	for _, entry := range src.apps {
 		var a app_v1alpha.AppInfo
 		a.SetName(entry.name)
 
@@ -266,39 +347,20 @@ func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) 
 			a.SetCurrentVersion(&vi)
 		}
 
-		// Pool state → health, instances, scaling
-		if ps, ok := poolStateMap[entry.name]; ok {
-			a.SetReadyInstances(int32(ps.ready))
-			a.SetDesiredInstances(int32(ps.desired))
+		health := src.healthOf(entry)
+		a.SetHealth(health.Health)
 
-			if ps.isAutoscale {
-				a.SetScalingMode("auto")
-			} else {
-				a.SetScalingMode("fixed")
-			}
-
-			a.SetHealth(ps.classify())
-			if ps.inCooldown {
-				a.SetCrashCount(ps.crashCount)
-				a.SetCooldownSeconds(int32(ps.cooldownLeft.Seconds()))
+		if health.Pooled {
+			a.SetReadyInstances(health.ReadyInstances)
+			a.SetDesiredInstances(health.DesiredInstances)
+			a.SetScalingMode(health.ScalingMode)
+			if health.InCooldown {
+				a.SetCrashCount(health.CrashCount)
+				a.SetCooldownSeconds(health.CooldownSeconds)
 			}
 		} else if entry.activeVersion != nil {
-			// Active version but no pools yet. Mirror AppInfo so `m app list`
-			// and app-status/deploy agree: an autoscale app reads as idle
-			// (deliberately at zero), while a fixed service reads as starting
-			// (not up yet) rather than a misleading idle.
-			// Both classifiers have to agree, or `m app list` and the deploy
-			// poller disagree about the same app.
-			spec := specMap[entry.activeVersion.ID.String()]
-			ps := poolHealth{
-				isAutoscale: specAllowsScaleToZero(spec),
-				isTaskOnly:  specIsTaskOnly(spec),
-			}
 			a.SetReadyInstances(0)
 			a.SetDesiredInstances(0)
-			a.SetHealth(ps.classify())
-		} else {
-			a.SetHealth(apphealth.Unknown)
 		}
 
 		// Routes


### PR DESCRIPTION
Entity sync tells cloud which apps exist, but nothing currently fills their health samples. This adds runtime-owned health reporting over the uplink, using the same classification as `miren app list` and keeping health separate from durable app identity.

Cloud chooses a slow background cadence and temporarily accelerates sampling while someone is viewing a panel. Viewer demand expires on its own, and both intervals travel in the protocol so cloud can change them without a runtime release.

Verified with a real local runtime/cloud stack and Chromium: health and counts matched the CLI, sampling slowed after the panel closed, and reopening produced a fresh reading. Cloud counterpart: mirendev/cloud#237.

Part of MIR-1777
