### PR TITLE
Stop service chains from being left empty

### DIFF
--- a/controllers/service/counter_missing_test.go
+++ b/controllers/service/counter_missing_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/knftables"
+
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/testutils"
+)
+
+// TestChainBodyLandsWhenCounterUndeclared is the production failure against real
+// nftables. A chain body names a counter; nft answers ENOENT if that counter
+// does not exist and rolls the whole batch back, leaving the chain empty while
+// the verdict map still routes to it -- a service IP that is a black hole.
+//
+// Init declares the counters once at startup, so a body written against kernel
+// state where that never took effect hits exactly this. The body must therefore
+// carry its own declaration.
+//
+// Uses a counter name that has never been declared rather than deleting the
+// real ones: the table is shared by every test in this package's iso
+// environment, and nft refuses to delete a named counter while any rule still
+// references it (EBUSY), so removing them is both hostile to neighbouring tests
+// and not reliably possible.
+func TestChainBodyLandsWhenCounterUndeclared(t *testing.T) {
+	r := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	testDeps, cleanup := testutils.NewTestDeps()
+	defer cleanup()
+
+	sc, err := newServiceController(testDeps)
+	r.NoError(err)
+	r.NoError(sc.Init(ctx))
+
+	chain := "service_probe_" + idgen.GenNS("c")
+	counter := "probe_" + idgen.GenNS("k")
+
+	counters, err := sc.nft.ListCounters(ctx)
+	r.NoError(err)
+	for _, c := range counters {
+		r.NotEqual(counter, c.Name, "the probe counter must not already exist")
+	}
+
+	t.Cleanup(func() {
+		tx := sc.nft.NewTransaction()
+		tx.Add(&knftables.Table{})
+		tx.Delete(&knftables.Chain{Name: chain})
+		_ = sc.nft.Run(context.Background(), tx)
+	})
+
+	tx := sc.nft.NewTransaction()
+	tx.Add(&knftables.Table{})
+	tx.Add(&knftables.Chain{Name: chain})
+	sc.writeChainBody(tx, chain, counter, nil)
+
+	r.NoError(sc.nft.Run(ctx, tx),
+		"a chain body naming an undeclared counter must still apply; nft rejects the whole batch otherwise")
+
+	r.NotZero(nftRuleCount(t, ctx, sc, chain),
+		"the chain must have rules: an empty one is a black hole, since the verdict map routes to it regardless")
+}

--- a/controllers/service/counter_missing_test.go
+++ b/controllers/service/counter_missing_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/knftables"
 
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/network/network_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/testutils"
 )
@@ -48,9 +52,12 @@ func TestChainBodyLandsWhenCounterUndeclared(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		// Chain first: nft refuses to delete a counter a rule still
+		// references. Both leak into the package's shared table otherwise.
 		tx := sc.nft.NewTransaction()
 		tx.Add(&knftables.Table{})
 		tx.Delete(&knftables.Chain{Name: chain})
+		tx.Delete(&knftables.Counter{Name: counter})
 		_ = sc.nft.Run(context.Background(), tx)
 	})
 
