### PR TITLE
Stop the ReplaceEntity index leak and drain the backlog

### DIFF
--- a/controllers/indexgc/gc.go
+++ b/controllers/indexgc/gc.go
@@ -1,11 +1,13 @@
 // Package indexgc runs a bounded, best-effort background sweep that removes
-// stale entity-store index (collection) entries whose backing entity is gone.
+// entity-store index (collection) entries the backing entity no longer
+// justifies: the entity is gone, or it still exists but no longer carries the
+// value the entry indexes.
 //
-// The source of these orphans was fixed upstream (atomic deletes, lease-bound
-// session index entries), so this exists to drain any legacy backlog on upgrade
-// and to keep a cluster self-healing if a future leak ever reappears, without
-// anyone having to run `miren debug reindex` by hand. It deliberately does its
-// work off the read path: foreground reads stay pure and never issue deletes.
+// It drains the backlog those leaks left and keeps a cluster self-healing
+// without anyone running `miren debug reindex` by hand. Mismatched entries in
+// particular cannot drain any other way, since no write path removes an indexed
+// value the entity has already stopped carrying. It deliberately works off the
+// read path: foreground reads stay pure and never issue deletes.
 package indexgc
 
 import (
@@ -16,35 +18,57 @@ import (
 	"miren.dev/runtime/pkg/entity"
 )
 
-const (
-	// initialDelay keeps the first sweep clear of the boot storm and any
-	// startup-time additive reindex before it begins deleting.
-	initialDelay = 1 * time.Minute
-)
+// defaultInitialDelay keeps the first sweep clear of the boot storm and any
+// startup-time additive reindex before it begins deleting.
+const defaultInitialDelay = 1 * time.Minute
 
 // GCConfig tunes the background sweep. Defaults are intentionally gentle: this
 // is convergence insurance, not active firefighting, so it drains slowly and
 // stays out of the way.
 type GCConfig struct {
-	// CheckInterval is how often to run a sweep.
+	// CheckInterval is how often to run a sweep. A sweep resolves the entities
+	// behind every entry it scans whether or not it deletes anything, so a
+	// drained store pays a full read of itself on every tick. That cost, not
+	// the delete rate, is what sets this.
 	CheckInterval time.Duration
-	// MaxDeletesPerSweep caps deletions per sweep so a large legacy backlog
-	// drains over several sweeps rather than one thundering pass. Zero means
-	// unbounded.
+	// MaxDeletesPerSweep caps deletions per sweep so a large backlog drains over
+	// several sweeps rather than one thundering pass. Zero means unbounded.
+	//
+	// Deletes are not the sweep's dominant cost, since every sweep resolves the
+	// entities behind the entries it scans regardless, so throttling them hard
+	// mostly stretches the drain.
 	MaxDeletesPerSweep int
 	// BatchPause is slept periodically during deletion to rate-limit write
 	// pressure. Zero disables pacing.
 	BatchPause time.Duration
-	// SweepTimeout bounds a single sweep. A truncated sweep is fine: the next
-	// one resumes the work, since the pass is idempotent.
+	// SweepTimeout bounds a single sweep. A truncated sweep is mostly fine: the
+	// pass is idempotent and the next one starts over, so finished work sticks.
+	//
+	// The caveat is that it restarts from the head of the keyspace, so a store
+	// too large for one sweep to scan would never reach its tail. A truncated
+	// sweep logs at Warn, which is the signal this needs a resume cursor.
 	SweepTimeout time.Duration
+	// InitialDelay is how long to wait before the first sweep. Zero means
+	// defaultInitialDelay; it is configurable so a test can drive the schedule.
+	InitialDelay time.Duration
 }
 
-// DefaultGCConfig returns the default (gentle) configuration.
+// initialDelay resolves the configured first-sweep delay.
+func (c GCConfig) initialDelay() time.Duration {
+	if c.InitialDelay > 0 {
+		return c.InitialDelay
+	}
+	return defaultInitialDelay
+}
+
+// DefaultGCConfig returns the default (gentle) configuration. At six hours and
+// 5000 deletes a sweep, a backlog in the low hundreds of thousands drains in
+// about a week, which is the right pace for entries that are bloat rather than
+// a correctness problem.
 func DefaultGCConfig() GCConfig {
 	return GCConfig{
-		CheckInterval:      1 * time.Hour,
-		MaxDeletesPerSweep: 500,
+		CheckInterval:      6 * time.Hour,
+		MaxDeletesPerSweep: 5000,
 		BatchPause:         1 * time.Second,
 		SweepTimeout:       10 * time.Minute,
 	}
@@ -60,6 +84,9 @@ type GCController struct {
 	Config GCConfig
 
 	cancel context.CancelFunc
+	// stopped closes when the sweep loop has returned, so Stop can be observed
+	// rather than merely requested.
+	stopped chan struct{}
 }
 
 // Start begins the periodic sweep.
@@ -69,14 +96,22 @@ func (c *GCController) Start(ctx context.Context) {
 		"max_deletes_per_sweep", c.Config.MaxDeletesPerSweep)
 
 	ctx, c.cancel = context.WithCancel(ctx)
-	go c.run(ctx)
+	c.stopped = make(chan struct{})
+	go func() {
+		defer close(c.stopped)
+		c.run(ctx)
+	}()
 }
 
-// Stop gracefully stops the controller.
+// Stop cancels the sweep loop and waits for it to return, so a stopped
+// controller is known to have stopped issuing deletes. Safe on a controller that
+// was never started, and safe to call more than once.
 func (c *GCController) Stop() {
-	if c.cancel != nil {
-		c.cancel()
+	if c.cancel == nil {
+		return
 	}
+	c.cancel()
+	<-c.stopped
 }
 
 func (c *GCController) run(ctx context.Context) {
@@ -85,7 +120,7 @@ func (c *GCController) run(ctx context.Context) {
 	// keeps the first interval a true CheckInterval and avoids a back-to-back
 	// double-fire if initialDelay is ever tuned longer than CheckInterval.
 	select {
-	case <-time.After(initialDelay):
+	case <-time.After(c.Config.initialDelay()):
 		c.sweep(ctx)
 	case <-ctx.Done():
 		c.Log.Info("stale index GC controller stopped")
@@ -134,6 +169,8 @@ func (c *GCController) sweep(ctx context.Context) {
 		c.Log.Info("stale index GC sweep complete",
 			"scanned", stats.CollectionEntriesScanned,
 			"found", stats.StaleEntriesFound,
+			"orphaned", stats.OrphanedEntriesFound,
+			"mismatched", stats.MismatchedEntriesFound,
 			"removed", stats.StaleEntriesRemoved,
 			"cas_conflicts", stats.CASConflicts,
 			"by_collection", stats.RemovedByCollection)

--- a/controllers/indexgc/gc_test.go
+++ b/controllers/indexgc/gc_test.go
@@ -1,0 +1,113 @@
+package indexgc
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/etcdtest"
+)
+
+// The sweep itself is covered in pkg/entity; these cover the wiring around it.
+
+// seedOrphan writes a collection entry pointing at a nonexistent entity, the
+// cheapest thing a sweep will delete.
+func seedOrphan(t *testing.T, store *entity.EtcdStore, client *clientv3.Client, entityID entity.Id) string {
+	t.Helper()
+
+	key := store.Prefix() + "/collections/test_kind_widget/" + base58.Encode([]byte(entityID))
+	_, err := client.Put(t.Context(), key, string(entityID))
+	require.NoError(t, err)
+	return key
+}
+
+func exists(t *testing.T, client *clientv3.Client, key string) bool {
+	t.Helper()
+
+	resp, err := client.Get(t.Context(), key)
+	require.NoError(t, err)
+	return len(resp.Kvs) > 0
+}
+
+func newTestController(t *testing.T, cfg GCConfig) (*GCController, *entity.EtcdStore, *clientv3.Client) {
+	t.Helper()
+
+	client, prefix := etcdtest.TestEtcdClient(t)
+	store, err := entity.NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	return &GCController{Log: slog.Default(), Store: store, Config: cfg}, store, client
+}
+
+// TestGCController_SweepsOnSchedule proves the loop reaches the sweep at all.
+// The controller is fire-and-forget, so a wiring mistake here looks exactly like
+// a cluster that never converges.
+func TestGCController_SweepsOnSchedule(t *testing.T) {
+	c, store, client := newTestController(t, GCConfig{
+		InitialDelay:       10 * time.Millisecond,
+		CheckInterval:      10 * time.Millisecond,
+		MaxDeletesPerSweep: 100,
+		SweepTimeout:       30 * time.Second,
+	})
+
+	key := seedOrphan(t, store, client, entity.Id("fake/nonexistent"))
+	require.True(t, exists(t, client, key))
+
+	c.Start(t.Context())
+	defer c.Stop()
+
+	require.Eventually(t, func() bool {
+		return !exists(t, client, key)
+	}, 10*time.Second, 20*time.Millisecond, "the scheduled sweep never removed the orphan")
+}
+
+// TestGCController_StopBeforeFirstSweep covers shutdown during the initial
+// delay, where a controller started at boot spends its first minute.
+func TestGCController_StopBeforeFirstSweep(t *testing.T) {
+	c, store, client := newTestController(t, GCConfig{
+		InitialDelay:       time.Hour,
+		CheckInterval:      time.Hour,
+		MaxDeletesPerSweep: 100,
+		SweepTimeout:       30 * time.Second,
+	})
+
+	key := seedOrphan(t, store, client, entity.Id("fake/nonexistent"))
+
+	c.Start(t.Context())
+
+	stopped := make(chan struct{})
+	go func() {
+		c.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Stop did not return; the sweep loop is not honouring cancellation")
+	}
+
+	assert.True(t, exists(t, client, key),
+		"a controller stopped during its initial delay must not have swept")
+}
+
+func TestGCController_StopIsSafeFromAnyState(t *testing.T) {
+	never := &GCController{Log: slog.Default()}
+	assert.NotPanics(t, never.Stop, "stopping an unstarted controller must be a no-op")
+
+	c, _, _ := newTestController(t, GCConfig{
+		InitialDelay:       time.Hour,
+		CheckInterval:      time.Hour,
+		MaxDeletesPerSweep: 100,
+		SweepTimeout:       30 * time.Second,
+	})
+	c.Start(t.Context())
+	c.Stop()
+	assert.NotPanics(t, c.Stop, "Stop must be idempotent")
+}

--- a/pkg/entity/cleanup.go
+++ b/pkg/entity/cleanup.go
@@ -10,7 +10,6 @@ import (
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"miren.dev/runtime/pkg/cond"
 )
 
 // cleanupDeleteBatchSize is how many stale entries we delete between rate-limit
@@ -18,6 +17,12 @@ import (
 // CleanupStaleCollectionEntries); this only governs how often we sleep for
 // BatchPause, not how many keys share a transaction.
 const cleanupDeleteBatchSize = 100
+
+// cleanupResolveBatchSize is how many scanned collection entries we buffer
+// before resolving their entities in one batched read. It bounds peak memory to
+// one scan page plus one resolve batch, and stays modest because every resolved
+// entity arrives with its full payload and some kinds carry sizeable blobs.
+const cleanupResolveBatchSize = 200
 
 // CleanupOptions bounds a single stale-cleanup pass so it can run continuously
 // in the background without overwhelming the store.
@@ -41,133 +46,299 @@ type CleanupStats struct {
 	CollectionEntriesScanned int64
 	StaleEntriesFound        int64
 	StaleEntriesRemoved      int64
+	// OrphanedEntriesFound counts stale entries whose entity is gone entirely;
+	// MismatchedEntriesFound those whose entity exists but no longer carries the
+	// value the entry indexes. The two have different sources, so the split says
+	// which leak is live when one keeps re-accumulating.
+	OrphanedEntriesFound   int64
+	MismatchedEntriesFound int64
 	// CASConflicts counts entries that changed between scan and delete (the slot
 	// was legitimately recreated/re-leased), so the CAS guard skipped them.
 	CASConflicts        int64
 	RemovedByCollection map[string]int64
 }
 
-// CleanupStaleCollectionEntries scans collection (index) entries and removes those
-// whose backing entity is authoritatively absent under a linearizable read.
+// CleanupStaleCollectionEntries scans collection (index) entries and removes
+// every entry the backing entity does not justify. An entry is justified when
+// the entity still exists and still carries an indexed value hashing to the
+// entry's collection segment; anything else is drift. An orphan is the
+// degenerate case, an entity with no justified values at all.
 //
-// Safety rests on creates being atomic: CreateEntity writes the entity key and its
-// collection entries in one transaction, so a collection entry whose entity is
-// absent is genuinely orphaned, with no create-in-flight race. Each delete is still
-// CAS'd on the entry's mod-revision captured at scan time, so a slot legitimately
-// recreated between scan and delete fails the compare and is left untouched (the
-// ABA guard). The pass is idempotent and bounded, so it is safe to run repeatedly
-// as a background sweep; repetition is what makes it resumable.
+// Safety rests on three things. Creates are atomic, so an entry whose entity is
+// absent is genuinely orphaned with no create-in-flight race. Entities are
+// resolved with a batched, linearizable read taken after the entry was scanned,
+// so the verdict sees state at least as new as the entry. And each delete is
+// CAS'd on the entry's mod-revision from scan time, which is what extends the
+// ABA guard to the mismatch verdict: any writer that re-justifies an entry has
+// to rewrite the key, so the compare fails and the entry survives.
+//
+// Session-scoped entries and entities whose attributes cannot be resolved are
+// left alone.
+//
+// The pass is idempotent and bounded, so it is safe to run repeatedly as a
+// background sweep.
 func (s *EtcdStore) CleanupStaleCollectionEntries(ctx context.Context, log *slog.Logger, opts CleanupOptions) (*CleanupStats, error) {
-	stats := &CleanupStats{RemovedByCollection: map[string]int64{}}
-
-	// Build the set of live entity ids so we only pay a per-entry GetEntity for
-	// collection entries that look orphaned. After a store has drained, almost
-	// every entry is in this set and the pass does no point reads at all.
-	allEntityIDs, err := s.ListAllEntityIDs(ctx)
-	if err != nil {
-		return stats, fmt.Errorf("cleanup: failed to list entities: %w", err)
-	}
-	validEntityIDs := make(map[Id]bool, len(allEntityIDs))
-	for _, id := range allEntityIDs {
-		validEntityIDs[id] = true
+	pass := &cleanupPass{
+		store:            s,
+		log:              log,
+		opts:             opts,
+		stats:            &CleanupStats{RemovedByCollection: map[string]int64{}},
+		collectionPrefix: s.prefix + "/collections/",
 	}
 
-	collectionPrefix := s.prefix + "/collections/"
-
-	// pending buffers confirmed-stale entries until we have a batch to delete.
-	// We scan and delete incrementally rather than materializing the whole
-	// keyspace: memory stays bounded by one page + one batch, and if the pass is
-	// cut short (deadline/shutdown) everything deleted before that point sticks.
-	var pending []staleCollectionEntry
-
-	flush := func() error {
-		if len(pending) == 0 {
-			return nil
-		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		s.deleteStaleBatch(ctx, log, pending, stats)
-		pending = pending[:0]
-		if opts.BatchPause > 0 {
-			select {
-			case <-time.After(opts.BatchPause):
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-		return nil
-	}
-
-	scanErr := scanPagedFunc(ctx, s.client, collectionPrefix, func(kv *mvccpb.KeyValue) error {
-		stats.CollectionEntriesScanned++
-
-		entityID := Id(kv.Value)
-		if validEntityIDs[entityID] {
-			return nil
-		}
-
-		// Not in the snapshot's live set; confirm authoritatively before
-		// treating it as stale. A linearizable not-found is the safe signal;
-		// any other error means we couldn't verify, so we leave it alone.
-		if _, err := s.GetEntity(ctx, entityID); err != nil {
-			if !errors.Is(err, cond.ErrNotFound{}) {
-				log.Warn("cleanup: could not verify entity existence",
-					"entity_id", entityID,
-					"key", string(kv.Key),
-					"error", err)
-				return nil
-			}
-		} else {
-			return nil
-		}
-
-		stats.StaleEntriesFound++
-		if opts.DryRun {
-			return nil
-		}
-
-		pending = append(pending, staleCollectionEntry{
-			key:        string(kv.Key),
-			modRev:     kv.ModRevision,
-			collection: collectionFromKey(string(kv.Key), collectionPrefix),
-		})
-
-		// Flush a full batch, or a short one that would otherwise carry us past
-		// MaxDeletes, so a bounded pass removes at most MaxDeletes and no more.
-		atBudget := opts.MaxDeletes > 0 && int(stats.StaleEntriesRemoved)+len(pending) >= opts.MaxDeletes
-		if len(pending) >= cleanupDeleteBatchSize || atBudget {
-			if err := flush(); err != nil {
-				return err
-			}
-		}
-		if opts.MaxDeletes > 0 && stats.StaleEntriesRemoved >= int64(opts.MaxDeletes) {
-			return errStopScan
-		}
-		return nil
+	scanErr := scanPagedFunc(ctx, s.client, pass.collectionPrefix, func(kv *mvccpb.KeyValue) error {
+		return pass.scan(ctx, kv)
 	})
 
-	if scanErr != nil && !errors.Is(scanErr, errStopScan) {
+	switch {
+	case scanErr != nil && !errors.Is(scanErr, errStopScan):
 		// Persist whatever we already confirmed before surfacing the error;
 		// partial progress is the whole point of streaming the sweep.
-		if flushErr := flush(); flushErr != nil {
+		if flushErr := pass.flush(ctx); flushErr != nil {
 			log.Warn("cleanup: failed to flush after scan error", "flush_error", flushErr)
 		}
-		return stats, fmt.Errorf("cleanup: scan failed: %w", scanErr)
+		return pass.stats, fmt.Errorf("cleanup: scan failed: %w", scanErr)
+	case scanErr == nil:
+		// Scan ended on its own, so judge the trailing partial page.
+		if err := pass.resolve(ctx); err != nil && !errors.Is(err, errStopScan) {
+			if flushErr := pass.flush(ctx); flushErr != nil {
+				log.Warn("cleanup: failed to flush after resolve error", "flush_error", flushErr)
+			}
+			return pass.stats, err
+		}
 	}
 
-	if err := flush(); err != nil {
-		return stats, err
+	if err := pass.flush(ctx); err != nil {
+		return pass.stats, err
 	}
 
-	return stats, nil
+	return pass.stats, nil
+}
+
+// cleanupPass holds the mutable state of one sweep. It exists so the scan,
+// verdict, and delete steps can be separate methods over named fields rather
+// than closures over a dozen captured variables.
+type cleanupPass struct {
+	store            *EtcdStore
+	log              *slog.Logger
+	opts             CleanupOptions
+	stats            *CleanupStats
+	collectionPrefix string
+
+	// page buffers scanned entries until there are enough to resolve in one
+	// read; pending buffers confirmed-stale entries until there are enough to
+	// delete in one batch. Both stream rather than materialize, so a pass cut
+	// short by a deadline or shutdown keeps everything it already deleted.
+	page    []collectionEntry
+	pending []staleCollectionEntry
+}
+
+// scan buffers one scanned entry, resolving the page once it fills.
+func (p *cleanupPass) scan(ctx context.Context, kv *mvccpb.KeyValue) error {
+	p.stats.CollectionEntriesScanned++
+
+	key := string(kv.Key)
+	p.page = append(p.page, collectionEntry{
+		key:           key,
+		modRev:        kv.ModRevision,
+		entityID:      Id(kv.Value),
+		sessionScoped: sessionScopedKey(key, p.collectionPrefix),
+	})
+
+	if len(p.page) >= cleanupResolveBatchSize {
+		return p.resolve(ctx)
+	}
+	return nil
+}
+
+// resolve judges the buffered page, reading the entities it refers to once.
+func (p *cleanupPass) resolve(ctx context.Context) error {
+	batch := p.page
+	p.page = nil
+	if len(batch) == 0 {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	justified, unverifiable, err := p.store.resolveJustified(ctx, p.log, batch)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range batch {
+		if unverifiable[e.entityID] {
+			continue
+		}
+		if err := p.judge(ctx, e, justified); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// judge classifies one entry against its entity's justified values and, when it
+// is stale, queues the delete and enforces the pass's delete budget. It returns
+// errStopScan once the budget is spent.
+func (p *cleanupPass) judge(ctx context.Context, e collectionEntry, justified map[Id]map[string]bool) error {
+	collection := collectionFromKey(e.key, p.collectionPrefix)
+	values, present := justified[e.entityID]
+
+	switch {
+	case present && values[collection]:
+		return nil
+	case present && e.sessionScoped:
+		// Leased, so etcd collects it with the session. This only covers a live
+		// entity; a session-scoped entry whose entity is gone falls to the
+		// orphan case and is deleted like any other.
+		return nil
+	case present:
+		p.stats.MismatchedEntriesFound++
+	default:
+		p.stats.OrphanedEntriesFound++
+	}
+
+	p.stats.StaleEntriesFound++
+	if p.opts.DryRun {
+		return nil
+	}
+
+	p.pending = append(p.pending, staleCollectionEntry{
+		key:        e.key,
+		modRev:     e.modRev,
+		collection: collection,
+	})
+
+	atBudget := p.opts.MaxDeletes > 0 && int(p.stats.StaleEntriesRemoved)+len(p.pending) >= p.opts.MaxDeletes
+	if len(p.pending) >= cleanupDeleteBatchSize || atBudget {
+		if err := p.flush(ctx); err != nil {
+			return err
+		}
+	}
+	if p.opts.MaxDeletes > 0 && p.stats.StaleEntriesRemoved >= int64(p.opts.MaxDeletes) {
+		return errStopScan
+	}
+	return nil
+}
+
+// flush deletes the queued entries, then paces the pass.
+func (p *cleanupPass) flush(ctx context.Context) error {
+	if len(p.pending) == 0 {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	p.store.deleteStaleBatch(ctx, p.log, p.pending, p.stats)
+	p.pending = p.pending[:0]
+
+	if p.opts.BatchPause > 0 {
+		select {
+		case <-time.After(p.opts.BatchPause):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// collectionEntry carries everything the verdict needs, so judging never
+// re-parses the key.
+type collectionEntry struct {
+	key           string
+	modRev        int64
+	entityID      Id
+	sessionScoped bool
+}
+
+// distinctEntityIDs returns the entities a page refers to, once each: an entity
+// commonly owns several entries in a page, one per indexed value.
+func distinctEntityIDs(entries []collectionEntry) []Id {
+	seen := make(map[Id]bool, len(entries))
+	ids := make([]Id, 0, len(entries))
+	for _, e := range entries {
+		if !seen[e.entityID] {
+			seen[e.entityID] = true
+			ids = append(ids, e.entityID)
+		}
+	}
+	return ids
+}
+
+// resolveJustified reads the entities a page refers to and returns, per entity,
+// the collection segments its current indexed attributes justify.
+//
+// An absent entity is absent from justified, so its entries read as orphans. An
+// entity that is present but unreadable, either because its payload will not
+// decode or because its attribute schema will not resolve, lands in
+// unverifiable and is left alone entirely: it is not absent, and guessing there
+// deletes live entries.
+func (s *EtcdStore) resolveJustified(
+	ctx context.Context,
+	log *slog.Logger,
+	batch []collectionEntry,
+) (justified map[Id]map[string]bool, unverifiable map[Id]bool, err error) {
+	ids := distinctEntityIDs(batch)
+	entities, undecodable, err := s.getEntities(ctx, ids, false)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cleanup: failed to resolve entities: %w", err)
+	}
+
+	justified = make(map[Id]map[string]bool, len(ids))
+	unverifiable = undecodable
+	for i, id := range ids {
+		ent := entities[i]
+		if ent == nil {
+			continue
+		}
+		values, err := s.justifiedCollections(ctx, ent)
+		if err != nil {
+			log.Warn("cleanup: could not resolve indexed attributes, leaving entries alone",
+				"entity_id", id, "error", err)
+			unverifiable[id] = true
+			continue
+		}
+		justified[id] = values
+	}
+	return justified, unverifiable, nil
+}
+
+// justifiedCollections returns the collection segments the entity's current
+// indexed attributes entitle it to, hashed the way the write path hashes them.
+//
+// Strict on purpose: it fails if any attribute's schema cannot be read, and the
+// caller then leaves that entity's entries alone. Reindex's tolerant variant
+// would drop the unreadable attribute, which here reads as "not justified" and
+// deletes a live entry.
+func (s *EtcdStore) justifiedCollections(ctx context.Context, ent *Entity) (map[string]bool, error) {
+	indexed, err := s.collectIndexedAttributes(ctx, ent.attrs)
+	if err != nil {
+		return nil, err
+	}
+
+	values := make(map[string]bool, len(indexed))
+	for _, attrs := range indexed {
+		for _, attr := range attrs {
+			values[tr.Replace(attr.CAS())] = true
+		}
+	}
+	return values, nil
+}
+
+// sessionScopedKey reports whether a collection entry is the session-scoped
+// variant. Plain entries are "{prefix}/collections/{colKey}/{base58 id}";
+// session entries carry a further "/{session}" segment and are leased.
+func sessionScopedKey(key, collectionPrefix string) bool {
+	return strings.Count(strings.TrimPrefix(key, collectionPrefix), "/") > 1
 }
 
 // errStopScan is a sentinel returned by the scan callback to halt scanning once
 // the per-pass delete budget is reached, without treating it as a real error.
 var errStopScan = errors.New("cleanup: delete budget reached")
 
-// staleCollectionEntry is a collection entry confirmed to point at an absent
+// staleCollectionEntry is a collection entry confirmed to be unjustified by its
 // entity, along with the mod-revision it carried at scan time (the CAS guard).
 type staleCollectionEntry struct {
 	key        string

--- a/pkg/entity/cleanup_test.go
+++ b/pkg/entity/cleanup_test.go
@@ -44,6 +44,9 @@ func TestCleanup_RemovesStaleKeepsLive(t *testing.T) {
 	stats, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{})
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, stats.StaleEntriesFound)
+	assert.EqualValues(t, 1, stats.OrphanedEntriesFound,
+		"the entity is gone, so this is an orphan and not a mismatch")
+	assert.EqualValues(t, 0, stats.MismatchedEntriesFound)
 	assert.EqualValues(t, 1, stats.StaleEntriesRemoved)
 	assert.EqualValues(t, 0, stats.CASConflicts)
 	// Removal is attributed to the specific collection so a persistent leak is
@@ -55,6 +58,216 @@ func TestCleanup_RemovesStaleKeepsLive(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ids, 1)
 	assert.Equal(t, live.Id(), ids[0])
+}
+
+// collectionSegmentFor returns the collection segment the write path uses for
+// attr. The segment is a hash, so it cannot be spelled out by hand.
+func collectionSegmentFor(attr Attr) string {
+	return tr.Replace(attr.CAS())
+}
+
+// TestCleanup_RemovesMismatchedEntryForLiveEntity seeds its entry at the real
+// hashed segment rather than an invented one, so it is indistinguishable from an
+// entry the store wrote itself.
+func TestCleanup_RemovesMismatchedEntryForLiveEntity(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	before := String(Id("test/kind"), "widget")
+	after := String(Id("test/kind"), "gadget")
+
+	live, err := store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		before,
+	))
+	require.NoError(t, err)
+
+	_, err = store.ReplaceEntity(ctx, New(
+		Ref(DBId, live.Id()),
+		Any(Ident, "entity-1"),
+		after,
+	))
+	require.NoError(t, err)
+
+	// Re-seed the entry the old writer would have left under the replaced value.
+	seedStaleEntry(t, store, client, collectionSegmentFor(before), live.Id())
+
+	ids, err := store.ListIndex(ctx, before)
+	require.NoError(t, err)
+	require.Contains(t, ids, live.Id(), "the seeded entry must be a real index hit before the sweep")
+
+	stats, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, stats.StaleEntriesFound)
+	assert.EqualValues(t, 1, stats.MismatchedEntriesFound,
+		"the entity exists, so this is a mismatch and not an orphan")
+	assert.EqualValues(t, 0, stats.OrphanedEntriesFound)
+	assert.EqualValues(t, 1, stats.StaleEntriesRemoved)
+
+	ids, err = store.ListIndex(ctx, before)
+	require.NoError(t, err)
+	assert.Empty(t, ids, "the replaced value must no longer return the entity")
+
+	ids, err = store.ListIndex(ctx, after)
+	require.NoError(t, err)
+	assert.Equal(t, []Id{live.Id()}, ids, "the current value must still return it")
+
+	got, err := store.GetEntity(ctx, live.Id())
+	require.NoError(t, err)
+	assert.NotNil(t, got, "repairing an index must never touch the entity")
+}
+
+// TestCleanup_LeavesUndecodableEntityAlone covers the gap between "the entity is
+// gone" and "the entity is here but I cannot read it". Both come back as a nil
+// from the batched read, and treating the second as the first deletes the index
+// entries of an entity that still exists, which is the one outcome the sweep
+// must never produce.
+func TestCleanup_LeavesUndecodableEntityAlone(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	indexed := String(Id("test/kind"), "widget")
+	live, err := store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		indexed,
+	))
+	require.NoError(t, err)
+
+	ids, err := store.ListIndex(ctx, indexed)
+	require.NoError(t, err)
+	require.Contains(t, ids, live.Id())
+
+	// Corrupt the stored payload, leaving the key itself in place: the entity
+	// exists, we just cannot say anything about its attributes.
+	_, err = client.Put(ctx, store.Prefix()+"/entity/"+base58.Encode([]byte(live.Id())),
+		"\xff\xff not valid cbor \xff\xff")
+	require.NoError(t, err)
+
+	stats, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{})
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 0, stats.StaleEntriesFound,
+		"an entity we cannot read is not an entity we can prove is gone")
+	assert.EqualValues(t, 0, stats.OrphanedEntriesFound)
+	assert.EqualValues(t, 0, stats.StaleEntriesRemoved)
+
+	ids, err = store.ListIndex(ctx, indexed)
+	require.NoError(t, err)
+	assert.Contains(t, ids, live.Id(), "the index entry must survive")
+}
+
+// TestCleanup_LeavesEntityWithUnreadableSessionAttrAlone is the session-scoped
+// half of the same hazard. An entity whose session blob will not decode comes
+// back missing those attributes, and judging it by what it carries then reads
+// the absence as "unjustified". No session attribute is indexed today, so this
+// pins the behaviour before that changes rather than after.
+func TestCleanup_LeavesEntityWithUnreadableSessionAttrAlone(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/session-kind",
+		Doc, "an indexed session-scoped attribute",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Session, true,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	sid, err := store.CreateSession(ctx, 30)
+	require.NoError(t, err)
+
+	indexed := String(Id("test/session-kind"), "widget")
+	live, err := store.CreateEntity(ctx, New([]Attr{indexed}), WithSession(sid))
+	require.NoError(t, err)
+
+	ids, err := store.ListIndex(ctx, indexed)
+	require.NoError(t, err)
+	require.Contains(t, ids, live.Id(), "the session attribute must be indexed to begin with")
+
+	// Corrupt the session blob, leaving the entity key itself intact.
+	sessionPrefix := store.Prefix() + "/entity/" + base58.Encode([]byte(live.Id())) + "/session/"
+	resp, err := client.Get(ctx, sessionPrefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Kvs, "expected a session blob to corrupt")
+	_, err = client.Put(ctx, string(resp.Kvs[0].Key), "\xff\xff not valid cbor \xff\xff")
+	require.NoError(t, err)
+
+	stats, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, stats.StaleEntriesFound,
+		"an entity whose session attributes will not decode is not an entity missing them")
+
+	ids, err = store.ListIndex(ctx, indexed)
+	require.NoError(t, err)
+	assert.Contains(t, ids, live.Id(), "the index entry must survive")
+}
+
+// TestCleanup_LeavesAConsistentStoreAlone is the safety net for the mismatch
+// verdict: a bug in the justified set shows up as deletions on a store with
+// nothing wrong with it, system and schema entities included.
+func TestCleanup_LeavesAConsistentStoreAlone(t *testing.T) {
+	store, _ := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/labels",
+		Doc, "an indexed cardinality-many attribute",
+		Cardinality, CardinalityMany,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	for _, name := range []string{"one", "two", "three"} {
+		_, err = store.CreateEntity(ctx, New(
+			Any(Ident, name),
+			String(Id("test/kind"), "widget"),
+			String(Id("test/labels"), "alpha"),
+			String(Id("test/labels"), "beta"),
+		))
+		require.NoError(t, err)
+	}
+
+	stats, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{})
+	require.NoError(t, err)
+
+	assert.Positive(t, stats.CollectionEntriesScanned, "the sweep must actually have looked at entries")
+	assert.EqualValues(t, 0, stats.StaleEntriesFound,
+		"a consistent store has nothing stale; removals here mean the justified set is wrong")
+	assert.EqualValues(t, 0, stats.StaleEntriesRemoved)
+
+	ids, err := store.ListIndex(ctx, String(Id("test/labels"), "alpha"))
+	require.NoError(t, err)
+	assert.Len(t, ids, 3, "every cardinality-many value must survive the sweep")
 }
 
 func TestCleanup_DryRunRemovesNothing(t *testing.T) {

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -33,6 +33,10 @@ type MockStore struct {
 	// WatchFromRevs records the fromRev argument of every WatchIndex call, in
 	// order, so tests can assert resume behavior.
 	WatchFromRevs []int64
+
+	// staleIndexEntries holds fault-injected index entries, keyed by attr.CAS().
+	// See AddStaleIndexEntry.
+	staleIndexEntries map[string][]Id
 }
 
 var _ Store = &MockStore{}
@@ -574,17 +578,43 @@ func (m *MockStore) ListIndex(ctx context.Context, attr Attr) ([]Id, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	var ids []Id
+	seen := make(map[Id]bool)
 	for id, entity := range m.Entities {
 		allAttrs := enumerateAllAttrs(entity.attrs)
 		for _, a := range allAttrs {
 			if a.ID == attr.ID && a.Value.Equal(attr.Value) {
 				ids = append(ids, id)
+				seen[id] = true
 				break
 			}
 		}
 	}
 
+	// Deduplicated because an index is a keyspace: it cannot hold the same
+	// entity twice under one value.
+	for _, id := range m.staleIndexEntries[attr.CAS()] {
+		if !seen[id] {
+			ids = append(ids, id)
+			seen[id] = true
+		}
+	}
+
 	return ids, nil
+}
+
+// AddStaleIndexEntry makes ListIndex report id under attr even though the stored
+// entity does not carry that value. MockStore derives its index from live
+// attributes and so cannot drift on its own; this is how a test reaches the case
+// where EtcdStore's separate collection keyspace disagrees with the entity.
+func (m *MockStore) AddStaleIndexEntry(attr Attr, id Id) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.staleIndexEntries == nil {
+		m.staleIndexEntries = make(map[string][]Id)
+	}
+	key := attr.CAS()
+	m.staleIndexEntries[key] = append(m.staleIndexEntries[key], id)
 }
 
 // ListIndexRevision returns the matching ids along with a revision. The mock

--- a/pkg/entity/scan.go
+++ b/pkg/entity/scan.go
@@ -150,9 +150,3 @@ func scanPagedFunc(ctx context.Context, client *clientv3.Client, prefix string, 
 
 	return nil
 }
-
-// scanPaged reads every key/value under prefix from the store's etcd client in
-// bounded pages. See the package-level scanPaged for why.
-func (s *EtcdStore) scanPaged(ctx context.Context, prefix string, opts ...scanOption) ([]*mvccpb.KeyValue, error) {
-	return scanPaged(ctx, s.client, prefix, opts...)
-}

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -496,12 +496,31 @@ func (s *EtcdStore) GetEntityAtRevision(ctx context.Context, id Id, rev int64) (
 }
 
 func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error) {
+	entities, _, err := s.getEntities(ctx, ids, true)
+	return entities, err
+}
+
+// getEntities reads entities in batches, leaving nil in the result for any id
+// that is absent. warnMissing is false for callers where a miss is expected
+// input rather than a surprise, such as the index sweep resolving ids read out
+// of the index itself.
+//
+// undecodable names the ids whose key was present but whose payload would not
+// unmarshal. Those are nil in the result too, so a caller that reads nil as
+// proof the entity is gone would be wrong about exactly the entities it can
+// say the least about.
+func (s *EtcdStore) getEntities(
+	ctx context.Context,
+	ids []Id,
+	warnMissing bool,
+) (entities []*Entity, undecodable map[Id]bool, err error) {
+	undecodable = map[Id]bool{}
 	if len(ids) == 0 {
-		return []*Entity{}, nil
+		return []*Entity{}, undecodable, nil
 	}
 
 	// Process entities in batches to avoid exceeding etcd transaction limits
-	entities := make([]*Entity, len(ids))
+	entities = make([]*Entity, len(ids))
 
 	for start := 0; start < len(ids); start += maxEntitiesPerBatch {
 		end := min(start+maxEntitiesPerBatch, len(ids))
@@ -519,11 +538,11 @@ func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 		// Execute transaction for this batch
 		tr, err := s.client.Txn(ctx).Then(ops...).Commit()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get entities from etcd: %w", err)
+			return nil, nil, fmt.Errorf("failed to get entities from etcd: %w", err)
 		}
 
 		if !tr.Succeeded {
-			return nil, fmt.Errorf("transaction failed")
+			return nil, nil, fmt.Errorf("transaction failed")
 		}
 
 		// Process results for this batch
@@ -539,13 +558,19 @@ func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 			primaryResp := tr.Responses[primaryIdx].GetResponseRange()
 			if len(primaryResp.Kvs) == 0 {
 				// Entity not found, leave nil in the result array
-				s.log.Warn("failed to get primary entity from etcd", "id", batchIds[i])
+				if warnMissing {
+					s.log.Warn("failed to get primary entity from etcd", "id", batchIds[i])
+				}
 				continue
 			}
 
 			var entity Entity
 			err = decoder.Unmarshal(primaryResp.Kvs[0].Value, &entity)
 			if err != nil {
+				// The key is there, so this entity exists; we just cannot read
+				// it. Always worth a line, whatever warnMissing says.
+				s.log.Error("failed to decode entity from etcd", "id", batchIds[i], "error", err)
+				undecodable[batchIds[i]] = true
 				continue
 			}
 
@@ -553,11 +578,19 @@ func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 
 			// Process session attributes
 			sessionResp := tr.Responses[sessionIdx].GetResponseRange()
+			sessionUnreadable := false
 			for _, kv := range sessionResp.Kvs {
 				var attrs []Attr
 				err = decoder.Unmarshal(kv.Value, &attrs)
 				if err != nil {
-					continue
+					// Same reasoning as the primary payload. An attribute we
+					// cannot read is not an attribute the entity lacks, and
+					// handing back a partially decoded entity invites a caller
+					// to conclude the missing value was never there.
+					s.log.Error("failed to decode session attributes from etcd",
+						"id", batchIds[i], "error", err)
+					sessionUnreadable = true
+					break
 				}
 
 				sid := string(kv.Key)
@@ -571,12 +604,17 @@ func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 				entity.attrs = append(entity.attrs, attrs...)
 			}
 
+			if sessionUnreadable {
+				undecodable[batchIds[i]] = true
+				continue
+			}
+
 			entity.postUnmarshal()
 			entities[start+i] = &entity
 		}
 	}
 
-	return entities, nil
+	return entities, undecodable, nil
 }
 
 type EntityOpType int
@@ -2056,38 +2094,6 @@ func enumerateAllAttrs(attrs []Attr) []Attr {
 		}
 	}
 	return result
-}
-
-// ListAllEntityIDs returns all entity IDs in the store
-func (s *EtcdStore) ListAllEntityIDs(ctx context.Context) ([]Id, error) {
-	prefix := fmt.Sprintf("%s/entity/", s.prefix)
-	kvs, err := s.scanPaged(ctx, prefix, withKeysOnly())
-	if err != nil {
-		return nil, fmt.Errorf("failed to list entities: %w", err)
-	}
-
-	var ids []Id
-	for _, kv := range kvs {
-		key := string(kv.Key)
-		// Skip session keys (they have /session/ in the path)
-		if strings.Contains(key, "/session/") {
-			continue
-		}
-		// Extract entity ID from key
-		// Key format: /prefix/entity/base58(entityid)
-		key = strings.TrimPrefix(key, prefix)
-		if key == "" {
-			continue
-		}
-		decoded, err := base58.Decode(key)
-		if err != nil {
-			s.log.Warn("failed to decode entity ID", "key", key, "error", err)
-			continue
-		}
-		ids = append(ids, Id(decoded))
-	}
-
-	return ids, nil
 }
 
 // DeletePrefixCount deletes all keys with prefix and returns count

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -1074,8 +1074,10 @@ func (s *EtcdStore) ReplaceEntity(
 		return nil, err
 	}
 
-	// Keep track of original indexed attributes for removal
-	originalIndexedAttrs, err := s.collectIndexedAttributes(ctx, repl.attrs)
+	// Must come from the stored entity, not the replacement: buildCollectionOps
+	// deletes the original indexed values the replacement no longer carries, and
+	// diffing repl against itself emits no deletes at all.
+	originalIndexedAttrs, err := s.collectIndexedAttributes(ctx, originalEntity.attrs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/entity/store_conformance_test.go
+++ b/pkg/entity/store_conformance_test.go
@@ -402,6 +402,67 @@ func TestStoreConformance_ReplaceEntity(t *testing.T) {
 	})
 }
 
+// TestStoreConformance_ReplaceEntityMaintainsIndexEntries asserts on the index a
+// replacement moved away from: the write and the read-back can both look correct
+// while that index still answers for the entity.
+func TestStoreConformance_ReplaceEntityMaintainsIndexEntries(t *testing.T) {
+	runStoreConformance(t, func(t *testing.T, store Store) {
+		ctx := t.Context()
+		applyConformanceSchema(t, store)
+
+		before := Id("conf-move-before/v1")
+		after := Id("conf-move-after/v1")
+		_, err := store.CreateEntity(ctx, New(Ref(DBId, before)))
+		require.NoError(t, err)
+		_, err = store.CreateEntity(ctx, New(Ref(DBId, after)))
+		require.NoError(t, err)
+
+		id := Id("conf-move-subject")
+		_, err = store.CreateEntity(ctx, New(
+			Ref(DBId, id),
+			Ref(Id("conf/ref"), before),
+		))
+		require.NoError(t, err)
+
+		indexed := func(t *testing.T, target Id) []Id {
+			t.Helper()
+			ids, err := store.ListIndex(ctx, Ref(Id("conf/ref"), target))
+			require.NoError(t, err)
+			return ids
+		}
+
+		require.Contains(t, indexed(t, before), id, "create must index the initial value")
+
+		// Changing the value moves the entry.
+		_, err = store.ReplaceEntity(ctx, New(
+			Ref(DBId, id),
+			Ref(Id("conf/ref"), after),
+		))
+		require.NoError(t, err)
+
+		assert.Contains(t, indexed(t, after), id, "replace must index the new value")
+		assert.NotContains(t, indexed(t, before), id,
+			"replace must remove the index entry for the value it replaced")
+
+		got, err := store.GetEntity(ctx, id)
+		require.NoError(t, err)
+		ref, ok := got.Get(Id("conf/ref"))
+		require.True(t, ok)
+		assert.Equal(t, after, ref.Value.Id(),
+			"the stored entity must carry only the new value")
+
+		// Dropping the attribute removes the entry outright.
+		_, err = store.ReplaceEntity(ctx, New(
+			Ref(DBId, id),
+			Any(Doc, "no longer indexed"),
+		))
+		require.NoError(t, err)
+
+		assert.NotContains(t, indexed(t, after), id,
+			"replace must remove the index entry for an attribute it dropped")
+	})
+}
+
 // TestStoreConformance_UpdateEntity pins the cardinality-aware merge: a
 // cardinality-one attribute is replaced, a cardinality-many attribute
 // accumulates. This is the behavior mock.go hand-mirrors from store.go.

--- a/pkg/saga/eac_storage.go
+++ b/pkg/saga/eac_storage.go
@@ -72,6 +72,7 @@ func (s *EACStorage) Get(ctx context.Context, id string) (*Execution, error) {
 // ListTerminal summarizes every execution in a terminal state via EAC.
 func (s *EACStorage) ListTerminal(ctx context.Context) ([]TerminalExecution, error) {
 	var result []TerminalExecution
+	var staleNonTerminal int
 	seen := make(map[string]struct{})
 
 	for _, status := range []entity.Id{
@@ -89,14 +90,19 @@ func (s *EACStorage) ListTerminal(ctx context.Context) ([]TerminalExecution, err
 			}
 			seen[id] = struct{}{}
 
-			summary, ok := terminalSummary(v.Entity())
-			if !ok {
+			summary, verdict := terminalSummary(v.Entity())
+			switch verdict {
+			case summaryOK:
+				result = append(result, summary)
+			case summaryNotTerminal:
+				staleNonTerminal++
+			case summaryNoTimestamp:
 				s.log.Warn("terminal saga has no usable timestamp, skipping", "id", id)
-				continue
 			}
-			result = append(result, summary)
 		}
 	}
+
+	logStaleTerminal(s.log, staleNonTerminal)
 
 	return result, nil
 }
@@ -148,6 +154,7 @@ func (s *EACStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
 	}
 
 	var executions []*Execution
+	var staleTerminal int
 	for _, eacEnt := range allEntities {
 		ent := eacEnt.Entity()
 		sagaEntity, ok := entity.As[saga_v1alpha.Saga](ent)
@@ -160,8 +167,14 @@ func (s *EACStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
 			s.log.Warn("failed to convert saga entity, skipping", "id", eacEnt.Id(), "error", err)
 			continue
 		}
+		if isTerminal(exec.Status) {
+			staleTerminal++
+			continue
+		}
 		executions = append(executions, exec)
 	}
+
+	logStaleIncomplete(s.log, staleTerminal)
 
 	return executions, nil
 }

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -168,6 +168,7 @@ func (s *EntityStorage) ListIncomplete(ctx context.Context) ([]*Execution, error
 
 	// Convert to executions
 	var executions []*Execution
+	var staleTerminal int
 	for _, ent := range entities {
 		if ent == nil {
 			continue
@@ -182,8 +183,14 @@ func (s *EntityStorage) ListIncomplete(ctx context.Context) ([]*Execution, error
 			s.log.Warn("failed to convert saga entity, skipping", "id", ent.Id(), "error", err)
 			continue
 		}
+		if isTerminal(exec.Status) {
+			staleTerminal++
+			continue
+		}
 		executions = append(executions, exec)
 	}
+
+	logStaleIncomplete(s.log, staleTerminal)
 
 	return executions, nil
 }
@@ -229,6 +236,7 @@ func (s *EntityStorage) ListTerminal(ctx context.Context) ([]TerminalExecution, 
 	}
 
 	var result []TerminalExecution
+	var staleNonTerminal int
 	for start := 0; start < len(ids); start += terminalFetchBatch {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -245,14 +253,19 @@ func (s *EntityStorage) ListTerminal(ctx context.Context) ([]TerminalExecution, 
 				// Deleted between the listing and the fetch. Nothing to report.
 				continue
 			}
-			summary, ok := terminalSummary(ent)
-			if !ok {
+			summary, verdict := terminalSummary(ent)
+			switch verdict {
+			case summaryOK:
+				result = append(result, summary)
+			case summaryNotTerminal:
+				staleNonTerminal++
+			case summaryNoTimestamp:
 				s.log.Warn("terminal saga has no usable timestamp, skipping", "id", ent.Id())
-				continue
 			}
-			result = append(result, summary)
 		}
 	}
+
+	logStaleTerminal(s.log, staleNonTerminal)
 
 	return result, nil
 }
@@ -268,17 +281,37 @@ func (s *EntityStorage) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-// terminalSummary reduces a saga entity to what retention needs, reporting
-// false when the entity carries no usable timestamp at all.
+// summaryVerdict says why terminalSummary rejected an entity. The two reasons
+// want different handling: stale index entries arrive in bulk, while a missing
+// timestamp is a one-off worth naming the entity for.
+type summaryVerdict int
+
+const (
+	summaryOK summaryVerdict = iota
+	// summaryNotTerminal means the decoded status is not terminal, so the index
+	// entry that produced this entity is stale.
+	summaryNotTerminal
+	// summaryNoTimestamp means the entity carries no usable finish time.
+	summaryNoTimestamp
+)
+
+// terminalSummary reduces a saga entity to what retention needs.
+//
+// The status index is a hint, not the truth: an entry can outlive the status it
+// was written for, so the decoded status decides whether this is terminal.
 //
 // The finish time prefers the saga's own updated_at but falls back to the
 // entity store's system timestamp, which is what makes retention safe across an
 // upgrade: every execution written before saga timestamps were persisted reads
 // back with a zero updated_at, and treating that as infinitely old would delete
 // a saga a runner on the old binary finished seconds ago.
-func terminalSummary(ent *entity.Entity) (TerminalExecution, bool) {
+func terminalSummary(ent *entity.Entity) (TerminalExecution, summaryVerdict) {
 	var s saga_v1alpha.Saga
 	s.Decode(ent)
+
+	if !isTerminal(statusFromEntity(s.Status)) {
+		return TerminalExecution{}, summaryNotTerminal
+	}
 
 	summary := TerminalExecution{
 		ID:       string(ent.Id()),
@@ -293,10 +326,33 @@ func terminalSummary(ent *entity.Entity) (TerminalExecution, bool) {
 	case !ent.GetCreatedAt().IsZero():
 		summary.FinishedAt = ent.GetCreatedAt()
 	default:
-		return TerminalExecution{}, false
+		return TerminalExecution{}, summaryNoTimestamp
 	}
 
-	return summary, true
+	return summary, summaryOK
+}
+
+// isTerminal reports whether a status is one of the two finished states.
+// ListIncomplete and ListTerminal both need it, in opposite directions.
+func isTerminal(s Status) bool {
+	return s == StatusCompleted || s == StatusFailed
+}
+
+// logStaleIncomplete and logStaleTerminal report index drift once per call
+// rather than once per entry: the backlog runs to tens of thousands, and a
+// per-entry line would drown the tier it logs in.
+func logStaleIncomplete(log *slog.Logger, count int) {
+	if count > 0 {
+		log.Warn("incomplete status index returned terminal executions, skipping; index needs repair",
+			"count", count)
+	}
+}
+
+func logStaleTerminal(log *slog.Logger, count int) {
+	if count > 0 {
+		log.Warn("terminal status index returned non-terminal executions, skipping; index needs repair",
+			"count", count)
+	}
 }
 
 // statusToEntity converts saga.Status to the entity enum value.

--- a/pkg/saga/storage_conformance_test.go
+++ b/pkg/saga/storage_conformance_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 )
 
@@ -232,4 +233,109 @@ func containsExecution(execs []*Execution, id string) bool {
 		}
 	}
 	return false
+}
+
+// runIndexBackedConformance runs scenario against the storages that answer from
+// the entity index, handing over the mock store beneath so it can seed drift.
+// MemoryStorage is absent: it has no index to make stale.
+func runIndexBackedConformance(t *testing.T, scenario func(t *testing.T, storage Storage, store *entity.MockStore)) {
+	t.Helper()
+
+	backends := []struct {
+		name string
+		make func(t *testing.T, inmem *testutils.InMemEntityServer) Storage
+	}{
+		{"EntityStorage", func(t *testing.T, inmem *testutils.InMemEntityServer) Storage {
+			return NewEntityStorage(inmem.Store, testutils.TestLogger(t))
+		}},
+		{"EACStorage", func(t *testing.T, inmem *testutils.InMemEntityServer) Storage {
+			return NewEACStorage(inmem.EAC, testutils.TestLogger(t))
+		}},
+	}
+
+	for _, backend := range backends {
+		t.Run(backend.name, func(t *testing.T) {
+			inmem, cleanup := testutils.NewInMemEntityServer(t)
+			t.Cleanup(cleanup)
+			scenario(t, backend.make(t, inmem), inmem.Store)
+		})
+	}
+}
+
+// seedStaleStatusIndex makes the status index report id under status while the
+// stored execution says otherwise.
+func seedStaleStatusIndex(t *testing.T, store *entity.MockStore, id string, status Status) {
+	t.Helper()
+
+	attr, ok := StatusIndexAttr(status)
+	require.True(t, ok, "status %v has no index attribute", status)
+	store.AddStaleIndexEntry(attr, entity.Id(id))
+}
+
+// TestStorageConformance_IncompleteListIgnoresStaleTerminalIndex is
+// CompletedExecutionLeavesIncompleteList again, with the index lying.
+func TestStorageConformance_IncompleteListIgnoresStaleTerminalIndex(t *testing.T) {
+	runIndexBackedConformance(t, func(t *testing.T, storage Storage, store *entity.MockStore) {
+		ctx := context.Background()
+
+		saveAged(t, storage, "teardown-postgres", StatusFailed, time.Hour)
+
+		// Every status this execution passed through on its way to failed.
+		seedStaleStatusIndex(t, store, "teardown-postgres", StatusPending)
+		seedStaleStatusIndex(t, store, "teardown-postgres", StatusRunning)
+
+		incomplete, err := storage.ListIncomplete(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, incomplete,
+			"a failed execution must not be recovered because stale pending and running index entries survived")
+
+		terminal, err := storage.ListTerminal(ctx)
+		require.NoError(t, err)
+		require.Len(t, terminal, 1, "the execution is still terminal and retention must still see it")
+		assert.Equal(t, "teardown-postgres", terminal[0].ID)
+	})
+}
+
+// TestStorageConformance_TerminalListIgnoresStaleIncompleteIndex is the
+// symmetric guard, with the sharper stake: retention deletes what ListTerminal
+// returns, so trusting a stale entry here deletes a running saga.
+func TestStorageConformance_TerminalListIgnoresStaleIncompleteIndex(t *testing.T) {
+	runIndexBackedConformance(t, func(t *testing.T, storage Storage, store *entity.MockStore) {
+		ctx := context.Background()
+
+		saveAged(t, storage, "create-sandbox", StatusRunning, 30*24*time.Hour)
+		seedStaleStatusIndex(t, store, "create-sandbox", StatusCompleted)
+
+		terminal, err := storage.ListTerminal(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, terminal,
+			"a running execution must not be offered to retention because a stale completed index entry survived")
+
+		incomplete, err := storage.ListIncomplete(ctx)
+		require.NoError(t, err)
+		require.Len(t, incomplete, 1, "the execution is still in flight and recovery must still find it")
+		assert.Equal(t, "create-sandbox", incomplete[0].ID)
+	})
+}
+
+// TestStorageConformance_RetentionCollectsChildOfStaleIncompleteParent covers
+// the stall one layer up: retention holds back children of a live parent, and
+// reads ListIncomplete to decide which parents are live.
+func TestStorageConformance_RetentionCollectsChildOfStaleIncompleteParent(t *testing.T) {
+	runIndexBackedConformance(t, func(t *testing.T, storage Storage, store *entity.MockStore) {
+		ctx := context.Background()
+
+		saveAged(t, storage, "finished-parent", StatusCompleted, 30*24*time.Hour)
+		saveChild(t, storage, "expired-child", "finished-parent", 30*24*time.Hour)
+		seedStaleStatusIndex(t, store, "finished-parent", StatusPending)
+
+		result, err := RunRetention(ctx, storage, weekRetention(), testutils.TestLogger(t))
+		require.NoError(t, err)
+
+		assert.Zero(t, result.Skipped,
+			"the parent is terminal, so its expired child is collectable no matter what the pending index claims")
+		assert.Equal(t, 2, result.Deleted)
+		assert.False(t, executionExists(t, storage, "expired-child"))
+		assert.False(t, executionExists(t, storage, "finished-parent"))
+	})
 }


### PR DESCRIPTION
A saga that had finished kept showing up in the list of sagas that hadn't. Every restart, recovery would pick up tens of thousands of long-dead teardown executions and try to resume them, and retention would refuse to delete anything whose parent looked similarly unfinished.

The entity store's index had been lying. `ReplaceEntity` is meant to drop index entries for values the replacement no longer carries, but it compared the new attributes against themselves, so it never dropped any: every entity that changed an indexed attribute kept the old value indexed forever. Sagas got hit hardest because they're saved on every status change, so each one ended up listed under all five statuses it had ever been in.

The first rev fixes that, and teaches the two etcd-backed saga storages to check the status they actually got back. That second part isn't just belt and braces. Listing an index is two separate reads, ids first and then the entities, so what the index said can be out of date by the time the entities arrive. The entity is the real answer and the index is only a pointer to it. `MemoryStorage` has no index and filters the executions directly, which is exactly why it was the one backend that never had this bug.

The second rev cleans up what's already sitting in etcd. The background sweep used to ask only whether an entry pointed at an entity that still exists. Now it asks whether that entity still actually carries the value the entry is indexing. Orphans fall out of the new question for free, since an entity that's gone carries nothing at all. Answering it means reading the entity's attributes instead of just checking it exists, and doing that a page at a time is what let us drop the full entity-ID snapshot the sweep used to build on every pass. That's MIR-1400, which this closes too.

Closes MIR-1735
Closes MIR-1400