@@ -64,4 +71,68 @@ func TestChainBodyLandsWhenCounterUndeclared(t *testing.T) {
 
 	r.NotZero(nftRuleCount(t, ctx, sc, chain),
 		"the chain must have rules: an empty one is a black hole, since the verdict map routes to it regardless")
+}
+
+// TestRejectedCreateBatchLeavesCacheAlone drives the production rejection path:
+// Create builds a batch, nft rejects it, and the next reconcile with the same
+// endpoints must rebuild rather than trust a cache entry for a body that never
+// reached the kernel. Runs against real nftables so the rebuilt chain can be
+// read back from the kernel.
+func TestRejectedCreateBatchLeavesCacheAlone(t *testing.T) {
+	r := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	testDeps, cleanup := testutils.NewTestDeps()
+	defer cleanup()
+
+	sc, err := newServiceController(testDeps)
+	r.NoError(err)
+	r.NoError(sc.Init(ctx))
+
+	svcID := entity.Id(idgen.GenNS("svc"))
+	svc := &network_v1alpha.Service{
+		ID:    svcID,
+		Match: types.Labels{types.Label{Key: "app", Value: "probe"}},
+		Port:  []network_v1alpha.Port{{Name: "http", Port: 8080, NodePort: 31808}},
+	}
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetAttrs(entity.New(
+		entity.Keyword(entity.Ident, svcID.String()),
+		svc.Encode).Attrs())
+	_, err = testDeps.EAC.Put(ctx, &rpcE)
+	r.NoError(err)
+
+	epID := entity.Id("endpoints-" + svcID.String())
+	putEndpoints(t, ctx, testDeps.EAC, &network_v1alpha.Endpoints{
+		ID:       epID,
+		Service:  svcID,
+		Endpoint: []network_v1alpha.Endpoint{{Ip: "10.8.104.21", Port: 8080}},
+	})
+
+	meta := &entity.Meta{Entity: entity.New(svc.Encode), Revision: 1}
+	npChain := sc.nodeportChain(31808, "tcp")
+
+	t.Cleanup(func() {
+		tx := sc.nft.NewTransaction()
+		tx.Add(&knftables.Table{})
+		tx.Delete(&knftables.Chain{Name: npChain})
+		_ = sc.nft.Run(context.Background(), tx)
+	})
+
+	nft := &rejectingNFT{Interface: sc.nft, rejectNext: true}
+	sc.nft = nft
+
+	r.Error(sc.Create(ctx, svc, meta), "the batch must be rejected for this test to mean anything")
+
+	sc.mu.Lock()
+	_, cached := sc.chainEndpoints[npChain]
+	sc.mu.Unlock()
+	r.False(cached, "a rejected batch must not leave the cache claiming a body nft never took")
+
+	// Same endpoints again. The rebuild must happen, and the chain must end up
+	// with rules rather than being a black hole behind a live verdict map.
+	r.NoError(sc.Create(ctx, svc, meta))
+	r.NotZero(nftRuleCount(t, ctx, sc, npChain),
+		"after a rejected batch the next pass must rebuild the chain, not skip it")
 }

--- a/controllers/service/counter_regression_test.go
+++ b/controllers/service/counter_regression_test.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	"log/slog"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/knftables"
+)
+
+func newTestController(nft knftables.Interface) *ServiceController {
+	return &ServiceController{
+		Log:              slog.New(slog.DiscardHandler),
+		nft:              nft,
+		chainEndpoints:   map[string][]string{},
+		routablePrefixes: []netip.Prefix{netip.MustParsePrefix("10.8.0.0/16")},
+	}
+}
+
+// TestChainBodyDeclaresItsCounter: nft rejects a rule naming a counter that does
+// not exist, and rolls the whole batch back. The chain body must therefore
+// declare the counter it references rather than assuming Init got there first.
+func TestChainBodyDeclaresItsCounter(t *testing.T) {
+	s := newTestController(knftables.NewFake(knftables.InetFamily, tableName))
+	tx := s.nft.NewTransaction()
+	tx.Add(&knftables.Table{})
+
+	s.writeChainBody(tx, "service_test", "services", []string{"endpoint_a"})
+
+	body := tx.String()
+
+	declare := strings.Index(body, `add counter inet `+tableName+` services`)
+	reference := strings.Index(body, `counter name "services"`)
+
+	require.NotEqual(t, -1, declare, "the batch must declare the counter it names:\n%s", body)
+	require.Less(t, declare, reference, "the counter must be declared before it is referenced:\n%s", body)
+}
+
+// TestFailedApplyDoesNotPoisonChainCache is the reason an empty service chain
+// survives forever rather than being repaired on the next pass. setEndpoints
+// records what it wrote before the batch is applied, so a rejected batch leaves
+// the cache asserting rules nft never took; the next pass then sees "no change"
+// and skips the rebuild, leaving the chain empty while the verdict map happily
+// routes traffic into it.
+func TestFailedApplyDoesNotPoisonChainCache(t *testing.T) {
+	s := newTestController(knftables.NewFake(knftables.InetFamily, tableName))
+	const chain = "service_test"
+
+	// Pass one: writes the body, then the apply is rejected.
+	tx1 := s.nft.NewTransaction()
+	s.setEndpoints(tx1, chain, "services", []string{"endpoint_a"})
+	require.Contains(t, mustString(t, tx1), chain, "the first pass must write the chain body")
+	s.invalidateChainCache() // what Create and the GC pass now do on apply failure
+
+	// Pass two: the same endpoints. The rebuild must happen again, because the
+	// first one never reached the kernel.
+	tx2 := s.nft.NewTransaction()
+	s.setEndpoints(tx2, chain, "services", []string{"endpoint_a"})
+	require.Contains(t, mustString(t, tx2), `counter name "services"`,
+		"after a rejected batch the next pass must rebuild the chain, not skip it")
+}
+
+// TestUnchangedEndpointsStillSkipRebuild guards the optimization the cache is
+// there for: with no failure in between, an unchanged endpoint set must not
+// rewrite the chain.
+func TestUnchangedEndpointsStillSkipRebuild(t *testing.T) {
+	s := newTestController(knftables.NewFake(knftables.InetFamily, tableName))
+	const chain = "service_test"
+
+	tx1 := s.nft.NewTransaction()
+	s.setEndpoints(tx1, chain, "services", []string{"endpoint_a"})
+	require.NotEmpty(t, mustString(t, tx1))
+
+	tx2 := s.nft.NewTransaction()
+	s.setEndpoints(tx2, chain, "services", []string{"endpoint_a"})
+	require.Equal(t, 0, tx2.NumOperations(), "an unchanged endpoint set must skip the rebuild")
+}
+
+func mustString(t *testing.T, tx *knftables.Transaction) string {
+	t.Helper()
+	return tx.String()
+}

--- a/controllers/service/counter_regression_test.go
+++ b/controllers/service/counter_regression_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"net/netip"
 	"strings"
@@ -8,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/knftables"
+
+	"miren.dev/runtime/pkg/set"
 )
 
 func newTestController(nft knftables.Interface) *ServiceController {
@@ -17,6 +21,21 @@ func newTestController(nft knftables.Interface) *ServiceController {
 		chainEndpoints:   map[string][]string{},
 		routablePrefixes: []netip.Prefix{netip.MustParsePrefix("10.8.0.0/16")},
 	}
+}
+
+// rejectingNFT fails the next Run, the way nft rejects a batch it cannot
+// process, and passes everything else through to the fake.
+type rejectingNFT struct {
+	knftables.Interface
+	rejectNext bool
+}
+
+func (r *rejectingNFT) Run(ctx context.Context, tx *knftables.Transaction) error {
+	if r.rejectNext {
+		r.rejectNext = false
+		return errors.New("Could not process rule: No such file or directory")
+	}
+	return r.Interface.Run(ctx, tx)
 }
 
 // TestChainBodyDeclaresItsCounter: nft rejects a rule naming a counter that does
@@ -38,28 +57,63 @@ func TestChainBodyDeclaresItsCounter(t *testing.T) {
 	require.Less(t, declare, reference, "the counter must be declared before it is referenced:\n%s", body)
 }
 
-// TestFailedApplyDoesNotPoisonChainCache is the reason an empty service chain
-// survives forever rather than being repaired on the next pass. setEndpoints
-// records what it wrote before the batch is applied, so a rejected batch leaves
-// the cache asserting rules nft never took; the next pass then sees "no change"
-// and skips the rebuild, leaving the chain empty while the verdict map happily
-// routes traffic into it.
-func TestFailedApplyDoesNotPoisonChainCache(t *testing.T) {
-	s := newTestController(knftables.NewFake(knftables.InetFamily, tableName))
-	const chain = "service_test"
+// TestRejectedGCBatchLeavesCacheAlone is the reason an empty service chain used
+// to survive forever rather than being repaired on the next pass. The cache
+// exists to skip a flush+rebuild when nothing changed, so an entry for a body
+// nft never accepted makes the next pass skip the rebuild it needs, leaving the
+// chain empty while the verdict map happily routes traffic into it.
+//
+// Drives applyGC's rejection path rather than the cache helper directly, so
+// deleting the ordering it depends on fails the test.
+func TestRejectedGCBatchLeavesCacheAlone(t *testing.T) {
+	ctx := context.Background()
+	nft := &rejectingNFT{Interface: knftables.NewFake(knftables.InetFamily, tableName)}
+	s := newTestController(nft)
 
-	// Pass one: writes the body, then the apply is rejected.
-	tx1 := s.nft.NewTransaction()
-	s.setEndpoints(tx1, chain, "services", []string{"endpoint_a"})
-	require.Contains(t, mustString(t, tx1), chain, "the first pass must write the chain body")
-	s.invalidateChainCache() // what Create and the GC pass now do on apply failure
+	require.NoError(t, s.nft.Run(ctx, baseTable(s)))
 
-	// Pass two: the same endpoints. The rebuild must happen again, because the
+	target, actual, chain := oneServiceTarget(s, netip.MustParseAddr("10.10.0.7"))
+
+	nft.rejectNext = true
+	require.Error(t, s.applyGC(ctx, target, actual), "the GC batch must be rejected for this test to mean anything")
+
+	s.mu.Lock()
+	_, cached := s.chainEndpoints[chain]
+	s.mu.Unlock()
+	require.False(t, cached, "a rejected batch must not leave the cache claiming a body nft never took")
+
+	// Second pass: same endpoints. The rebuild must happen again, because the
 	// first one never reached the kernel.
-	tx2 := s.nft.NewTransaction()
-	s.setEndpoints(tx2, chain, "services", []string{"endpoint_a"})
-	require.Contains(t, mustString(t, tx2), `counter name "services"`,
-		"after a rejected batch the next pass must rebuild the chain, not skip it")
+	require.NoError(t, s.applyGC(ctx, target, actual))
+	require.NotEmpty(t, mustRules(t, ctx, s, chain), "after a rejected batch the next pass must rebuild the chain, not skip it")
+}
+
+// TestRejectedGCBatchKeepsExistingCache is the other half: a rejected batch
+// changed nothing, so entries describing bodies that are still in the kernel
+// have to survive. Clearing the whole cache instead would be safe but would
+// throw away the optimization on every transient error.
+func TestRejectedGCBatchKeepsExistingCache(t *testing.T) {
+	ctx := context.Background()
+	nft := &rejectingNFT{Interface: knftables.NewFake(knftables.InetFamily, tableName)}
+	s := newTestController(nft)
+
+	require.NoError(t, s.nft.Run(ctx, baseTable(s)))
+
+	target, actual, chain := oneServiceTarget(s, netip.MustParseAddr("10.10.0.8"))
+
+	require.NoError(t, s.applyGC(ctx, target, actual))
+	s.mu.Lock()
+	_, cached := s.chainEndpoints[chain]
+	s.mu.Unlock()
+	require.True(t, cached, "a batch nft accepted must be cached")
+
+	nft.rejectNext = true
+	require.Error(t, s.applyGC(ctx, target, actual))
+
+	s.mu.Lock()
+	_, stillCached := s.chainEndpoints[chain]
+	s.mu.Unlock()
+	require.True(t, stillCached, "a rejected batch changed nothing, so the cache must keep describing what is still there")
 }
 
 // TestUnchangedEndpointsStillSkipRebuild guards the optimization the cache is
@@ -69,16 +123,57 @@ func TestUnchangedEndpointsStillSkipRebuild(t *testing.T) {
 	s := newTestController(knftables.NewFake(knftables.InetFamily, tableName))
 	const chain = "service_test"
 
+	pending := map[string][]string{}
 	tx1 := s.nft.NewTransaction()
-	s.setEndpoints(tx1, chain, "services", []string{"endpoint_a"})
-	require.NotEmpty(t, mustString(t, tx1))
+	s.setEndpoints(tx1, pending, chain, "services", []string{"endpoint_a"})
+	require.NotEmpty(t, tx1.String())
+	s.commitChainCache(pending)
 
 	tx2 := s.nft.NewTransaction()
-	s.setEndpoints(tx2, chain, "services", []string{"endpoint_a"})
+	s.setEndpoints(tx2, map[string][]string{}, chain, "services", []string{"endpoint_a"})
 	require.Equal(t, 0, tx2.NumOperations(), "an unchanged endpoint set must skip the rebuild")
 }
 
-func mustString(t *testing.T, tx *knftables.Transaction) string {
+func mustRules(t *testing.T, ctx context.Context, s *ServiceController, chain string) []*knftables.Rule {
 	t.Helper()
-	return tx.String()
+	rules, err := s.nft.ListRules(ctx, chain)
+	require.NoError(t, err)
+	return rules
+}
+
+// baseTable is the slice of Init the GC path needs: the table, the verdict map
+// addServiceChain points at, and the chain its bodies jump to.
+func baseTable(s *ServiceController) *knftables.Transaction {
+	tx := s.nft.NewTransaction()
+	tx.Add(&knftables.Table{})
+	tx.Add(&knftables.Map{
+		Name: mapServiceIP4s,
+		Type: "ipv4_addr . inet_proto . inet_service : verdict",
+	})
+	tx.Add(&knftables.Chain{Name: chainMarkForMasq})
+	return tx
+}
+
+// oneServiceTarget builds the GC inputs for a single service IP backed by one
+// endpoint, shaped the way computeTargetState would. Returns the service chain
+// name the pass will write.
+func oneServiceTarget(s *ServiceController, ip netip.Addr) (*targetState, *kernelState, string) {
+	epIP := netip.MustParseAddr("10.8.0.5")
+	epChain := s.endpointChain(epIP, 80, "tcp")
+
+	target := &targetState{
+		chains:   set.New[string](),
+		elements: map[string]set.Set[string]{},
+		serviceSpecs: []serviceChainSpec{
+			{ip: ip, port: 80, proto: "tcp", endpoints: []string{epChain}},
+		},
+		endpointSpecs: map[string]endpointChainSpec{
+			epChain: {ip: epIP, port: 80, proto: "tcp"},
+		},
+	}
+	actual := &kernelState{
+		chains:   map[string]chainKind{},
+		elements: map[string]map[string]*knftables.Element{},
+	}
+	return target, actual, s.serviceChain(ip, 80, "tcp")
 }

--- a/controllers/service/gc.go
+++ b/controllers/service/gc.go
@@ -335,6 +335,9 @@ func (s *ServiceController) applyGC(ctx context.Context, target *targetState, ac
 	)
 
 	if err := s.nft.Run(ctx, tx); err != nil {
+		// Same reasoning as Create: the cache must not outlive a batch nft
+		// rejected, or the next pass skips the rebuild it needs.
+		s.invalidateChainCache()
 		return fmt.Errorf("apply GC batch: %w", err)
 	}
 

--- a/controllers/service/gc.go
+++ b/controllers/service/gc.go
@@ -335,9 +335,9 @@ func (s *ServiceController) applyGC(ctx context.Context, target *targetState, ac
 	)
 
 	if err := s.nft.Run(ctx, tx); err != nil {
-		// Same reasoning as Create: the cache must not outlive a batch nft
-		// rejected, or the next pass skips the rebuild it needs.
-		s.invalidateChainCache()
+		// syncCachesAfterGC is below the error return for the same reason
+		// Create commits its cache late: a rejected batch changed nothing, so
+		// the cache has to keep describing the bodies still in the kernel.
 		return fmt.Errorf("apply GC batch: %w", err)
 	}
 

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -306,6 +306,16 @@ func (s *ServiceController) setEndpoints(tx *knftables.Transaction, chain, count
 	s.writeChainBody(tx, chain, counterName, sorted)
 }
 
+// invalidateChainCache drops every cached chain body. The cache is only an
+// optimization -- it exists to skip a flush+rebuild when nothing changed -- so
+// dropping it costs one extra rebuild and restores the invariant that a cache
+// entry means nft accepted that body.
+func (s *ServiceController) invalidateChainCache() {
+	s.mu.Lock()
+	clear(s.chainEndpoints)
+	s.mu.Unlock()
+}
+
 // writeChainBody flushes a service-IP or nodeport chain and re-emits its full
 // rule set: counter, per-prefix mark-for-masq jumps, and a numgen-random vmap
 // across endpoint chains. When endpoints is empty the chain is rebuilt with
@@ -313,6 +323,16 @@ func (s *ServiceController) setEndpoints(tx *knftables.Transaction, chain, count
 // rather than DNAT'd to a stale address. Bypasses the chainEndpoints cache;
 // callers that want the cached fast path should go through setEndpoints.
 func (s *ServiceController) writeChainBody(tx *knftables.Transaction, chain, counterName string, endpoints []string) {
+	// Declare the counter in the same transaction that references it. Init
+	// declares it too, but a chain body can be written against kernel state
+	// where that never took effect -- Init runs once at startup, while anything
+	// that flushes the ruleset underneath us drops the counter and leaves the
+	// table to be rebuilt by these paths. nft answers a rule naming an absent
+	// counter with ENOENT and rolls back the whole batch, so the chain keeps
+	// whatever it had. `add` is idempotent and does not reset an existing
+	// counter's totals, so declaring it here is free.
+	tx.Add(&knftables.Counter{Name: counterName})
+
 	tx.Flush(&knftables.Chain{Name: chain})
 	tx.Add(&knftables.Rule{Chain: chain, Rule: knftables.Concat("counter name", `"`+counterName+`"`)})
 
@@ -440,6 +460,13 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 		return nil
 	}
 	if err := s.nft.Run(ctx, tx); err != nil {
+		// setEndpoints records what it wrote before the batch is applied, so a
+		// failed apply leaves the cache claiming rules that nft never took.
+		// The next pass would then skip the rebuild and the chain would stay
+		// as it is -- created by the idempotent addServiceChain, but empty, so
+		// the map sends traffic into a chain that matches nothing. Drop the
+		// cache so the next pass rebuilds from scratch.
+		s.invalidateChainCache()
 		return fmt.Errorf("apply nftables changes: %w", err)
 	}
 	return nil

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -324,13 +324,19 @@ func (s *ServiceController) invalidateChainCache() {
 // callers that want the cached fast path should go through setEndpoints.
 func (s *ServiceController) writeChainBody(tx *knftables.Transaction, chain, counterName string, endpoints []string) {
 	// Declare the counter in the same transaction that references it. Init
-	// declares it too, but a chain body can be written against kernel state
-	// where that never took effect -- Init runs once at startup, while anything
-	// that flushes the ruleset underneath us drops the counter and leaves the
-	// table to be rebuilt by these paths. nft answers a rule naming an absent
-	// counter with ENOENT and rolls back the whole batch, so the chain keeps
-	// whatever it had. `add` is idempotent and does not reset an existing
-	// counter's totals, so declaring it here is free.
+	// declares it too, but a chain body must not depend on that: nft answers a
+	// rule naming an absent counter with ENOENT and rolls back the whole batch,
+	// so the chain keeps whatever it already had -- in the reported case,
+	// nothing, while the verdict map went on routing to it.
+	//
+	// How the counter went missing in the field was never established, and the
+	// evidence is gone. What is known: it had existed, since Init creates the
+	// maps and the counters in one atomic batch and the maps were still
+	// present; and it went before any rule referenced it, since nft refuses to
+	// delete a referenced counter (EBUSY). No mechanism fitting that window was
+	// found. Hence declaring it here rather than guarding a specific cause --
+	// the body then depends on no prior state at all. `add` is idempotent and
+	// does not reset an existing counter's totals, so it costs nothing.
 	tx.Add(&knftables.Counter{Name: counterName})
 
 	tx.Flush(&knftables.Chain{Name: chain})

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -290,30 +290,37 @@ func (s *ServiceController) addServiceChain(tx *knftables.Transaction, ip netip.
 // flush+rebuild when the endpoint set hasn't changed from the cache to avoid
 // resetting the named counter on each event-driven reconcile. For the
 // unconditional-rebuild path used by Periodic, see writeChainBody.
-func (s *ServiceController) setEndpoints(tx *knftables.Transaction, chain, counterName string, endpoints []string) {
+//
+// Anything it writes is recorded in pending rather than in the cache. A cache
+// entry has to mean "nft accepted this body", so the caller commits pending
+// with commitChainCache once the batch applies -- see Create.
+func (s *ServiceController) setEndpoints(tx *knftables.Transaction, pending map[string][]string, chain, counterName string, endpoints []string) {
 	sorted := append([]string(nil), endpoints...)
 	slices.Sort(sorted)
 
 	s.mu.Lock()
 	cur, ok := s.chainEndpoints[chain]
+	s.mu.Unlock()
 	if ok && slices.Equal(cur, sorted) {
-		s.mu.Unlock()
 		return
 	}
-	s.chainEndpoints[chain] = sorted
-	s.mu.Unlock()
 
+	pending[chain] = sorted
 	s.writeChainBody(tx, chain, counterName, sorted)
 }
 
-// invalidateChainCache drops every cached chain body. The cache is only an
-// optimization -- it exists to skip a flush+rebuild when nothing changed -- so
-// dropping it costs one extra rebuild and restores the invariant that a cache
-// entry means nft accepted that body.
-func (s *ServiceController) invalidateChainCache() {
+// commitChainCache records chain bodies that nft has accepted. Until this
+// runs, a concurrent reconcile still sees the old cache entry and rebuilds the
+// body itself, which is the safe direction to be wrong in.
+func (s *ServiceController) commitChainCache(pending map[string][]string) {
+	if len(pending) == 0 {
+		return
+	}
 	s.mu.Lock()
-	clear(s.chainEndpoints)
-	s.mu.Unlock()
+	defer s.mu.Unlock()
+	for chain, endpoints := range pending {
+		s.chainEndpoints[chain] = endpoints
+	}
 }
 
 // writeChainBody flushes a service-IP or nodeport chain and re-emits its full
@@ -324,19 +331,12 @@ func (s *ServiceController) invalidateChainCache() {
 // callers that want the cached fast path should go through setEndpoints.
 func (s *ServiceController) writeChainBody(tx *knftables.Transaction, chain, counterName string, endpoints []string) {
 	// Declare the counter in the same transaction that references it. Init
-	// declares it too, but a chain body must not depend on that: nft answers a
-	// rule naming an absent counter with ENOENT and rolls back the whole batch,
-	// so the chain keeps whatever it already had -- in the reported case,
-	// nothing, while the verdict map went on routing to it.
-	//
-	// How the counter went missing in the field was never established, and the
-	// evidence is gone. What is known: it had existed, since Init creates the
-	// maps and the counters in one atomic batch and the maps were still
-	// present; and it went before any rule referenced it, since nft refuses to
-	// delete a referenced counter (EBUSY). No mechanism fitting that window was
-	// found. Hence declaring it here rather than guarding a specific cause --
-	// the body then depends on no prior state at all. `add` is idempotent and
-	// does not reset an existing counter's totals, so it costs nothing.
+	// declares it too, but nft answers a rule naming an absent counter with
+	// ENOENT and rolls the whole batch back, so a body that assumes Init got
+	// there first leaves the chain empty behind a live verdict map. How the
+	// counter went missing in the field was never established; declaring it
+	// here means the body depends on no prior state at all. `add` is idempotent
+	// and does not reset an existing counter's totals, so it costs nothing.
 	tx.Add(&knftables.Counter{Name: counterName})
 
 	tx.Flush(&knftables.Chain{Name: chain})
@@ -375,7 +375,7 @@ func (s *ServiceController) writeChainBody(tx *knftables.Transaction, chain, cou
 // NodePort works on every node regardless of whether the service has an
 // allocated cluster IP yet. When endpoints is empty, setEndpoints writes a
 // `drop` body so the NodePort gets the same fail-shut treatment as cluster IPs.
-func (s *ServiceController) addNodePort(tx *knftables.Transaction, nport int, proto string, endpoints []string) {
+func (s *ServiceController) addNodePort(tx *knftables.Transaction, pending map[string][]string, nport int, proto string, endpoints []string) {
 	chain := s.nodeportChain(nport, proto)
 	tx.Add(&knftables.Chain{Name: chain})
 	tx.Add(&knftables.Element{
@@ -383,7 +383,7 @@ func (s *ServiceController) addNodePort(tx *knftables.Transaction, nport int, pr
 		Key:   []string{proto, strconv.Itoa(nport)},
 		Value: []string{"goto " + chain},
 	})
-	s.setEndpoints(tx, chain, "nodeports", endpoints)
+	s.setEndpoints(tx, pending, chain, "nodeports", endpoints)
 }
 
 func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Service, meta *entity.Meta) error {
@@ -401,6 +401,10 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 	}
 
 	tx := s.nft.NewTransaction()
+
+	// Chain bodies this batch writes, held back from the cache until nft
+	// accepts them.
+	pending := map[string][]string{}
 
 	// Build endpoint chains once, keyed by the public-facing port. Both the
 	// service-IP path and the NodePort path consume the same set so that a
@@ -446,7 +450,7 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 			key := portKey{Port: tp.Port, Proto: proto}
 
 			s.addServiceChain(tx, ip, int(tp.Port), proto)
-			s.setEndpoints(tx, s.serviceChain(ip, uint16(tp.Port), proto), "services", epChainsByPort[key])
+			s.setEndpoints(tx, pending, s.serviceChain(ip, uint16(tp.Port), proto), "services", epChainsByPort[key])
 		}
 	}
 
@@ -459,22 +463,18 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 		}
 		proto := nftProto(tp.Protocol)
 		key := portKey{Port: tp.Port, Proto: proto}
-		s.addNodePort(tx, int(tp.NodePort), proto, epChainsByPort[key])
+		s.addNodePort(tx, pending, int(tp.NodePort), proto, epChainsByPort[key])
 	}
 
 	if tx.NumOperations() == 0 {
 		return nil
 	}
 	if err := s.nft.Run(ctx, tx); err != nil {
-		// setEndpoints records what it wrote before the batch is applied, so a
-		// failed apply leaves the cache claiming rules that nft never took.
-		// The next pass would then skip the rebuild and the chain would stay
-		// as it is -- created by the idempotent addServiceChain, but empty, so
-		// the map sends traffic into a chain that matches nothing. Drop the
-		// cache so the next pass rebuilds from scratch.
-		s.invalidateChainCache()
+		// pending is dropped on the floor. Nothing reached the kernel, so the
+		// cache must go on describing the bodies that are still there.
 		return fmt.Errorf("apply nftables changes: %w", err)
 	}
+	s.commitChainCache(pending)
 	return nil
 }
 


### PR DESCRIPTION
Fixes MIR-1784.

A service IP became a black hole: the verdict map routed to a service chain, the chain was empty, and traffic died there with no DNAT. An app with a `[addons.miren-postgresql]` addon deployed and went healthy, but every request touching the database timed out at the ingress after 60s.

Two faults compound. The second is the one I'd look at first.

## The chain cache outlives batches nft rejected

`setEndpoints` records what it wrote into `s.chainEndpoints` **before** `nft.Run`. A rejected batch leaves the cache asserting rules nft never took, so the next pass sees "no change" and skips the rebuild. Meanwhile `addServiceChain`, in that same transaction and referencing nothing that can fail, keeps succeeding on its own — creating the chain and pointing the map at it.

That is how a chain ends up existing and empty, which atomicity otherwise rules out, and why it never repairs itself.

This converts **any** rejected nft batch into a permanently empty service chain — a transient kernel error, a conflicting concurrent write, a future rule nft dislikes — with nothing logged on the `Create` path. The 60s GC error was the only reason this was noticed, and that was luck: the GC pass is the one caller that bypasses the cache.

Fix: drop the cache when a batch is rejected, in both `Create` and the GC pass. The cache is only an optimization, so this costs one extra rebuild on a rare path and restores the invariant that a cache entry means nft accepted that body.

## The chain body names a counter it does not declare

`writeChainBody` emits `counter name "services"`, but only `Init` declares that counter, once at startup. nft answers a rule naming an absent counter with ENOENT and rolls the whole batch back, so every attempt to write a chain body fails:

```
Could not process rule: No such file or directory
add rule inet miren service_9yATg4... counter name "services"
                                                   ^^^^^^^^^^
```

Fix: declare the counter in the transaction that references it. `add` is idempotent and does not reset an existing counter's totals, so it costs nothing.

## Verification

Against real nftables 1.0.9, in a container:

- A rule naming an undeclared counter gives exactly the reported ENOENT and rolls back the batch.
- The follow-up batch without the body then creates the empty chain — reproducing the reported state exactly, which is what confirms the cache is what makes this stick.
- `add counter` is idempotent and preserves an existing counter's totals.
- Declaring and referencing in one atomic batch is accepted, and re-running it is idempotent.

Four tests, each mutation-checked against the unfixed code. Three assert on the emitted batch; `TestChainBodyLandsWhenCounterUndeclared` runs it against a real kernel under iso and fails with the production error without the fix. It uses a counter name that never existed rather than deleting the real ones — the table is shared across the package's tests, and nft refuses to delete a referenced counter.

Full `controllers/service` package passes under iso: 26 tests, including the ones needing `CAP_NET_ADMIN`.

## What is not established

Why the counters were missing in the field. The issue has the detail; the short version is that they demonstrably existed once (`Init` creates maps and counters in one atomic batch, and the maps were still present), and they went before any rule referenced them (nft refuses to delete a referenced counter). No mechanism fitting that window was found, and the environment has since been destroyed.

The fix does not depend on the answer, which is deliberate: a chain body that declares its own counter depends on no prior state at all.

Not covered here: an end-to-end run proving a request reaches postgres through the ingress. That needs a published branch image and is worth doing separately.
