### PR TITLE
Page saga recovery and retention so a backlog cannot exhaust startup memory

### DIFF
--- a/api/entityserver/entityserver_v1alpha/rpc.gen.go
+++ b/api/entityserver/entityserver_v1alpha/rpc.gen.go
@@ -1433,6 +1433,108 @@ func (v *EntityAccessListResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type entityAccessListPageArgsData struct {
+	Index  *entity.Attr `cbor:"0,keyasint,omitempty" json:"index,omitempty"`
+	Cursor *string      `cbor:"1,keyasint,omitempty" json:"cursor,omitempty"`
+	Limit  *int64       `cbor:"2,keyasint,omitempty" json:"limit,omitempty"`
+}
+
+type EntityAccessListPageArgs struct {
+	call rpc.Call
+	data entityAccessListPageArgsData
+}
+
+func (v *EntityAccessListPageArgs) HasIndex() bool {
+	return v.data.Index != nil
+}
+
+func (v *EntityAccessListPageArgs) Index() entity.Attr {
+	return *v.data.Index
+}
+
+func (v *EntityAccessListPageArgs) HasCursor() bool {
+	return v.data.Cursor != nil
+}
+
+func (v *EntityAccessListPageArgs) Cursor() string {
+	if v.data.Cursor == nil {
+		return ""
+	}
+	return *v.data.Cursor
+}
+
+func (v *EntityAccessListPageArgs) HasLimit() bool {
+	return v.data.Limit != nil
+}
+
+func (v *EntityAccessListPageArgs) Limit() int64 {
+	if v.data.Limit == nil {
+		return 0
+	}
+	return *v.data.Limit
+}
+
+func (v *EntityAccessListPageArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *EntityAccessListPageArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *EntityAccessListPageArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *EntityAccessListPageArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type entityAccessListPageResultsData struct {
+	Values   *[]*Entity `cbor:"0,keyasint,omitempty" json:"values,omitempty"`
+	Cursor   *string    `cbor:"1,keyasint,omitempty" json:"cursor,omitempty"`
+	Total    *int64     `cbor:"2,keyasint,omitempty" json:"total,omitempty"`
+	Revision *int64     `cbor:"3,keyasint,omitempty" json:"revision,omitempty"`
+}
+
+type EntityAccessListPageResults struct {
+	call rpc.Call
+	data entityAccessListPageResultsData
+}
+
+func (v *EntityAccessListPageResults) SetValues(values []*Entity) {
+	x := slices.Clone(values)
+	v.data.Values = &x
+}
+
+func (v *EntityAccessListPageResults) SetCursor(cursor string) {
+	v.data.Cursor = &cursor
+}
+
+func (v *EntityAccessListPageResults) SetTotal(total int64) {
+	v.data.Total = &total
+}
+
+func (v *EntityAccessListPageResults) SetRevision(revision int64) {
+	v.data.Revision = &revision
+}
+
+func (v *EntityAccessListPageResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *EntityAccessListPageResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *EntityAccessListPageResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *EntityAccessListPageResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type entityAccessMakeAttrArgsData struct {
 	Id    *string `cbor:"0,keyasint,omitempty" json:"id,omitempty"`
 	Value *string `cbor:"1,keyasint,omitempty" json:"value,omitempty"`
@@ -2440,6 +2542,32 @@ func (t *EntityAccessList) Results() *EntityAccessListResults {
 	return results
 }
 
+type EntityAccessListPage struct {
+	rpc.Call
+	args    EntityAccessListPageArgs
+	results EntityAccessListPageResults
+}
+
+func (t *EntityAccessListPage) Args() *EntityAccessListPageArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *EntityAccessListPage) Results() *EntityAccessListPageResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type EntityAccessMakeAttr struct {
 	rpc.Call
 	args    EntityAccessMakeAttrArgs
@@ -2712,6 +2840,7 @@ type EntityAccess interface {
 	WatchIndex(ctx context.Context, state *EntityAccessWatchIndex) error
 	WatchEntity(ctx context.Context, state *EntityAccessWatchEntity) error
 	List(ctx context.Context, state *EntityAccessList) error
+	ListPage(ctx context.Context, state *EntityAccessListPage) error
 	MakeAttr(ctx context.Context, state *EntityAccessMakeAttr) error
 	LookupKind(ctx context.Context, state *EntityAccessLookupKind) error
 	Parse(ctx context.Context, state *EntityAccessParse) error
@@ -2769,6 +2898,10 @@ func (reexportEntityAccess) WatchEntity(ctx context.Context, state *EntityAccess
 }
 
 func (reexportEntityAccess) List(ctx context.Context, state *EntityAccessList) error {
+	panic("not implemented")
+}
+
+func (reexportEntityAccess) ListPage(ctx context.Context, state *EntityAccessListPage) error {
 	panic("not implemented")
 }
 
@@ -2926,6 +3059,16 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Params:        []string{"index"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &EntityAccessList{Call: call})
+			},
+		},
+		{
+			Name:          "list_page",
+			InterfaceName: "EntityAccess",
+			Index:         0,
+			Public:        false,
+			Params:        []string{"index", "cursor", "limit"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ListPage(ctx, &EntityAccessListPage{Call: call})
 			},
 		},
 		{
@@ -3456,6 +3599,71 @@ func (v EntityAccessClient) List(ctx context.Context, index entity.Attr) (*Entit
 	}
 
 	return &EntityAccessClientListResults{client: v.Client, data: ret}, nil
+}
+
+type EntityAccessClientListPageResults struct {
+	client rpc.Client
+	data   entityAccessListPageResultsData
+}
+
+func (v *EntityAccessClientListPageResults) HasValues() bool {
+	return v.data.Values != nil
+}
+
+func (v *EntityAccessClientListPageResults) Values() []*Entity {
+	if v.data.Values == nil {
+		return nil
+	}
+	return *v.data.Values
+}
+
+func (v *EntityAccessClientListPageResults) HasCursor() bool {
+	return v.data.Cursor != nil
+}
+
+func (v *EntityAccessClientListPageResults) Cursor() string {
+	if v.data.Cursor == nil {
+		return ""
+	}
+	return *v.data.Cursor
+}
+
+func (v *EntityAccessClientListPageResults) HasTotal() bool {
+	return v.data.Total != nil
+}
+
+func (v *EntityAccessClientListPageResults) Total() int64 {
+	if v.data.Total == nil {
+		return 0
+	}
+	return *v.data.Total
+}
+
+func (v *EntityAccessClientListPageResults) HasRevision() bool {
+	return v.data.Revision != nil
+}
+
+func (v *EntityAccessClientListPageResults) Revision() int64 {
+	if v.data.Revision == nil {
+		return 0
+	}
+	return *v.data.Revision
+}
+
+func (v EntityAccessClient) ListPage(ctx context.Context, index entity.Attr, cursor string, limit int64) (*EntityAccessClientListPageResults, error) {
+	args := EntityAccessListPageArgs{}
+	args.data.Index = &index
+	args.data.Cursor = &cursor
+	args.data.Limit = &limit
+
+	var ret entityAccessListPageResultsData
+
+	err := v.Call(ctx, "list_page", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EntityAccessClientListPageResults{client: v.Client, data: ret}, nil
 }
 
 type EntityAccessClientMakeAttrResults struct {

--- a/api/entityserver/rpc.yml
+++ b/api/entityserver/rpc.yml
@@ -222,6 +222,56 @@ interfaces:
           - name: revision
             type: int64
 
+      - name: list_page
+        doc: |
+          List one bounded page of entities from an index.
+
+          `list` reads the whole index and then fetches every entity it named,
+          server-side, before it answers. That costs the coordinator the entire
+          collection in memory no matter what the caller intended to do with it,
+          which is how a runner recovering sagas against a six-figure backlog
+          took the coordinator down with it. This reads only the page.
+
+          Ids and entities are fetched at one store revision, so a page is
+          internally consistent: an entity written between the two reads cannot
+          appear under a value the index has not caught up to, nor vanish from
+          under an id the index just handed out. That pinning is per page and
+          deliberately not carried across pages. A revision only stays readable
+          inside etcd's compaction window, and a long walk over a large index
+          would eventually fail outright rather than return a torn result. So an
+          entity written mid-walk may be missed or repeated, exactly as it may
+          be for `list_documents`, and a caller that cannot tolerate that wants
+          a watch rather than a listing.
+
+          This sits beside `list` rather than replacing it because `list` has
+          well over a hundred call sites, almost all of them CLI commands.
+          Migrating them is MIR-1302's scope and wants a client-side page walk
+          first, so that each command does not hand-roll its own loop. The
+          direction of travel is toward this method: do not add another caller
+          of `list`.
+        parameters:
+          - name: index
+            type: entity.Attr
+          - name: cursor
+            type: string
+            doc: Opaque resume point from a previous page. Empty starts at the head.
+          - name: limit
+            type: int64
+            doc: Maximum entities to fetch. Zero or less means the server's own page cap.
+        results:
+          - name: values
+            type: list
+            element: Entity
+          - name: cursor
+            type: string
+            doc: Resume point for the next page, empty when the index is exhausted.
+          - name: total
+            type: int64
+            doc: Entries in the index, reported only when starting from the head.
+          - name: revision
+            type: int64
+            doc: The store revision this page was read at.
+
       - name: makeAttr
         parameters:
           - name: id

--- a/controllers/deploymentattempts/controller.go
+++ b/controllers/deploymentattempts/controller.go
@@ -108,14 +108,11 @@ func (c *Controller) Step(ctx context.Context) error {
 	}
 
 	kind, migrate := c.phaseWork(c.phase)
-	page, err := c.Store.ListIndexPage(ctx, entity.Ref(entity.EntityKind, kind), c.cursor, c.Config.BatchSize)
+	page, err := c.Store.ListIndexEntitiesPage(ctx, entity.Ref(entity.EntityKind, kind), c.cursor, c.Config.BatchSize)
 	if err != nil {
 		return err
 	}
-	entities, err := c.Store.GetEntities(ctx, page.Ids)
-	if err != nil {
-		return err
-	}
+	entities := page.Entities
 	var migrateErrs []error
 	marker := core_v1alpha.CloudExportContract.MarkerID()
 	for _, ent := range entities {

--- a/pkg/entity/cleanup.go
+++ b/pkg/entity/cleanup.go
@@ -281,7 +281,7 @@ func (s *EtcdStore) resolveJustified(
 	batch []collectionEntry,
 ) (justified map[Id]map[string]bool, unverifiable map[Id]bool, err error) {
 	ids := distinctEntityIDs(batch)
-	entities, undecodable, err := s.getEntities(ctx, ids, false)
+	entities, undecodable, err := s.getEntities(ctx, ids, false, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cleanup: failed to resolve entities: %w", err)
 	}

--- a/pkg/entity/export/backfill.go
+++ b/pkg/entity/export/backfill.go
@@ -61,15 +61,11 @@ func BackfillMarker(
 		}
 		cursor := ""
 		for {
-			page, err := store.ListIndexPage(ctx, entity.Ref(entity.EntityKind, kindID), cursor, pageSize)
-			if err != nil {
-				return stats, fmt.Errorf("list %s for cloud export: %w", kind.ID, err)
-			}
-			entities, err := store.GetEntities(ctx, page.Ids)
+			page, err := store.ListIndexEntitiesPage(ctx, entity.Ref(entity.EntityKind, kindID), cursor, pageSize)
 			if err != nil {
 				return stats, fmt.Errorf("read %s for cloud export: %w", kind.ID, err)
 			}
-			for _, source := range entities {
+			for _, source := range page.Entities {
 				if source == nil {
 					continue
 				}

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -115,6 +115,40 @@ func (m *MockStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 	return entities, nil
 }
 
+// ListIndexEntitiesPage composes the mock's own paging and batch read.
+//
+// It reports nothing undecodable and ignores the revision when resolving
+// entities: the mock keeps one version of each entity, so there is no history
+// to read at and nothing stored that could fail to decode. It cannot prove a
+// caller pinned the right revision, which is what the EtcdStore conformance
+// case is for. What it can still check is that a caller handles nils, indexes
+// the map without a nil check, and walks the cursor to the end.
+func (m *MockStore) ListIndexEntitiesPage(
+	ctx context.Context,
+	attr Attr,
+	cursor string,
+	limit int64,
+) (*EntityPage, error) {
+	page, err := m.ListIndexPage(ctx, attr, cursor, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	entities, err := m.GetEntities(ctx, page.Ids)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EntityPage{
+		Ids:         page.Ids,
+		Entities:    entities,
+		Undecodable: map[Id]bool{},
+		Cursor:      page.Cursor,
+		Total:       page.Total,
+		Revision:    page.Revision,
+	}, nil
+}
+
 // validateSessionAttrs checks that if any attributes are session-scoped,
 // a session ID was provided via EntityOption. This matches EtcdStore behavior.
 func (m *MockStore) validateSessionAttrs(ctx context.Context, attrs []Attr, opts []EntityOption) error {

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -57,6 +57,17 @@ type Store interface {
 	// the first call establishes the revision reported by the returned page;
 	// passing that revision to every continuation produces one consistent scan.
 	ListIndexPageAtRevision(ctx context.Context, attr Attr, cursor string, limit, revision int64) (*IndexPage, error)
+	// ListIndexEntitiesPage reads one bounded page of an index together with the
+	// entities it names, both at a single store revision.
+	//
+	// This is the operation callers actually want, and it exists because
+	// assembling it by hand is easy to get subtly wrong. Listing an index and
+	// fetching what it named are two reads, and every caller that paired them
+	// itself paired them unpinned, so an entity written between the two came
+	// back carrying a value the index had not caught up to. That is
+	// indistinguishable from a stale index entry, which is a real defect this
+	// tree has had, so the difference is worth removing rather than documenting.
+	ListIndexEntitiesPage(ctx context.Context, attr Attr, cursor string, limit int64) (*EntityPage, error)
 	ListCollection(ctx context.Context, collection string) ([]Id, error)
 
 	CreateSession(ctx context.Context, ttl int64) ([]byte, error)
@@ -496,14 +507,57 @@ func (s *EtcdStore) GetEntityAtRevision(ctx context.Context, id Id, rev int64) (
 }
 
 func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error) {
-	entities, _, err := s.getEntities(ctx, ids, true)
+	entities, _, err := s.getEntities(ctx, ids, true, 0)
 	return entities, err
+}
+
+// ListIndexEntitiesPage reads one page of an index and the entities it names,
+// both as of one store revision.
+//
+// Pinning is per page and deliberately not carried across a walk. A revision
+// only stays readable inside etcd's compaction window, so a scan that held one
+// revision across many pages of a large index would eventually fail with
+// ErrCompacted rather than return a torn result, and for a caller paging a
+// six-figure backlog on a small host that is the worse of the two failures.
+// Within a page the window is milliseconds. So an entity written mid-walk may
+// still be missed or repeated between pages; a caller that cannot tolerate that
+// wants a watch, not a listing.
+//
+// Entities line up with Ids positionally, with a nil for any id the store no
+// longer holds, which for ids read out of an index is an ordinary race rather
+// than a surprise.
+func (s *EtcdStore) ListIndexEntitiesPage(
+	ctx context.Context,
+	attr Attr,
+	cursor string,
+	limit int64,
+) (*EntityPage, error) {
+	page, err := s.ListIndexPage(ctx, attr, cursor, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	entities, undecodable, err := s.getEntities(ctx, page.Ids, false, page.Revision)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EntityPage{
+		Ids:         page.Ids,
+		Entities:    entities,
+		Undecodable: undecodable,
+		Cursor:      page.Cursor,
+		Total:       page.Total,
+		Revision:    page.Revision,
+	}, nil
 }
 
 // getEntities reads entities in batches, leaving nil in the result for any id
 // that is absent. warnMissing is false for callers where a miss is expected
 // input rather than a surprise, such as the index sweep resolving ids read out
 // of the index itself.
+//
+// A non-zero rev reads every key as of that revision instead of the latest.
 //
 // undecodable names the ids whose key was present but whose payload would not
 // unmarshal. Those are nil in the result too, so a caller that reads nil as
@@ -513,6 +567,7 @@ func (s *EtcdStore) getEntities(
 	ctx context.Context,
 	ids []Id,
 	warnMissing bool,
+	rev int64,
 ) (entities []*Entity, undecodable map[Id]bool, err error) {
 	undecodable = map[Id]bool{}
 	if len(ids) == 0 {
@@ -527,12 +582,20 @@ func (s *EtcdStore) getEntities(
 
 		batchIds := ids[start:end]
 
-		// Build all the ops for this batch
+		// Build all the ops for this batch. A pinned read applies the revision
+		// to the session sub-read too: the two halves of an entity have to come
+		// from the same point in time or a caller can see attributes bonded by
+		// a session that did not exist yet at the revision it asked for.
+		var revOpt []clientv3.OpOption
+		if rev > 0 {
+			revOpt = []clientv3.OpOption{clientv3.WithRev(rev)}
+		}
+
 		var ops []clientv3.Op
 		for _, id := range batchIds {
 			key := s.buildKey(id)
-			ops = append(ops, clientv3.OpGet(key))
-			ops = append(ops, clientv3.OpGet(key+"/session/", clientv3.WithPrefix()))
+			ops = append(ops, clientv3.OpGet(key, revOpt...))
+			ops = append(ops, clientv3.OpGet(key+"/session/", append([]clientv3.OpOption{clientv3.WithPrefix()}, revOpt...)...))
 		}
 
 		// Execute transaction for this batch
@@ -1634,6 +1697,32 @@ type IndexPage struct {
 	Total int64
 
 	// Revision is the store revision the page was read at.
+	Revision int64
+}
+
+// EntityPage is one bounded page of an index together with the entities it
+// names, as returned by ListIndexEntitiesPage.
+type EntityPage struct {
+	// Ids are the index entries in this page.
+	Ids []Id
+
+	// Entities line up with Ids positionally. A nil means the store no longer
+	// holds that id, or holds it in a form that would not decode; Undecodable
+	// separates the two, because a caller that reads nil as proof the entity is
+	// gone would be wrong about exactly the entities it can say the least
+	// about. It is always non-nil, so it is safe to index without a nil check.
+	Entities    []*Entity
+	Undecodable map[Id]bool
+
+	// Cursor resumes the listing after this page, empty once the index is
+	// exhausted.
+	Cursor string
+
+	// Total counts the entries in the index, filled only when the caller starts
+	// from the head.
+	Total int64
+
+	// Revision is the store revision both reads were made at.
 	Revision int64
 }
 

--- a/pkg/entity/store_conformance_test.go
+++ b/pkg/entity/store_conformance_test.go
@@ -1044,6 +1044,66 @@ func TestStoreConformance_GetEntityAtRevision_Historical(t *testing.T) {
 	})
 }
 
+// TestStoreConformance_ListIndexEntitiesPage pins the parts of the paged index
+// read both backends must agree on, because callers cannot tell which one they
+// are talking to.
+//
+// Alignment is the one worth stating outright. A caller pairs entities back up
+// with the ids that named them, so a backend that dropped misses instead of
+// holding their place would shift every entity after the gap onto the wrong id,
+// and nothing about that failure looks like a bug until much later.
+func TestStoreConformance_ListIndexEntitiesPage(t *testing.T) {
+	runStoreConformance(t, func(t *testing.T, store Store) {
+		ctx := t.Context()
+
+		attrEnt, err := store.CreateEntity(ctx, New(
+			String(Ident, "conf-page-attr"),
+			Ref(Type, TypeStr),
+			Bool(Index, true),
+		))
+		require.NoError(t, err)
+
+		index := String(attrEnt.Id(), "value")
+
+		for i := range 3 {
+			_, err := store.CreateEntity(ctx, New(
+				index,
+				String(Ident, fmt.Sprintf("conf-page-%02d", i)),
+			))
+			require.NoError(t, err)
+		}
+
+		page, err := store.ListIndexEntitiesPage(ctx, index, "", 10)
+		require.NoError(t, err)
+		require.Len(t, page.Entities, len(page.Ids), "entities must line up with the ids that named them")
+		require.NotNil(t, page.Undecodable, "the map must be indexable without a nil check")
+
+		seen := map[Id]bool{}
+		for i, ent := range page.Entities {
+			require.NotNil(t, ent)
+			assert.Equal(t, page.Ids[i], ent.Id())
+			seen[ent.Id()] = true
+		}
+		assert.Len(t, seen, 3)
+
+		// Walking must terminate, and must not hand back a cursor to nothing
+		// when the index ends exactly on a page boundary.
+		cursor := ""
+		total := 0
+		for range 20 {
+			p, err := store.ListIndexEntitiesPage(ctx, index, cursor, 3)
+			require.NoError(t, err)
+			total += len(p.Entities)
+			cursor = p.Cursor
+			if cursor == "" {
+				break
+			}
+		}
+		assert.Equal(t, "", cursor, "the walk must terminate")
+		assert.Equal(t, 3, total)
+	})
+}
+
 // TestStoreConformance_Sessions pins the minimal session lifecycle both
 // backends support (create yields a non-empty token; ping and revoke succeed).
 // MockStore's sessions are stubs that do not enforce scoping or expiry, so

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -3029,3 +3029,220 @@ func TestEtcdStore_DeleteIsAtomicUnderConcurrentPatch(t *testing.T) {
 	r.Empty(collectionKVsForEntity(t, client, store.Prefix(), pool.Id()),
 		"no index entry may survive a delete that raced a patch (MIR-1334)")
 }
+
+// TestEtcdStore_getEntitiesAtRevision covers the property the whole paged-read
+// design rests on: that a caller holding ids from one moment can read the
+// entities those ids name as of that same moment.
+//
+// It tests the unexported read rather than ListIndexEntitiesPage because this
+// is where the revision is applied. The operation above it is tested for what
+// it composes, not for re-proving this.
+//
+// Listing an index and fetching what it named are two reads. Without a common
+// revision, an entity written between them comes back carrying a value the
+// index has not caught up to, which is indistinguishable from the stale-index
+// bug MIR-1735 fixed and would send a caller hunting the wrong defect.
+func TestEtcdStore_getEntitiesAtRevision(t *testing.T) {
+	t.Run("reads the value the entity carried at that revision", func(t *testing.T) {
+		store, _ := setupTestEtcdStore(t)
+
+		created, err := store.CreateEntity(t.Context(), New(
+			Any(Ident, "revtest"),
+			Any(Doc, "before"),
+		))
+		require.NoError(t, err)
+
+		before := created.GetRevision()
+		require.NotZero(t, before, "a created entity must report the revision it was written at")
+
+		_, err = store.ReplaceEntity(t.Context(), New(
+			Ref(DBId, Id(created.Id())),
+			Any(Ident, "revtest"),
+			Any(Doc, "after"),
+		))
+		require.NoError(t, err)
+
+		ids := []Id{Id(created.Id())}
+
+		pinned, undecodable, err := store.getEntities(t.Context(), ids, false, before)
+		require.NoError(t, err)
+		require.Len(t, pinned, 1)
+		require.NotNil(t, pinned[0], "the entity existed at that revision")
+		assert.Empty(t, undecodable)
+		doc, ok := pinned[0].Get(Doc)
+		require.True(t, ok)
+		assert.Equal(t, "before", doc.Value.String(),
+			"a pinned read must see the entity as it was, not as it is")
+
+		current, _, err := store.getEntities(t.Context(), ids, false, 0)
+		require.NoError(t, err)
+		require.Len(t, current, 1)
+		require.NotNil(t, current[0])
+		doc, ok = current[0].Get(Doc)
+		require.True(t, ok)
+		assert.Equal(t, "after", doc.Value.String(),
+			"a zero revision means now, which is what makes this a superset of GetEntities")
+	})
+
+	t.Run("leaves nil for an id absent at that revision", func(t *testing.T) {
+		store, _ := setupTestEtcdStore(t)
+
+		created, err := store.CreateEntity(t.Context(), New(
+			Any(Ident, "present"),
+			Any(Doc, "here"),
+		))
+		require.NoError(t, err)
+
+		// Position matters: a caller pairs the result back up with the ids it
+		// asked for, so a miss has to hold its place rather than shorten the
+		// slice and silently shift every entity after it onto the wrong id.
+		ids := []Id{"missing-before", Id(created.Id()), "missing-after"}
+
+		entities, undecodable, err := store.getEntities(t.Context(), ids, false, 0)
+		require.NoError(t, err)
+		require.Len(t, entities, 3)
+		assert.Nil(t, entities[0])
+		require.NotNil(t, entities[1])
+		assert.Equal(t, created.Id(), entities[1].Id())
+		assert.Nil(t, entities[2])
+		assert.Empty(t, undecodable)
+	})
+
+	t.Run("an entity created after the revision is absent from a pinned read", func(t *testing.T) {
+		store, _ := setupTestEtcdStore(t)
+
+		first, err := store.CreateEntity(t.Context(), New(
+			Any(Ident, "first"),
+		))
+		require.NoError(t, err)
+
+		later, err := store.CreateEntity(t.Context(), New(
+			Any(Ident, "later"),
+		))
+		require.NoError(t, err)
+
+		entities, _, err := store.getEntities(t.Context(),
+			[]Id{Id(first.Id()), Id(later.Id())}, false, first.GetRevision())
+		require.NoError(t, err)
+		require.Len(t, entities, 2)
+		assert.NotNil(t, entities[0])
+		assert.Nil(t, entities[1], "it did not exist yet at the revision asked for")
+	})
+
+	t.Run("returns an indexable map for an empty request", func(t *testing.T) {
+		store, _ := setupTestEtcdStore(t)
+
+		entities, undecodable, err := store.getEntities(t.Context(), nil, false, 0)
+		require.NoError(t, err)
+		assert.Empty(t, entities)
+
+		// Non-nil on every path, including this one. A caller that indexes it
+		// to tell "gone" from "unreadable" should not need a nil check on the
+		// empty case, and the sweep in cleanup.go already assumes it.
+		require.NotNil(t, undecodable)
+		assert.False(t, undecodable["anything"])
+	})
+
+}
+
+// TestEtcdStore_ListIndexEntitiesPage covers what the operation composes: the
+// page's ids and its entities line up, the walk terminates, and an id the index
+// still names but the store has dropped holds its place as a nil rather than
+// shifting every entity after it onto the wrong id.
+func TestEtcdStore_ListIndexEntitiesPage(t *testing.T) {
+	setup := func(t *testing.T, n int) (*EtcdStore, *clientv3.Client, Attr, []Id) {
+		t.Helper()
+		store, client := setupTestEtcdStore(t)
+
+		attr, err := store.CreateEntity(t.Context(), New(
+			String(Ident, "test-entities-page"),
+			Ref(Type, TypeStr),
+			Bool(Index, true),
+		))
+		require.NoError(t, err)
+
+		index := String(attr.Id(), "value")
+
+		var ids []Id
+		for i := range n {
+			created, err := store.CreateEntity(t.Context(), New(
+				index,
+				String(Ident, fmt.Sprintf("entities-page-%d", i)),
+			))
+			require.NoError(t, err)
+			ids = append(ids, created.Id())
+		}
+
+		return store, client, index, ids
+	}
+
+	t.Run("ids and entities line up", func(t *testing.T) {
+		store, _, index, _ := setup(t, 3)
+
+		page, err := store.ListIndexEntitiesPage(t.Context(), index, "", 10)
+		require.NoError(t, err)
+		require.Len(t, page.Entities, len(page.Ids))
+		require.Len(t, page.Entities, 3)
+
+		for i, ent := range page.Entities {
+			require.NotNil(t, ent)
+			assert.Equal(t, page.Ids[i], ent.Id(),
+				"entity %d must be the one its id names", i)
+		}
+
+		require.NotNil(t, page.Undecodable, "must be indexable without a nil check")
+		assert.NotZero(t, page.Revision, "a page has to say what revision it read at")
+	})
+
+	t.Run("pages to the end without repeating or dropping", func(t *testing.T) {
+		store, _, index, want := setup(t, 5)
+
+		seen := map[Id]bool{}
+		cursor := ""
+		for range 20 {
+			page, err := store.ListIndexEntitiesPage(t.Context(), index, cursor, 2)
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(page.Entities), 2)
+
+			for _, ent := range page.Entities {
+				require.False(t, seen[ent.Id()], "paging repeated %s", ent.Id())
+				seen[ent.Id()] = true
+			}
+
+			cursor = page.Cursor
+			if cursor == "" {
+				break
+			}
+		}
+
+		assert.Equal(t, "", cursor, "the walk must terminate")
+		assert.Len(t, seen, len(want))
+	})
+
+	t.Run("an id the store cannot answer for holds its place", func(t *testing.T) {
+		store, client, index, _ := setup(t, 2)
+
+		// An index entry pointing at an entity that is not there, which is
+		// exactly the stale-index shape this tree has had. The page has to
+		// survive it without shifting the entities that follow onto the wrong
+		// ids.
+		seedStaleEntry(t, store, client, index.CAS(), Id("fake/nonexistent"))
+
+		page, err := store.ListIndexEntitiesPage(t.Context(), index, "", 10)
+		require.NoError(t, err)
+		require.Len(t, page.Entities, len(page.Ids))
+		require.Len(t, page.Ids, 3)
+
+		var nils int
+		for i, ent := range page.Entities {
+			if ent == nil {
+				nils++
+				assert.Equal(t, Id("fake/nonexistent"), page.Ids[i],
+					"the nil must sit under the id that is missing")
+				continue
+			}
+			assert.Equal(t, page.Ids[i], ent.Id())
+		}
+		assert.Equal(t, 1, nils)
+	})
+}

--- a/pkg/saga/eac_storage.go
+++ b/pkg/saga/eac_storage.go
@@ -69,42 +69,53 @@ func (s *EACStorage) Get(ctx context.Context, id string) (*Execution, error) {
 	return entityToExecution(sagaEntity)
 }
 
-// ListTerminal summarizes every execution in a terminal state via EAC.
-func (s *EACStorage) ListTerminal(ctx context.Context) ([]TerminalExecution, error) {
+// ListTerminalPage summarizes one bounded page of finished executions via EAC.
+func (s *EACStorage) ListTerminalPage(ctx context.Context, q TerminalQuery) (*TerminalPage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	stage, inner, err := decodeStageCursor(q.Cursor, len(terminalStatuses))
+	if err != nil {
+		return nil, err
+	}
+
+	status := terminalStatuses[stage]
+
+	resp, err := s.eac.ListPage(ctx, entity.Ref(saga_v1alpha.SagaStatusId, status), inner, int64(clampLimit(q.Limit)))
+	if err != nil {
+		return nil, fmt.Errorf("listing sagas with status %s: %w", status, err)
+	}
+
+	next := nextStageCursor(stage, resp.Cursor(), len(terminalStatuses))
+
+	// An empty page is the shortest possible short page, not the end of the
+	// walk. The server drops ids it could not resolve into entities, so a page
+	// of nothing but stale index entries comes back with no values and a live
+	// cursor into the rest of this index. Treating that as an exhausted index
+	// would skip everything after it.
+	if len(resp.Values()) == 0 {
+		return &TerminalPage{Cursor: next}, nil
+	}
+
 	var result []TerminalExecution
 	var staleNonTerminal int
-	seen := make(map[string]struct{})
 
-	for _, status := range []entity.Id{
-		saga_v1alpha.SagaStatusCompletedId,
-		saga_v1alpha.SagaStatusFailedId,
-	} {
-		resp, err := s.eac.List(ctx, entity.Ref(saga_v1alpha.SagaStatusId, status))
-		if err != nil {
-			return nil, fmt.Errorf("listing sagas with status %s: %w", status, err)
-		}
-		for _, v := range resp.Values() {
-			id := v.Id()
-			if _, dup := seen[id]; dup {
-				continue
-			}
-			seen[id] = struct{}{}
-
-			summary, verdict := terminalSummary(v.Entity())
-			switch verdict {
-			case summaryOK:
-				result = append(result, summary)
-			case summaryNotTerminal:
-				staleNonTerminal++
-			case summaryNoTimestamp:
-				s.log.Warn("terminal saga has no usable timestamp, skipping", "id", id)
-			}
+	for _, v := range resp.Values() {
+		summary, verdict := terminalSummary(v.Entity())
+		switch verdict {
+		case summaryOK:
+			result = append(result, summary)
+		case summaryNotTerminal:
+			staleNonTerminal++
+		case summaryNoTimestamp:
+			s.log.Warn("terminal saga has no usable timestamp, skipping", "id", v.Id())
 		}
 	}
 
 	logStaleTerminal(s.log, staleNonTerminal)
 
-	return result, nil
+	return &TerminalPage{Executions: result, Cursor: next}, nil
 }
 
 // Delete removes a saga execution entity via EAC.
@@ -118,46 +129,43 @@ func (s *EACStorage) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-// ListIncomplete returns all executions that need recovery via EAC.
-func (s *EACStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
-	// Query for each incomplete status
-	var allEntities []*es.Entity
-	seen := make(map[string]struct{})
-
-	for _, statusRef := range []entity.Id{
-		saga_v1alpha.SagaStatusPendingId,
-		saga_v1alpha.SagaStatusRunningId,
-		saga_v1alpha.SagaStatusUndoingId,
-	} {
-		resp, err := s.eac.List(ctx, entity.Ref(
-			saga_v1alpha.SagaStatusId,
-			statusRef,
-		))
-		if err != nil {
-			return nil, fmt.Errorf("listing sagas with status %s: %w", statusRef, err)
-		}
-		// Deduplicate by ID: a saga can appear under more than one status
-		// index (e.g. a stale pending entry after transitioning to running),
-		// and recovering the same execution twice causes double execution.
-		for _, v := range resp.Values() {
-			id := v.Id()
-			if _, dup := seen[id]; dup {
-				continue
-			}
-			seen[id] = struct{}{}
-			allEntities = append(allEntities, v)
-		}
+// ListIncompletePage returns one bounded page of executions needing recovery
+// via EAC.
+//
+// The RPC pins the ids and the entities of a page to one store revision, so the
+// tear between listing an index and fetching what it named is closed on the
+// server rather than guessed at here.
+func (s *EACStorage) ListIncompletePage(ctx context.Context, q IncompleteQuery) (*IncompletePage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	if len(allEntities) == 0 {
-		return nil, nil
+	stage, inner, err := decodeStageCursor(q.Cursor, len(incompleteStatuses))
+	if err != nil {
+		return nil, err
+	}
+
+	status := incompleteStatuses[stage]
+
+	resp, err := s.eac.ListPage(ctx, entity.Ref(saga_v1alpha.SagaStatusId, status), inner, int64(clampLimit(q.Limit)))
+	if err != nil {
+		return nil, fmt.Errorf("listing sagas with status %s: %w", status, err)
+	}
+
+	next := nextStageCursor(stage, resp.Cursor(), len(incompleteStatuses))
+
+	// See ListTerminalPage: an empty page still carries a cursor, and dropping
+	// it here would skip the rest of this status index and every saga in it
+	// that still needs recovering.
+	if len(resp.Values()) == 0 {
+		return &IncompletePage{Cursor: next}, nil
 	}
 
 	var executions []*Execution
 	var staleTerminal int
-	for _, eacEnt := range allEntities {
-		ent := eacEnt.Entity()
-		sagaEntity, ok := entity.As[saga_v1alpha.Saga](ent)
+
+	for _, eacEnt := range resp.Values() {
+		sagaEntity, ok := entity.As[saga_v1alpha.Saga](eacEnt.Entity())
 		if !ok {
 			s.log.Warn("entity is not a saga, skipping", "id", eacEnt.Id())
 			continue
@@ -167,6 +175,8 @@ func (s *EACStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
 			s.log.Warn("failed to convert saga entity, skipping", "id", eacEnt.Id(), "error", err)
 			continue
 		}
+		// The index selected this id, the entity says what it actually is, and
+		// the entity wins.
 		if isTerminal(exec.Status) {
 			staleTerminal++
 			continue
@@ -176,5 +186,5 @@ func (s *EACStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
 
 	logStaleIncomplete(s.log, staleTerminal)
 
-	return executions, nil
+	return &IncompletePage{Executions: executions, Cursor: next}, nil
 }

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -68,15 +68,28 @@ type Storage interface {
 	// Get retrieves an execution by ID.
 	Get(ctx context.Context, id string) (*Execution, error)
 
-	// ListIncomplete returns all executions that need recovery (Pending, Running, or Undoing).
-	ListIncomplete(ctx context.Context) ([]*Execution, error)
+	// ListIncompletePage returns one bounded page of executions that need
+	// recovery (Pending, Running, or Undoing).
+	//
+	// Paged rather than whole because the whole set is not a size anyone
+	// chooses. A cluster that accumulated a six-figure backlog of incomplete
+	// executions made every restarting runner materialize all of them, with
+	// their action-output blobs, before recovery got as far as deciding which
+	// three it owned (MIR-1785).
+	//
+	// The walk covers several status indexes and is not pinned to one store
+	// revision, so an execution written mid-walk may be missed or repeated. A
+	// miss is recovered on the next pass, and a repeat is refused by the
+	// executor's own claim, which is the cheaper failure than a walk that dies
+	// with ErrCompacted partway through a large backlog.
+	ListIncompletePage(ctx context.Context, q IncompleteQuery) (*IncompletePage, error)
 
-	// ListTerminal returns a summary of every execution that has finished
-	// (Completed or Failed). It deliberately returns summaries rather than
-	// executions: retention only needs an ID and an age, and a backend holding
-	// a six-figure backlog must not have to materialize every action-output
-	// blob to answer.
-	ListTerminal(ctx context.Context) ([]TerminalExecution, error)
+	// ListTerminalPage returns one bounded page of executions that have
+	// finished (Completed or Failed). It deliberately returns summaries rather
+	// than executions: retention only needs an ID and an age, and a backend
+	// holding a six-figure backlog must not have to materialize every
+	// action-output blob to answer.
+	ListTerminalPage(ctx context.Context, q TerminalQuery) (*TerminalPage, error)
 
 	// Delete removes an execution. Deleting one that is already gone is not an
 	// error, so a retried or overlapping sweep converges instead of failing.
@@ -673,14 +686,71 @@ func (e *Executor) runUndo(ctx context.Context, def *Definition, exec *Execution
 }
 
 // Recover finds and resumes incomplete sagas after a restart.
+//
+// It walks the incomplete set a page at a time and never holds more than one
+// page, because the set is shared across every executor in the cluster and its
+// size is nobody's decision. A runner restarting into a six-figure backlog used
+// to load all of it, with every action-output blob, before getting as far as
+// deciding which handful it owned.
+//
+// Recovery is sequential on purpose. Resuming a page's worth of sagas at once
+// would trade the memory this bounds for the same amount of it plus concurrent
+// action side effects, and nothing here needs the throughput.
 func (e *Executor) Recover(ctx context.Context) error {
-	incomplete, err := e.storage.ListIncomplete(ctx)
-	if err != nil {
-		return fmt.Errorf("listing incomplete sagas: %w", err)
+	var recoverErrors []error
+
+	// Recovering one execution twice re-runs actions that already completed and
+	// collides on the entities the first pass created, so this is the one place
+	// a duplicate genuinely costs something. The walk cannot deduplicate across
+	// status indexes without holding all of them, so the set lives here instead
+	// and is bounded by what this executor actually attempted, not by the size
+	// of the backlog it walked past.
+	attempted := make(map[string]struct{})
+
+	cursor := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		page, err := e.storage.ListIncompletePage(ctx, IncompleteQuery{Cursor: cursor})
+		if err != nil {
+			return fmt.Errorf("listing incomplete sagas: %w", err)
+		}
+
+		if err := e.recoverPage(ctx, page.Executions, attempted, &recoverErrors); err != nil {
+			return err
+		}
+
+		cursor = page.Cursor
+		if cursor == "" {
+			break
+		}
 	}
 
-	var recoverErrors []error
-	for _, exec := range incomplete {
+	if len(recoverErrors) > 0 {
+		return fmt.Errorf("recovery completed with %d errors", len(recoverErrors))
+	}
+	return nil
+}
+
+// recoverPage resumes the executions in one page that belong to this executor.
+func (e *Executor) recoverPage(
+	ctx context.Context,
+	page []*Execution,
+	attempted map[string]struct{},
+	recoverErrors *[]error,
+) error {
+	for _, exec := range page {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if _, dup := attempted[exec.ID]; dup {
+			e.log.Debug("execution already attempted in this recovery pass, skipping",
+				"saga", exec.DefinitionName, "execution", exec.ID)
+			continue
+		}
 		// The shared store contains every runner's incomplete sandbox sagas.
 		// Scope is checked before even taking the local claim so this executor
 		// cannot drive another runner's record. Empty is an exact value here,
@@ -721,6 +791,9 @@ func (e *Executor) Recover(ctx context.Context) error {
 				"saga", exec.DefinitionName, "execution", exec.ID)
 			continue
 		}
+
+		attempted[exec.ID] = struct{}{}
+
 		// Released through defer so an action that panics cannot strand the
 		// claim. A stranded one is permanent: every later Execute under that
 		// name would report the work as still in flight and never run it.
@@ -730,13 +803,10 @@ func (e *Executor) Recover(ctx context.Context) error {
 		}()
 
 		if err != nil {
-			recoverErrors = append(recoverErrors, err)
+			*recoverErrors = append(*recoverErrors, err)
 		}
 	}
 
-	if len(recoverErrors) > 0 {
-		return fmt.Errorf("recovery completed with %d errors", len(recoverErrors))
-	}
 	return nil
 }
 

--- a/pkg/saga/memory_storage.go
+++ b/pkg/saga/memory_storage.go
@@ -3,6 +3,7 @@ package saga
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 )
 
@@ -50,43 +51,99 @@ func (m *MemoryStorage) Get(ctx context.Context, id string) (*Execution, error) 
 	return exec, nil
 }
 
-// ListIncomplete returns all executions that need recovery.
-// This includes pending (crashed before starting), running, and undoing sagas.
-func (m *MemoryStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
+// ListIncompletePage returns one bounded page of executions needing recovery:
+// pending (crashed before starting), running, and undoing.
+//
+// The map has no order of its own, so the ids are sorted to give paging a
+// stable sequence to resume in. That costs O(n) per page, which is fine for a
+// backend that holds everything in memory anyway and is the price of behaving
+// like the durable backends for the tests that exercise all three.
+func (m *MemoryStorage) ListIncompletePage(ctx context.Context, q IncompleteQuery) (*IncompletePage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var result []*Execution
-	for _, exec := range m.executions {
+	var ids []string
+	for id, exec := range m.executions {
 		switch exec.Status {
 		case StatusPending, StatusRunning, StatusUndoing:
-			result = append(result, exec)
+			ids = append(ids, id)
 		case StatusCompleted, StatusFailed:
 			// Terminal states are complete; skip them.
 		}
 	}
-	return result, nil
+
+	ids, next := pageSortedIDs(ids, q.Cursor, clampLimit(q.Limit))
+
+	executions := make([]*Execution, 0, len(ids))
+	for _, id := range ids {
+		executions = append(executions, m.executions[id])
+	}
+
+	return &IncompletePage{Executions: executions, Cursor: next}, nil
 }
 
-// ListTerminal summarizes the executions that have finished.
-func (m *MemoryStorage) ListTerminal(ctx context.Context) ([]TerminalExecution, error) {
+// ListTerminalPage summarizes one bounded page of finished executions.
+func (m *MemoryStorage) ListTerminalPage(ctx context.Context, q TerminalQuery) (*TerminalPage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var result []TerminalExecution
-	for _, exec := range m.executions {
+	var ids []string
+	for id, exec := range m.executions {
 		switch exec.Status {
 		case StatusCompleted, StatusFailed:
-			result = append(result, TerminalExecution{
-				ID:         exec.ID,
-				FinishedAt: exec.UpdatedAt,
-				ParentID:   exec.ParentExecutionID,
-			})
+			ids = append(ids, id)
 		case StatusPending, StatusRunning, StatusUndoing:
 			// Still in flight; retention does not apply.
 		}
 	}
-	return result, nil
+
+	ids, next := pageSortedIDs(ids, q.Cursor, clampLimit(q.Limit))
+
+	result := make([]TerminalExecution, 0, len(ids))
+	for _, id := range ids {
+		exec := m.executions[id]
+		result = append(result, TerminalExecution{
+			ID:         exec.ID,
+			FinishedAt: exec.UpdatedAt,
+			ParentID:   exec.ParentExecutionID,
+		})
+	}
+
+	return &TerminalPage{Executions: result, Cursor: next}, nil
+}
+
+// pageSortedIDs slices one page out of an unordered id set, returning the page
+// and the cursor that resumes after it.
+//
+// The cursor is the last id in the page, and is set only when something
+// actually follows it. Handing one back merely because the page filled would
+// give the caller a cursor to nothing every time the set ends exactly on a page
+// boundary, and the caller cannot tell that from a real continuation without
+// making the extra round trip that paging exists to avoid.
+func pageSortedIDs(ids []string, cursor string, limit int) ([]string, string) {
+	slices.Sort(ids)
+
+	if cursor != "" {
+		idx, _ := slices.BinarySearch(ids, cursor)
+		for idx < len(ids) && ids[idx] <= cursor {
+			idx++
+		}
+		ids = ids[idx:]
+	}
+
+	if len(ids) > limit {
+		return ids[:limit], ids[limit-1]
+	}
+
+	return ids, ""
 }
 
 // Delete removes an execution. Deleting a missing execution is a no-op.

--- a/pkg/saga/paging.go
+++ b/pkg/saga/paging.go
@@ -1,0 +1,117 @@
+package saga
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// defaultPageLimit is what a backend uses when a caller names no limit.
+//
+// Sized against what a page costs rather than what it returns: every execution
+// carries JSON blobs of its initial inputs and of every action's output, and a
+// sandbox creation's outputs are not small. Two hundred of those is a page an
+// operator would not notice on a 4 GB host, which is the size of box this whole
+// change exists to keep alive.
+const defaultPageLimit = 200
+
+// maxPageLimit caps what a caller can ask for. A limit is a request, not an
+// instruction: a caller passing a huge one has misunderstood what paging is
+// for, and honouring it would reintroduce the unbounded read through the front
+// door.
+const maxPageLimit = 1000
+
+// clampLimit resolves a caller's limit against the backend's own bounds.
+func clampLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultPageLimit
+	case limit > maxPageLimit:
+		return maxPageLimit
+	default:
+		return limit
+	}
+}
+
+// incompleteStatuses are the status indexes a recovery walk covers, in the
+// order it covers them.
+//
+// The order is load-bearing, so do not reorder these on cost grounds. An
+// execution only ever moves forward through pending, running, undoing, and the
+// walk is not pinned to one revision, so walking the indexes in that same
+// direction means a saga that transitions partway through the walk is seen
+// twice at worst. Reverse the order and it can be missed entirely: one sitting
+// in running when the undoing index is read, and in undoing by the time the
+// running index is read, appears in neither.
+//
+// Pending also happens to come first for the cheapest reason, an execution that
+// crashed between its initial save and its first transition has done the least
+// work to resume, but that is the coincidence and the ordering above is the
+// requirement.
+var incompleteStatuses = []entity.Id{
+	saga_v1alpha.SagaStatusPendingId,
+	saga_v1alpha.SagaStatusRunningId,
+	saga_v1alpha.SagaStatusUndoingId,
+}
+
+// terminalStatuses are the status indexes a retention walk covers.
+var terminalStatuses = []entity.Id{
+	saga_v1alpha.SagaStatusCompletedId,
+	saga_v1alpha.SagaStatusFailedId,
+}
+
+// A walk covers several status indexes in sequence, so a cursor has to say both
+// which index it is in and where inside it. The inner cursor belongs to the
+// store that issued it and is opaque here, which is why the stage is encoded as
+// a prefix rather than by parsing anything: splitting on the first separator
+// leaves whatever the store put in the remainder untouched, including
+// separators of its own.
+//
+// The whole cursor is opaque to callers in the same way. It is only ever handed
+// back to the storage that produced it, and a cursor from one backend means
+// nothing to another.
+
+// encodeStageCursor joins a stage index and a store cursor.
+func encodeStageCursor(stage int, inner string) string {
+	return strconv.Itoa(stage) + ":" + inner
+}
+
+// decodeStageCursor splits a cursor back into its stage and store parts. An
+// empty cursor is the start of the walk.
+func decodeStageCursor(cursor string, stages int) (stage int, inner string, err error) {
+	if cursor == "" {
+		return 0, "", nil
+	}
+
+	head, rest, found := strings.Cut(cursor, ":")
+	if !found {
+		return 0, "", fmt.Errorf("malformed page cursor %q", cursor)
+	}
+
+	stage, err = strconv.Atoi(head)
+	if err != nil {
+		return 0, "", fmt.Errorf("malformed page cursor %q: %w", cursor, err)
+	}
+	if stage < 0 || stage >= stages {
+		return 0, "", fmt.Errorf("page cursor %q names stage %d, which does not exist", cursor, stage)
+	}
+
+	return stage, rest, nil
+}
+
+// nextStageCursor reports where a walk resumes after finishing a page.
+//
+// Exhausting one index moves to the head of the next; exhausting the last ends
+// the walk, which is the only thing an empty cursor means.
+func nextStageCursor(stage int, inner string, stages int) string {
+	if inner != "" {
+		return encodeStageCursor(stage, inner)
+	}
+	if stage+1 < stages {
+		return encodeStageCursor(stage+1, "")
+	}
+	return ""
+}

--- a/pkg/saga/paging_test.go
+++ b/pkg/saga/paging_test.go
@@ -1,0 +1,86 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStageCursor covers the cursor the durable backends use to walk several
+// status indexes as one sequence.
+//
+// The inner half belongs to the store that issued it and is opaque here, which
+// is why the stage is a prefix split on the first separator rather than
+// anything parsed: a store cursor is free to contain separators of its own, and
+// a scheme that could not survive that would corrupt a walk only on the stores
+// where it mattered.
+func TestStageCursor(t *testing.T) {
+	t.Run("round-trips a store cursor containing separators", func(t *testing.T) {
+		inner := "abc:def:ghi"
+
+		stage, got, err := decodeStageCursor(encodeStageCursor(2, inner), 3)
+		require.NoError(t, err)
+		assert.Equal(t, 2, stage)
+		assert.Equal(t, inner, got, "the store's own separators must survive the round trip")
+	})
+
+	t.Run("an empty cursor starts at the first stage", func(t *testing.T) {
+		stage, inner, err := decodeStageCursor("", 3)
+		require.NoError(t, err)
+		assert.Equal(t, 0, stage)
+		assert.Equal(t, "", inner)
+	})
+
+	t.Run("rejects a cursor with no stage", func(t *testing.T) {
+		_, _, err := decodeStageCursor("no-separator-here", 3)
+		assert.Error(t, err, "a malformed cursor must not silently restart the walk")
+	})
+
+	t.Run("rejects a non-numeric stage", func(t *testing.T) {
+		_, _, err := decodeStageCursor("x:inner", 3)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects a stage that does not exist", func(t *testing.T) {
+		// A cursor issued against a longer stage list, or simply invented.
+		// Reading it as stage 0 would silently rewalk the whole set.
+		_, _, err := decodeStageCursor("7:inner", 3)
+		assert.Error(t, err)
+
+		_, _, err = decodeStageCursor("-1:inner", 3)
+		assert.Error(t, err)
+	})
+
+	t.Run("advances to the next stage when one is exhausted", func(t *testing.T) {
+		next := nextStageCursor(0, "", 3)
+
+		stage, inner, err := decodeStageCursor(next, 3)
+		require.NoError(t, err)
+		assert.Equal(t, 1, stage, "an exhausted index must hand the walk to the next one")
+		assert.Equal(t, "", inner, "and start it at the head")
+	})
+
+	t.Run("stays in the current stage while it has more", func(t *testing.T) {
+		stage, inner, err := decodeStageCursor(nextStageCursor(1, "more", 3), 3)
+		require.NoError(t, err)
+		assert.Equal(t, 1, stage)
+		assert.Equal(t, "more", inner)
+	})
+
+	t.Run("ends the walk after the last stage", func(t *testing.T) {
+		assert.Equal(t, "", nextStageCursor(2, "", 3),
+			"an empty cursor is the only thing that ends a walk, so the last stage must produce one")
+	})
+}
+
+func TestClampLimit(t *testing.T) {
+	// A limit is a request, not an instruction. Honouring an enormous one would
+	// reintroduce through the front door the unbounded read this exists to
+	// remove, and honouring zero would make "I didn't think about it" mean
+	// "give me everything".
+	assert.Equal(t, defaultPageLimit, clampLimit(0))
+	assert.Equal(t, defaultPageLimit, clampLimit(-1))
+	assert.Equal(t, maxPageLimit, clampLimit(maxPageLimit+1))
+	assert.Equal(t, 50, clampLimit(50))
+}

--- a/pkg/saga/retention.go
+++ b/pkg/saga/retention.go
@@ -2,42 +2,57 @@ package saga
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 )
 
-// liveParentsOf returns the IDs of executions still in flight, but only when
-// the terminal set actually contains a child. Most clusters run no nested
-// sagas, and paying for an extra listing every sweep to answer a question
-// nobody asked is not worth it.
+// parentLiveness answers whether a terminal execution's parent is still in
+// flight, one parent at a time and remembering what it learned.
 //
-// An in-flight parent is exactly ListIncomplete's set: the three non-terminal
-// statuses and nothing else. A parent absent from the store entirely is safe,
-// since nothing remains to re-find the child.
-func liveParentsOf(ctx context.Context, storage Storage, terminal []TerminalExecution) (map[string]struct{}, error) {
-	hasChild := false
-	for _, exec := range terminal {
-		if exec.ParentID != "" {
-			hasChild = true
-			break
-		}
-	}
-	if !hasChild {
-		return nil, nil
+// This used to be a second full listing of the incomplete set, taken whenever
+// any execution in the terminal set had a parent. That asked the store for
+// every in-flight execution in the cluster in order to answer a question about
+// at most a page's worth of parents, and on a large backlog it was the second
+// unbounded read in a sweep that already had one.
+//
+// Reading each parent directly costs a round trip per distinct parent instead.
+// Most clusters run no nested sagas at all, so most sweeps ask nothing; and
+// where they do, children of one parent share the answer.
+type parentLiveness struct {
+	storage Storage
+	live    map[string]bool
+}
+
+func newParentLiveness(storage Storage) *parentLiveness {
+	return &parentLiveness{storage: storage, live: map[string]bool{}}
+}
+
+// isLive reports whether the named parent is still in flight.
+//
+// A parent that is absent from the store is not live: nothing remains that
+// could re-find the child. A parent that cannot be read is treated as live,
+// which is the safe direction. Protecting a child that did not need it costs
+// one more sweep; deleting one that did turns a resumed saga into a duplicated
+// one.
+func (p *parentLiveness) isLive(ctx context.Context, id string, log *slog.Logger) bool {
+	if live, known := p.live[id]; known {
+		return live
 	}
 
-	incomplete, err := storage.ListIncomplete(ctx)
-	if err != nil {
-		return nil, err
+	exec, err := p.storage.Get(ctx, id)
+	switch {
+	case errors.Is(err, ErrExecutionNotFound):
+		p.live[id] = false
+	case err != nil:
+		log.Warn("could not read saga parent, keeping its children for now",
+			"parent", id, "error", err)
+		p.live[id] = true
+	default:
+		p.live[id] = !isTerminal(exec.Status)
 	}
 
-	live := make(map[string]struct{}, len(incomplete))
-	for _, exec := range incomplete {
-		if exec != nil {
-			live[exec.ID] = struct{}{}
-		}
-	}
-	return live, nil
+	return p.live[id]
 }
 
 // RetentionConfig tunes a retention sweep.
@@ -108,52 +123,104 @@ func RunRetention(ctx context.Context, storage Storage, cfg RetentionConfig, log
 		return result, nil
 	}
 
-	terminal, err := storage.ListTerminal(ctx)
-	if err != nil {
-		return result, err
-	}
-
-	liveParents, err := liveParentsOf(ctx, storage, terminal)
-	if err != nil {
-		return result, err
-	}
-
+	parents := newParentLiveness(storage)
 	cutoff := time.Now().Add(-cfg.Retention)
 
-	for i, exec := range terminal {
+	cursor := ""
+	for {
 		if err := ctx.Err(); err != nil {
 			return result, err
 		}
-		result.Scanned++
 
-		if exec.FinishedAt.After(cutoff) {
-			continue
+		page, err := storage.ListTerminalPage(ctx, TerminalQuery{Cursor: cursor})
+		if err != nil {
+			return result, err
 		}
 
-		// A finished child whose parent is still in flight has to stay. The
-		// parent does not re-run a nested saga on resume, it re-finds the child
-		// by deterministic ID and reuses the result, so deleting the child
-		// converts a resumed saga into a duplicated one.
-		if exec.ParentID != "" {
-			if _, live := liveParents[exec.ParentID]; live {
+		for _, exec := range page.Executions {
+			if err := ctx.Err(); err != nil {
+				return result, err
+			}
+			result.Scanned++
+
+			if exec.FinishedAt.After(cutoff) {
+				continue
+			}
+
+			// A finished child whose parent is still in flight has to stay. The
+			// parent does not re-run a nested saga on resume, it re-finds the
+			// child by deterministic ID and reuses the result, so deleting the
+			// child converts a resumed saga into a duplicated one.
+			if exec.ParentID != "" && parents.isLive(ctx, exec.ParentID, log) {
 				result.Skipped++
 				continue
 			}
+
+			if err := storage.Delete(ctx, exec.ID); err != nil {
+				log.Warn("failed to delete expired saga execution",
+					"id", exec.ID, "finished_at", exec.FinishedAt, "error", err)
+				result.Failed++
+				continue
+			}
+			result.Deleted++
+
+			if cfg.MaxDeletes > 0 && result.Deleted >= cfg.MaxDeletes {
+				capped, err := stoppedEarly(ctx, storage, page, exec.ID)
+				if err != nil {
+					return result, err
+				}
+				result.Capped = capped
+				return result, nil
+			}
 		}
 
-		if err := storage.Delete(ctx, exec.ID); err != nil {
-			log.Warn("failed to delete expired saga execution",
-				"id", exec.ID, "finished_at", exec.FinishedAt, "error", err)
-			result.Failed++
-			continue
-		}
-		result.Deleted++
-
-		if cfg.MaxDeletes > 0 && result.Deleted >= cfg.MaxDeletes {
-			result.Capped = i < len(terminal)-1
+		cursor = page.Cursor
+		if cursor == "" {
 			return result, nil
 		}
 	}
+}
 
-	return result, nil
+// stoppedEarly reports whether a sweep that just spent its delete budget left
+// anything uninspected.
+//
+// Spending the budget is not the same as being cut short. A sweep that deletes
+// its last permitted execution and has nothing left to look at did the whole
+// job, and reporting that as capped would have an operator chasing a backlog
+// that is not there.
+//
+// Deciding takes a look ahead, because the cursor alone cannot answer it. The
+// walk covers several status indexes in sequence, so a cursor can point at the
+// head of a next index that turns out to be empty, and a page can come back
+// empty while its cursor still has an index behind it. So the lookahead reads
+// forward until it finds something or the walk genuinely ends, rather than
+// reading one page and concluding from an empty one. It runs at all only in the
+// exact case where the budget landed on a page boundary.
+func stoppedEarly(ctx context.Context, storage Storage, page *TerminalPage, deletedID string) (bool, error) {
+	if len(page.Executions) == 0 {
+		return false, nil
+	}
+
+	// Anything after it in the page it stopped in is already unlooked-at.
+	if deletedID != page.Executions[len(page.Executions)-1].ID {
+		return true, nil
+	}
+
+	cursor := page.Cursor
+	for cursor != "" {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+
+		next, err := storage.ListTerminalPage(ctx, TerminalQuery{Cursor: cursor, Limit: 1})
+		if err != nil {
+			return false, err
+		}
+		if len(next.Executions) > 0 {
+			return true, nil
+		}
+		cursor = next.Cursor
+	}
+
+	return false, nil
 }

--- a/pkg/saga/retention_etcd_test.go
+++ b/pkg/saga/retention_etcd_test.go
@@ -45,7 +45,7 @@ func TestRetention_AgainstRealEtcd(t *testing.T) {
 	saveAged(t, storage, "etcd-fresh", StatusCompleted, 1*time.Hour)
 	saveAged(t, storage, "etcd-running", StatusRunning, 90*24*time.Hour)
 
-	terminal, err := storage.ListTerminal(ctx)
+	terminal, err := collectTerminal(ctx, storage)
 	require.NoError(t, err)
 	require.Len(t, terminal, 3, "the three terminal executions must be discoverable through the real status index")
 
@@ -100,7 +100,7 @@ func TestRetention_LegacyExecutionAgainstRealEtcd(t *testing.T) {
 		ExecutionOrder:  []string{},
 	}))
 
-	terminal, err := storage.ListTerminal(ctx)
+	terminal, err := collectTerminal(ctx, storage)
 	require.NoError(t, err)
 	require.Len(t, terminal, 1)
 	assert.False(t, terminal[0].FinishedAt.IsZero(),

--- a/pkg/saga/retention_test.go
+++ b/pkg/saga/retention_test.go
@@ -277,7 +277,7 @@ func TestListTerminal_LegacyExecutionsUseStoreTimestamp(t *testing.T) {
 				ExecutionOrder:  []string{},
 			}))
 
-			terminal, err := tc.storage.ListTerminal(ctx)
+			terminal, err := collectTerminal(ctx, tc.storage)
 			require.NoError(t, err)
 
 			var found *TerminalExecution

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -111,64 +111,61 @@ func (s *EntityStorage) Get(ctx context.Context, id string) (*Execution, error) 
 	return entityToExecution(sagaEntity)
 }
 
-// ListIncomplete returns all executions that need recovery.
-func (s *EntityStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
-	// Query for pending sagas (crashed between initial save and status transition)
-	pendingIds, err := s.store.ListIndex(ctx, entity.Ref(
-		saga_v1alpha.SagaStatusId,
-		saga_v1alpha.SagaStatusPendingId,
-	))
+// ListIncompletePage returns one bounded page of executions needing recovery.
+//
+// The three incomplete status indexes are walked one after another rather than
+// merged, because merging would mean holding all three id sets to deduplicate
+// across them, which is the allocation this is here to avoid. A cursor names
+// which index it is in, so a page never straddles two.
+//
+// Nothing deduplicates across indexes as a result. An execution listed under
+// two statuses at once is a stale index entry, and the caller is the right
+// place to notice: recovery refuses to drive an execution twice through its
+// own claim, and retention's deletes are idempotent by contract.
+func (s *EntityStorage) ListIncompletePage(ctx context.Context, q IncompleteQuery) (*IncompletePage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	stage, inner, err := decodeStageCursor(q.Cursor, len(incompleteStatuses))
 	if err != nil {
-		return nil, fmt.Errorf("listing pending sagas: %w", err)
+		return nil, err
 	}
 
-	// Query for running sagas
-	runningIds, err := s.store.ListIndex(ctx, entity.Ref(
-		saga_v1alpha.SagaStatusId,
-		saga_v1alpha.SagaStatusRunningId,
-	))
+	attr := entity.Ref(saga_v1alpha.SagaStatusId, incompleteStatuses[stage])
+
+	page, err := s.store.ListIndexEntitiesPage(ctx, attr, inner, int64(clampLimit(q.Limit)))
 	if err != nil {
-		return nil, fmt.Errorf("listing running sagas: %w", err)
+		return nil, fmt.Errorf("listing sagas with status %s: %w", incompleteStatuses[stage], err)
 	}
 
-	// Query for undoing sagas
-	undoingIds, err := s.store.ListIndex(ctx, entity.Ref(
-		saga_v1alpha.SagaStatusId,
-		saga_v1alpha.SagaStatusUndoingId,
-	))
-	if err != nil {
-		return nil, fmt.Errorf("listing undoing sagas: %w", err)
+	next := nextStageCursor(stage, page.Cursor, len(incompleteStatuses))
+
+	// Empty is a short page, not an ending, exactly as it is for EACStorage.
+	// This backend cannot produce an empty page with a live cursor, since a
+	// dropped id holds its place as a nil and an empty id list means an empty
+	// cursor, but the two backends answer one contract and should not read
+	// differently.
+	if len(page.Entities) == 0 {
+		return &IncompletePage{Cursor: next}, nil
 	}
 
-	// Combine IDs, deduplicating by ID. A saga can transiently appear under
-	// more than one status index (e.g. a stale pending entry lingering after
-	// the transition to running). Recovering the same execution twice causes
-	// double execution: the second pass re-runs already-completed actions and
-	// collides on entities the first pass created.
-	seen := make(map[entity.Id]struct{})
-	var allIds []entity.Id
-	for _, ids := range [][]entity.Id{pendingIds, runningIds, undoingIds} {
-		for _, id := range ids {
-			if _, dup := seen[id]; dup {
-				continue
-			}
-			seen[id] = struct{}{}
-			allIds = append(allIds, id)
-		}
-	}
-	if len(allIds) == 0 {
-		return nil, nil
-	}
+	executions, stale := s.decodeIncomplete(page.Entities)
+	logStaleIncomplete(s.log, stale)
 
-	// Batch fetch all entities
-	entities, err := s.store.GetEntities(ctx, allIds)
-	if err != nil {
-		return nil, fmt.Errorf("fetching saga entities: %w", err)
-	}
+	return &IncompletePage{Executions: executions, Cursor: next}, nil
+}
 
-	// Convert to executions
+// decodeIncomplete converts a page of entities into executions, dropping the
+// ones whose decoded status says they are already finished and counting them.
+//
+// The index is a hint and the entity is the answer. An entry can outlive the
+// status it was written for, and a page is two reads, so the status that
+// selected an id can be out of date by the time its entity arrives.
+func (s *EntityStorage) decodeIncomplete(entities []*entity.Entity) ([]*Execution, int) {
 	var executions []*Execution
-	var staleTerminal int
+	var stale int
+
 	for _, ent := range entities {
 		if ent == nil {
 			continue
@@ -184,90 +181,66 @@ func (s *EntityStorage) ListIncomplete(ctx context.Context) ([]*Execution, error
 			continue
 		}
 		if isTerminal(exec.Status) {
-			staleTerminal++
+			stale++
 			continue
 		}
 		executions = append(executions, exec)
 	}
 
-	logStaleIncomplete(s.log, staleTerminal)
-
-	return executions, nil
+	return executions, stale
 }
 
-// terminalFetchBatch is how many entities ListTerminal materializes at a time.
-// Every entity carries its action-output blobs, so a store holding a large
-// backlog must not be pulled into memory all at once just to read timestamps
-// off it.
-//
-// This is not redundant with the batching GetEntities already does internally.
-// That one chunks the etcd transaction ops and then still allocates and returns
-// the full slice, so it bounds request size, not memory. This outer loop is
-// what keeps peak memory flat.
-const terminalFetchBatch = 200
-
-// ListTerminal summarizes every execution in a terminal state.
+// ListTerminalPage summarizes one bounded page of finished executions.
 //
 // The store's index lookups are equality-only, so there is no range query over
-// a timestamp that would let us ask for expired executions directly. We list
-// the terminal set (IDs only, which stays cheap) and read each one's finish
-// time, fetching in batches and keeping only the summary.
-func (s *EntityStorage) ListTerminal(ctx context.Context) ([]TerminalExecution, error) {
-	var ids []entity.Id
-	seen := make(map[entity.Id]struct{})
+// a timestamp that would let us ask for expired executions directly. We walk
+// the terminal indexes and read each execution's finish time, keeping only the
+// summary.
+func (s *EntityStorage) ListTerminalPage(ctx context.Context, q TerminalQuery) (*TerminalPage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
-	for _, status := range []entity.Id{
-		saga_v1alpha.SagaStatusCompletedId,
-		saga_v1alpha.SagaStatusFailedId,
-	} {
-		statusIds, err := s.store.ListIndex(ctx, entity.Ref(saga_v1alpha.SagaStatusId, status))
-		if err != nil {
-			return nil, fmt.Errorf("listing terminal sagas: %w", err)
-		}
-		// Deduplicate for the same reason recovery does: an execution can
-		// transiently appear under more than one status index.
-		for _, id := range statusIds {
-			if _, dup := seen[id]; dup {
-				continue
-			}
-			seen[id] = struct{}{}
-			ids = append(ids, id)
-		}
+	stage, inner, err := decodeStageCursor(q.Cursor, len(terminalStatuses))
+	if err != nil {
+		return nil, err
+	}
+
+	attr := entity.Ref(saga_v1alpha.SagaStatusId, terminalStatuses[stage])
+
+	page, err := s.store.ListIndexEntitiesPage(ctx, attr, inner, int64(clampLimit(q.Limit)))
+	if err != nil {
+		return nil, fmt.Errorf("listing terminal sagas: %w", err)
+	}
+
+	next := nextStageCursor(stage, page.Cursor, len(terminalStatuses))
+
+	if len(page.Entities) == 0 {
+		return &TerminalPage{Cursor: next}, nil
 	}
 
 	var result []TerminalExecution
 	var staleNonTerminal int
-	for start := 0; start < len(ids); start += terminalFetchBatch {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
 
-		end := min(start+terminalFetchBatch, len(ids))
-		entities, err := s.store.GetEntities(ctx, ids[start:end])
-		if err != nil {
-			return nil, fmt.Errorf("fetching terminal sagas: %w", err)
+	for _, ent := range page.Entities {
+		if ent == nil {
+			// Deleted between the listing and the fetch. Nothing to report.
+			continue
 		}
-
-		for _, ent := range entities {
-			if ent == nil {
-				// Deleted between the listing and the fetch. Nothing to report.
-				continue
-			}
-			summary, verdict := terminalSummary(ent)
-			switch verdict {
-			case summaryOK:
-				result = append(result, summary)
-			case summaryNotTerminal:
-				staleNonTerminal++
-			case summaryNoTimestamp:
-				s.log.Warn("terminal saga has no usable timestamp, skipping", "id", ent.Id())
-			}
+		summary, verdict := terminalSummary(ent)
+		switch verdict {
+		case summaryOK:
+			result = append(result, summary)
+		case summaryNotTerminal:
+			staleNonTerminal++
+		case summaryNoTimestamp:
+			s.log.Warn("terminal saga has no usable timestamp, skipping", "id", ent.Id())
 		}
 	}
 
 	logStaleTerminal(s.log, staleNonTerminal)
 
-	return result, nil
+	return &TerminalPage{Executions: result, Cursor: next}, nil
 }
 
 // Delete removes a saga execution entity.

--- a/pkg/saga/storage_conformance_test.go
+++ b/pkg/saga/storage_conformance_test.go
@@ -2,6 +2,7 @@ package saga
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,6 +18,12 @@ import (
 type storageFactory struct {
 	name string
 	make func(t *testing.T) Storage
+
+	// makeIndexed is set only for the backends that find their work through a
+	// status index, and hands back the store underneath so a test can seed an
+	// index entry pointing at an execution that is not there. MemoryStorage
+	// leaves it nil: it has no index, so it has no index to corrupt.
+	makeIndexed func(t *testing.T) (Storage, *entity.MockStore)
 }
 
 // allStorageBackends returns every production Storage implementation behind a
@@ -52,6 +59,11 @@ func allStorageBackends() []storageFactory {
 				t.Cleanup(cleanup)
 				return NewEntityStorage(inmem.Store, testutils.TestLogger(t))
 			},
+			makeIndexed: func(t *testing.T) (Storage, *entity.MockStore) {
+				inmem, cleanup := testutils.NewInMemEntityServer(t)
+				t.Cleanup(cleanup)
+				return NewEntityStorage(inmem.Store, testutils.TestLogger(t)), inmem.Store
+			},
 		},
 		{
 			name: "EACStorage",
@@ -59,6 +71,11 @@ func allStorageBackends() []storageFactory {
 				inmem, cleanup := testutils.NewInMemEntityServer(t)
 				t.Cleanup(cleanup)
 				return NewEACStorage(inmem.EAC, testutils.TestLogger(t))
+			},
+			makeIndexed: func(t *testing.T) (Storage, *entity.MockStore) {
+				inmem, cleanup := testutils.NewInMemEntityServer(t)
+				t.Cleanup(cleanup)
+				return NewEACStorage(inmem.EAC, testutils.TestLogger(t)), inmem.Store
 			},
 		},
 	}
@@ -144,7 +161,7 @@ func TestStorageConformance_CompletedExecutionLeavesIncompleteList(t *testing.T)
 			}
 			require.NoError(t, storage.Save(ctx, exec))
 
-			incomplete, err := storage.ListIncomplete(ctx)
+			incomplete, err := collectIncomplete(ctx, storage)
 			require.NoError(t, err)
 			assert.True(t, containsExecution(incomplete, exec.ID),
 				"a pending saga must appear in ListIncomplete")
@@ -152,7 +169,7 @@ func TestStorageConformance_CompletedExecutionLeavesIncompleteList(t *testing.T)
 			exec.Status = StatusCompleted
 			require.NoError(t, storage.Save(ctx, exec))
 
-			incomplete, err = storage.ListIncomplete(ctx)
+			incomplete, err = collectIncomplete(ctx, storage)
 			require.NoError(t, err)
 			assert.False(t, containsExecution(incomplete, exec.ID),
 				"a completed saga must NOT appear in ListIncomplete; if it does, recovery will re-run finished work")
@@ -284,12 +301,12 @@ func TestStorageConformance_IncompleteListIgnoresStaleTerminalIndex(t *testing.T
 		seedStaleStatusIndex(t, store, "teardown-postgres", StatusPending)
 		seedStaleStatusIndex(t, store, "teardown-postgres", StatusRunning)
 
-		incomplete, err := storage.ListIncomplete(ctx)
+		incomplete, err := collectIncomplete(ctx, storage)
 		require.NoError(t, err)
 		assert.Empty(t, incomplete,
 			"a failed execution must not be recovered because stale pending and running index entries survived")
 
-		terminal, err := storage.ListTerminal(ctx)
+		terminal, err := collectTerminal(ctx, storage)
 		require.NoError(t, err)
 		require.Len(t, terminal, 1, "the execution is still terminal and retention must still see it")
 		assert.Equal(t, "teardown-postgres", terminal[0].ID)
@@ -306,12 +323,12 @@ func TestStorageConformance_TerminalListIgnoresStaleIncompleteIndex(t *testing.T
 		saveAged(t, storage, "create-sandbox", StatusRunning, 30*24*time.Hour)
 		seedStaleStatusIndex(t, store, "create-sandbox", StatusCompleted)
 
-		terminal, err := storage.ListTerminal(ctx)
+		terminal, err := collectTerminal(ctx, storage)
 		require.NoError(t, err)
 		assert.Empty(t, terminal,
 			"a running execution must not be offered to retention because a stale completed index entry survived")
 
-		incomplete, err := storage.ListIncomplete(ctx)
+		incomplete, err := collectIncomplete(ctx, storage)
 		require.NoError(t, err)
 		require.Len(t, incomplete, 1, "the execution is still in flight and recovery must still find it")
 		assert.Equal(t, "create-sandbox", incomplete[0].ID)
@@ -338,4 +355,316 @@ func TestStorageConformance_RetentionCollectsChildOfStaleIncompleteParent(t *tes
 		assert.False(t, executionExists(t, storage, "expired-child"))
 		assert.False(t, executionExists(t, storage, "finished-parent"))
 	})
+}
+
+// collectIncomplete and collectTerminal walk a storage's pages to the end and
+// return everything, for tests that are asserting on the contents of the set
+// rather than on how it is paged. Paging itself is exercised separately, by
+// TestStorageConformance_Paging.
+func collectIncomplete(ctx context.Context, s Storage) ([]*Execution, error) {
+	var all []*Execution
+	cursor := ""
+	// A bound rather than `for {}`: a backend whose cursor failed to advance
+	// would otherwise hang the suite instead of failing it, and a hung test
+	// says much less than a failed one.
+	for range 1000 {
+		page, err := s.ListIncompletePage(ctx, IncompleteQuery{Cursor: cursor})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page.Executions...)
+		cursor = page.Cursor
+		if cursor == "" {
+			return all, nil
+		}
+	}
+	return nil, fmt.Errorf("incomplete walk did not terminate")
+}
+
+func collectTerminal(ctx context.Context, s Storage) ([]TerminalExecution, error) {
+	var all []TerminalExecution
+	cursor := ""
+	for range 1000 {
+		page, err := s.ListTerminalPage(ctx, TerminalQuery{Cursor: cursor})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page.Executions...)
+		cursor = page.Cursor
+		if cursor == "" {
+			return all, nil
+		}
+	}
+	return nil, fmt.Errorf("terminal walk did not terminate")
+}
+
+// TestStorageConformance_Paging pins the paging contract every backend has to
+// satisfy, because the callers cannot tell which one they are talking to.
+//
+// The properties that matter to a caller walking a backlog: a page never
+// exceeds the limit it asked for, the pages together cover the set exactly
+// once, the walk terminates, and a short page is not mistaken for the end. That
+// last one is the trap. The etcd-backed backends finish one status index before
+// starting the next and never straddle two, so a page can come back well under
+// the limit with plenty still to come, and a caller that stopped on a short
+// page would silently skip every running and undoing saga in the store.
+func TestStorageConformance_Paging(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			t.Run("covers the incomplete set exactly once across pages", func(t *testing.T) {
+				storage := backend.make(t)
+
+				// Spread across all three incomplete statuses so a backend that
+				// walks them in stages actually has stages to walk, and enough
+				// per status that a limit of 2 cannot clear one in a page.
+				want := map[string]bool{}
+				for i := range 5 {
+					for _, status := range []Status{StatusPending, StatusRunning, StatusUndoing} {
+						id := fmt.Sprintf("page-%s-%02d", status, i)
+						saveWithStatus(t, storage, id, status)
+						want[id] = true
+					}
+				}
+
+				seen := map[string]bool{}
+				cursor := ""
+				pages := 0
+
+				for range 100 {
+					page, err := storage.ListIncompletePage(ctx, IncompleteQuery{Cursor: cursor, Limit: 2})
+					require.NoError(t, err)
+					require.LessOrEqual(t, len(page.Executions), 2,
+						"a page must never exceed the limit it was given")
+
+					pages++
+					for _, exec := range page.Executions {
+						require.False(t, seen[exec.ID], "paging returned %s twice", exec.ID)
+						seen[exec.ID] = true
+					}
+
+					cursor = page.Cursor
+					if cursor == "" {
+						break
+					}
+				}
+
+				assert.Equal(t, "", cursor, "the walk must terminate")
+				assert.Equal(t, want, seen, "the pages together must cover the set")
+				assert.Greater(t, pages, 1, "15 executions at 2 per page must take more than one page")
+			})
+
+			t.Run("covers the terminal set exactly once across pages", func(t *testing.T) {
+				storage := backend.make(t)
+
+				want := map[string]bool{}
+				for i := range 5 {
+					for _, status := range []Status{StatusCompleted, StatusFailed} {
+						id := fmt.Sprintf("page-%s-%02d", status, i)
+						saveWithStatus(t, storage, id, status)
+						want[id] = true
+					}
+				}
+
+				seen := map[string]bool{}
+				cursor := ""
+
+				for range 100 {
+					page, err := storage.ListTerminalPage(ctx, TerminalQuery{Cursor: cursor, Limit: 2})
+					require.NoError(t, err)
+					require.LessOrEqual(t, len(page.Executions), 2)
+
+					for _, exec := range page.Executions {
+						require.False(t, seen[exec.ID], "paging returned %s twice", exec.ID)
+						seen[exec.ID] = true
+					}
+
+					cursor = page.Cursor
+					if cursor == "" {
+						break
+					}
+				}
+
+				assert.Equal(t, "", cursor, "the walk must terminate")
+				assert.Equal(t, want, seen, "the pages together must cover the set")
+			})
+
+			t.Run("an empty store ends the walk", func(t *testing.T) {
+				storage := backend.make(t)
+
+				// Not "immediately": an empty page still carries the cursor to
+				// the next status index, because a backend cannot tell an
+				// exhausted index from one whose page happened to resolve to
+				// nothing without asking. That costs a walk over an empty store
+				// one round trip per status index, which is the price of not
+				// silently skipping the rest of an index that had stale entries
+				// at the front of it.
+				incomplete := 0
+				cursor := ""
+				for range 100 {
+					page, err := storage.ListIncompletePage(ctx, IncompleteQuery{Cursor: cursor})
+					require.NoError(t, err)
+					incomplete += len(page.Executions)
+					cursor = page.Cursor
+					if cursor == "" {
+						break
+					}
+				}
+				assert.Equal(t, "", cursor, "the walk must still terminate")
+				assert.Zero(t, incomplete)
+
+				terminal := 0
+				cursor = ""
+				for range 100 {
+					page, err := storage.ListTerminalPage(ctx, TerminalQuery{Cursor: cursor})
+					require.NoError(t, err)
+					terminal += len(page.Executions)
+					cursor = page.Cursor
+					if cursor == "" {
+						break
+					}
+				}
+				assert.Equal(t, "", cursor, "the walk must still terminate")
+				assert.Zero(t, terminal)
+			})
+
+			t.Run("a set that ends on a page boundary ends the walk", func(t *testing.T) {
+				storage := backend.make(t)
+
+				// One status only, four of them, read two at a time: the second
+				// page fills exactly and there is nothing after it.
+				for i := range 4 {
+					saveWithStatus(t, storage, fmt.Sprintf("boundary-%02d", i), StatusCompleted)
+				}
+
+				seen := 0
+				cursor := ""
+				for range 100 {
+					page, err := storage.ListTerminalPage(ctx, TerminalQuery{Cursor: cursor, Limit: 2})
+					require.NoError(t, err)
+					seen += len(page.Executions)
+					cursor = page.Cursor
+					if cursor == "" {
+						break
+					}
+				}
+
+				assert.Equal(t, 4, seen)
+				assert.Equal(t, "", cursor, "the walk must terminate on an exact boundary too")
+			})
+
+			t.Run("stops when the context is cancelled", func(t *testing.T) {
+				storage := backend.make(t)
+
+				for i := range 10 {
+					saveWithStatus(t, storage, fmt.Sprintf("cancel-%02d", i), StatusPending)
+				}
+
+				cancelled, cancel := context.WithCancel(ctx)
+				cancel()
+
+				// Not asserting on which error: what matters is that a walk
+				// under a dead context does not quietly do a store's worth of
+				// work on its way to noticing.
+				_, err := storage.ListIncompletePage(cancelled, IncompleteQuery{})
+				assert.Error(t, err)
+			})
+		})
+	}
+}
+
+// Cursor validation is deliberately not part of this suite. A cursor is opaque
+// and only ever handed back to the storage that issued it, and the backends
+// have nothing in common underneath: the etcd-backed ones prefix a status-index
+// stage and can spot a malformed cursor, while MemoryStorage's is a bare
+// execution id, where "garbage" and "an id deleted since the last page" are the
+// same string. Requiring rejection would mean giving the memory backend a
+// cursor format it has no other reason to have. The stage encoding the durable
+// backends do share is tested directly, in TestStageCursor.
+
+// saveWithStatus persists an execution in the given status, going through the
+// same two-step save the executor does so a backend's index sees the transition
+// rather than only the final value.
+func saveWithStatus(t *testing.T, storage Storage, id string, status Status) {
+	t.Helper()
+
+	now := time.Now()
+	exec := &Execution{
+		ID:              id,
+		DefinitionName:  "paging-test",
+		Status:          StatusPending,
+		InitialInputs:   map[string]any{},
+		ExecutedActions: map[string]*ActionResult{},
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	require.NoError(t, storage.Save(context.Background(), exec))
+
+	if status == StatusPending {
+		return
+	}
+
+	exec.Status = status
+	exec.UpdatedAt = now
+	require.NoError(t, storage.Save(context.Background(), exec))
+}
+
+// TestStorageConformance_PagingPastStaleEntries is the regression for a page
+// that resolves to nothing.
+//
+// A status index can name executions that are not there. That is the whole
+// premise of MIR-1735, and runners read the index across an RPC whose server
+// drops the ids it cannot resolve while keeping the cursor. So a page can come
+// back empty with an entire index still behind it, and a backend that read that
+// as "this index is exhausted" would walk off the end of it and silently leave
+// every saga after the stale run unrecovered.
+//
+// The stale entries sort ahead of the real ones on purpose: the first page has
+// to be the empty one, or the bug hides.
+func TestStorageConformance_PagingPastStaleEntries(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		if backend.makeIndexed == nil {
+			continue
+		}
+
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			storage, store := backend.makeIndexed(t)
+
+			pending, ok := StatusIndexAttr(StatusPending)
+			require.True(t, ok)
+
+			store.AddStaleIndexEntry(pending, entity.Id("aaa-stale-00"))
+			store.AddStaleIndexEntry(pending, entity.Id("aaa-stale-01"))
+
+			want := map[string]bool{}
+			for i := range 3 {
+				id := fmt.Sprintf("zzz-real-%02d", i)
+				saveWithStatus(t, storage, id, StatusPending)
+				want[id] = true
+			}
+
+			seen := map[string]bool{}
+			cursor := ""
+			for range 100 {
+				page, err := storage.ListIncompletePage(ctx, IncompleteQuery{Cursor: cursor, Limit: 2})
+				require.NoError(t, err)
+
+				for _, exec := range page.Executions {
+					seen[exec.ID] = true
+				}
+
+				cursor = page.Cursor
+				if cursor == "" {
+					break
+				}
+			}
+
+			assert.Equal(t, "", cursor, "the walk must terminate")
+			assert.Equal(t, want, seen,
+				"a page that resolved to nothing must not end the walk of its index")
+		})
+	}
 }

--- a/pkg/saga/types.go
+++ b/pkg/saga/types.go
@@ -110,3 +110,56 @@ type TerminalExecution struct {
 	// duplicated one.
 	ParentID string
 }
+
+// IncompleteQuery selects one page of incomplete executions.
+//
+// It is a struct rather than positional arguments because what recovery needs
+// to say about a page grows: the filtering that keeps an executor from loading
+// another executor's payloads is expressed here too.
+type IncompleteQuery struct {
+	// Cursor resumes after the last execution of a previous page. Empty starts
+	// at the beginning.
+	Cursor string
+
+	// Limit caps how many executions the page materializes. Zero or less means
+	// the backend's own cap, which every backend has: a page with no ceiling is
+	// the unbounded read this whole design exists to remove.
+	Limit int
+}
+
+// IncompletePage is one bounded page of executions needing recovery.
+type IncompletePage struct {
+	// Executions are the incomplete executions in this page.
+	Executions []*Execution
+
+	// Cursor resumes the walk after this page, and is empty once there is
+	// nothing left.
+	//
+	// A short page does not mean the end. Backends that walk several status
+	// indexes finish one before starting the next, and never straddle two in
+	// one page, so a page can come back well under the limit with plenty still
+	// to come. Only an empty cursor ends the walk.
+	Cursor string
+}
+
+// TerminalQuery selects one page of terminal executions.
+type TerminalQuery struct {
+	// Cursor resumes after the last execution of a previous page. Empty starts
+	// at the beginning.
+	Cursor string
+
+	// Limit caps how many executions the page summarizes. Zero or less means
+	// the backend's own cap.
+	Limit int
+}
+
+// TerminalPage is one bounded page of finished executions.
+type TerminalPage struct {
+	// Executions summarizes the terminal executions in this page.
+	Executions []TerminalExecution
+
+	// Cursor resumes the walk after this page, empty once the walk is done.
+	// The same caveat as IncompletePage.Cursor applies: a short page is not an
+	// ending, only an empty cursor is.
+	Cursor string
+}

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -692,6 +692,39 @@ func (e *EntityServer) List(ctx context.Context, req *entityserver_v1alpha.Entit
 	return nil
 }
 
+// ListPage reads a bounded page of entities from an index.
+func (e *EntityServer) ListPage(ctx context.Context, req *entityserver_v1alpha.EntityAccessListPage) error {
+	args := req.Args()
+
+	if !args.HasIndex() {
+		return fmt.Errorf("missing required field: index")
+	}
+
+	page, err := e.entityPage(ctx, args.Index(), args.Cursor(), args.Limit())
+	if err != nil {
+		return err
+	}
+
+	ret := make([]*entityserver_v1alpha.Entity, 0, len(page.entities))
+	for _, ent := range page.entities {
+		var rpcEntity entityserver_v1alpha.Entity
+		rpcEntity.SetId(ent.Id().String())
+		rpcEntity.SetCreatedAt(ent.GetCreatedAt().UnixMilli())
+		rpcEntity.SetUpdatedAt(ent.GetUpdatedAt().UnixMilli())
+		rpcEntity.SetRevision(ent.GetRevision())
+		rpcEntity.SetAttrs(ent.Attrs())
+
+		ret = append(ret, &rpcEntity)
+	}
+
+	req.Results().SetValues(ret)
+	req.Results().SetCursor(encodeCursor(page.cursor))
+	req.Results().SetTotal(page.total)
+	req.Results().SetRevision(page.revision)
+
+	return nil
+}
+
 func (e *EntityServer) MakeAttr(ctx context.Context, req *entityserver_v1alpha.EntityAccessMakeAttr) error {
 	args := req.Args()
 
@@ -938,50 +971,17 @@ func (e *EntityServer) ListDocuments(ctx context.Context, req *entityserver_v1al
 		return fmt.Errorf("missing required field: index")
 	}
 
-	index := args.Index()
-
-	cursor, err := decodeCursor(args.Cursor())
+	page, err := e.entityPage(ctx, args.Index(), args.Cursor(), args.Limit())
 	if err != nil {
 		return err
-	}
-
-	// Zero means "everything" to the caller, which the client turns into a walk
-	// over successive pages rather than one enormous response.
-	limit := args.Limit()
-	if limit <= 0 || limit > MaxPageLimit {
-		limit = MaxPageLimit
-	}
-
-	ids, next, total, err := e.pageIds(ctx, index, cursor, limit)
-	if err != nil {
-		return err
-	}
-
-	entities, err := e.Store.GetEntities(ctx, ids)
-	if err != nil {
-		return fmt.Errorf("failed to get entities: %w", err)
 	}
 
 	opts := model.Options{MaxValueLen: int(args.MaxValueLen())}
 
 	// Non-nil so an empty page marshals as [] rather than null, which spares
 	// every JSON consumer a null check.
-	docs := make([]*model.Document, 0, len(entities))
-
-	for i, ent := range entities {
-		if ent == nil {
-			e.Log.Error("entity in index but not in store, skipping",
-				"id", ids[i],
-				"index", index)
-
-			// Keep the reported total honest about what the caller can see.
-			if total > 0 {
-				total--
-			}
-
-			continue
-		}
-
+	docs := make([]*model.Document, 0, len(page.entities))
+	for _, ent := range page.entities {
 		docs = append(docs, model.BuildDocument(ctx, e.sc, ent, opts))
 	}
 
@@ -991,10 +991,111 @@ func (e *EntityServer) ListDocuments(ctx context.Context, req *entityserver_v1al
 	}
 
 	req.Results().SetDocuments(data)
-	req.Results().SetCursor(encodeCursor(next))
-	req.Results().SetTotal(total)
+	req.Results().SetCursor(encodeCursor(page.cursor))
+	req.Results().SetTotal(page.total)
 
 	return nil
+}
+
+// resolvedPage is one page of entities that actually resolved, with the ids
+// that did not already dropped and accounted for.
+type resolvedPage struct {
+	entities []*entity.Entity
+	cursor   string
+	total    int64
+	revision int64
+}
+
+// entityPage reads one page of an index and the entities it names.
+//
+// Both listing methods reduce to this plus a transform, and keeping the read in
+// one place is what stops them drifting: they differ in what they render, not
+// in what they read or in how they account for an id the store could not
+// resolve.
+//
+// Session indexes stay here rather than moving into the store, because reaching
+// ListSessionEntities means base58-decoding a session id out of the attribute
+// value, which is a wire concern. Those listings carry no revision to pin to.
+// The index arrives already read rather than as the request, so callers have to
+// check HasIndex before they get here: Index() dereferences the optional field,
+// and Go evaluates the argument before the call, so a guard inside this
+// function would be a panic that never got the chance to fire.
+func (e *EntityServer) entityPage(
+	ctx context.Context,
+	index entity.Attr,
+	rawCursor string,
+	limit int64,
+) (*resolvedPage, error) {
+	cursor, err := decodeCursor(rawCursor)
+	if err != nil {
+		return nil, err
+	}
+
+	// Zero means "everything" to the caller, which the client turns into a walk
+	// over successive pages rather than one enormous response.
+	if limit <= 0 || limit > MaxPageLimit {
+		limit = MaxPageLimit
+	}
+
+	if index.ID == entity.AttrSession {
+		ids, next, total, err := e.pageSessionIds(ctx, index, cursor, limit)
+		if err != nil {
+			return nil, err
+		}
+
+		entities, err := e.Store.GetEntities(ctx, ids)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get entities: %w", err)
+		}
+
+		return e.resolve(index, ids, entities, nil, next, total, 0), nil
+	}
+
+	page, err := e.Store.ListIndexEntitiesPage(ctx, index, cursor, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list entities: %w", err)
+	}
+
+	return e.resolve(index, page.Ids, page.Entities, page.Undecodable, page.Cursor, page.Total, page.Revision), nil
+}
+
+// resolve drops the ids the store could not answer for and keeps the reported
+// total honest about what the caller can actually see.
+//
+// Absent and unreadable both arrive as a nil entity and deserve different
+// lines. An id the index still names but the store has dropped is stale-index
+// work; a key that will not decode is a corrupt entity nobody should assume is
+// gone.
+func (e *EntityServer) resolve(
+	index entity.Attr,
+	ids []entity.Id,
+	entities []*entity.Entity,
+	undecodable map[entity.Id]bool,
+	cursor string,
+	total, revision int64,
+) *resolvedPage {
+	resolved := make([]*entity.Entity, 0, len(entities))
+
+	for i, ent := range entities {
+		if ent != nil {
+			resolved = append(resolved, ent)
+			continue
+		}
+
+		if undecodable[ids[i]] {
+			e.Log.Error("entity in index cannot be decoded, skipping",
+				"id", ids[i], "index", index)
+		} else {
+			e.Log.Error("entity in index but not in store, skipping",
+				"id", ids[i], "index", index)
+		}
+
+		if total > 0 {
+			total--
+		}
+	}
+
+	return &resolvedPage{entities: resolved, cursor: cursor, total: total, revision: revision}
 }
 
 // encodeCursor hides the store key a cursor is made of. It is a resume point,
@@ -1020,47 +1121,47 @@ func decodeCursor(cursor string) (string, error) {
 	return string(key), nil
 }
 
-// pageIds resolves one page of an index.
+// pageSessionIds reads one page of a session's entities.
 //
-// Session membership is not an attribute index and the store cannot page it, so
-// that case lists and slices. Everything else pages in the store.
-func (e *EntityServer) pageIds(ctx context.Context, index entity.Attr, cursor string, limit int64) ([]entity.Id, string, int64, error) {
-	if index.ID == entity.AttrSession {
-		ids, _, err := e.listIds(ctx, index)
-		if err != nil {
-			return nil, "", 0, err
-		}
-
-		// The only sort on the paging path, and the only place a page costs
-		// O(all matches). Session membership has no keyspace to resume from, so
-		// the cursor has to be an entity id, which needs a total order the
-		// store does not provide. It is bounded by what one session bonded,
-		// which is small; the indexed path below pages in etcd instead.
-		slices.Sort(ids)
-
-		total := int64(len(ids))
-
-		if cursor != "" {
-			for len(ids) > 0 && string(ids[0]) <= cursor {
-				ids = ids[1:]
-			}
-		}
-
-		var next string
-		if limit > 0 && int64(len(ids)) > limit {
-			next = string(ids[limit-1])
-			ids = ids[:limit]
-		}
-
-		return ids, next, total, nil
-	}
-
-	page, err := e.Store.ListIndexPage(ctx, index, cursor, limit)
+// Session membership is not an attribute index, so the store cannot page it and
+// this lists and slices instead. It is the only sort left on the paging path
+// and the only place a page costs O(all matches), which is tolerable because a
+// page is bounded by what one session bonded. Everything else pages in the
+// store.
+//
+// Reaching the store here means base58-decoding a session id out of the
+// attribute value, which is why this stays on the server rather than moving
+// into ListIndexEntitiesPage with the rest of the paging.
+func (e *EntityServer) pageSessionIds(
+	ctx context.Context,
+	index entity.Attr,
+	cursor string,
+	limit int64,
+) (ids []entity.Id, next string, total int64, err error) {
+	ids, _, err = e.listIds(ctx, index)
 	if err != nil {
-		return nil, "", 0, fmt.Errorf("failed to list entities: %w", err)
+		return nil, "", 0, err
 	}
 
-	return page.Ids, page.Cursor, page.Total, nil
+	// The cursor has to be an entity id, since session membership has no
+	// keyspace to resume from, and that needs a total order the store does not
+	// provide.
+	slices.Sort(ids)
+
+	total = int64(len(ids))
+
+	if cursor != "" {
+		for len(ids) > 0 && string(ids[0]) <= cursor {
+			ids = ids[1:]
+		}
+	}
+
+	if limit > 0 && int64(len(ids)) > limit {
+		next = string(ids[limit-1])
+		ids = ids[:limit]
+	}
+
+	return ids, next, total, nil
 }
 
 func (e *EntityServer) CreateSession(ctx context.Context, req *entityserver_v1alpha.EntityAccessCreateSession) error {

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -1140,3 +1140,106 @@ type failingGetStore struct {
 func (f *failingGetStore) GetEntity(ctx context.Context, id entity.Id) (*entity.Entity, error) {
 	return nil, f.err
 }
+
+func TestEntityServer_ListPage(t *testing.T) {
+	const testKind = "dev.miren.core/kind.project"
+
+	index := entity.Attr{ID: entity.EntityKind, Value: entity.RefValue(testKind)}
+
+	seed := func(t *testing.T, store entity.Store, count int) {
+		t.Helper()
+		for i := range count {
+			_, err := store.CreateEntity(context.TODO(), entity.New([]entity.Attr{
+				{ID: entity.Ident, Value: entity.KeywordValue(fmt.Sprintf("test/entity%02d", i))},
+				{ID: entity.EntityKind, Value: entity.RefValue(testKind)},
+			}))
+			require.NoError(t, err)
+		}
+	}
+
+	setup := func(t *testing.T, count int) v1alpha.EntityAccessClient {
+		t.Helper()
+		r := require.New(t)
+
+		store := entity.NewMockStore()
+		server, err := NewEntityServer(slog.Default(), store)
+		r.NoError(err)
+		r.NoError(schema.Apply(context.TODO(), store))
+
+		seed(t, store, count)
+
+		return v1alpha.EntityAccessClient{
+			Client: rpc.LocalClient(v1alpha.AdaptEntityAccess(server)),
+		}
+	}
+
+	t.Run("pages through the index without repeating or dropping", func(t *testing.T) {
+		r := require.New(t)
+		sc := setup(t, 5)
+
+		seen := map[string]bool{}
+		cursor := ""
+
+		for range 10 {
+			res, err := sc.ListPage(context.TODO(), index, cursor, 2)
+			r.NoError(err)
+			r.LessOrEqual(len(res.Values()), 2, "a page must honour the limit it was given")
+
+			for _, v := range res.Values() {
+				r.False(seen[v.Id()], "paging repeated %s", v.Id())
+				seen[v.Id()] = true
+			}
+
+			cursor = res.Cursor()
+			if cursor == "" {
+				break
+			}
+		}
+
+		r.Equal("", cursor, "paging must terminate")
+		r.Len(seen, 5, "the pages together must cover the index")
+	})
+
+	t.Run("offers no cursor when the index ends on a page boundary", func(t *testing.T) {
+		r := require.New(t)
+		sc := setup(t, 4)
+
+		res, err := sc.ListPage(context.TODO(), index, "", 2)
+		r.NoError(err)
+		r.Len(res.Values(), 2)
+
+		second, err := sc.ListPage(context.TODO(), index, res.Cursor(), 2)
+		r.NoError(err)
+		r.Len(second.Values(), 2)
+		r.Equal("", second.Cursor(),
+			"a full last page must not hand back a cursor to nothing")
+	})
+
+	t.Run("reports the total only when starting from the head", func(t *testing.T) {
+		r := require.New(t)
+		sc := setup(t, 5)
+
+		first, err := sc.ListPage(context.TODO(), index, "", 2)
+		r.NoError(err)
+		r.Equal(int64(5), first.Total(), "the caller needs the full count to say what it is hiding")
+
+		next, err := sc.ListPage(context.TODO(), index, first.Cursor(), 2)
+		r.NoError(err)
+		r.Equal(int64(0), next.Total())
+	})
+
+	t.Run("returns entities with their attributes intact", func(t *testing.T) {
+		r := require.New(t)
+		sc := setup(t, 1)
+
+		res, err := sc.ListPage(context.TODO(), index, "", 0)
+		r.NoError(err)
+		r.Len(res.Values(), 1)
+
+		ent := res.Values()[0].Entity()
+		kind, ok := ent.Get(entity.EntityKind)
+		r.True(ok, "a listed entity must arrive carrying the attribute it was indexed on")
+		r.Equal(testKind, kind.Value.Id().String())
+	})
+
+}


### PR DESCRIPTION
Upgrading a 4 GB host stalled in sandbox saga recovery and never brought application ingress up. Recovery asks "which sagas do I need to resume?", which ANDs a status predicate with an ownership one, and the entity store only answers equality on a single indexed attribute at a time. So it drove off status, got the whole cluster's incomplete set, and loaded every payload to find the handful it owned. On that host the answer was three executions and the set was around 95,000, each carrying JSON blobs of every action's output.

The first rev is really about the entity store. Listing an index is two reads, the ids and then the entities those ids name, and every caller in the tree paired them by hand and unpinned. `ListIndexEntitiesPage` makes that one operation, pinned to a single revision per page, and the three walks that already open-coded it collapse onto it and get shorter. `list_page` is the same operation over RPC, since `EntityAccess.list` materializes the whole index server-side too, which is how one restarting runner took the coordinator down with it. `list` keeps its hundred-plus callers for now; migrating them is MIR-1302, and the new method's doc says which way the migration runs.

The second rev pages recovery and retention on top of that, and picks up a second unbounded read on the way: retention was listing every in-flight execution in the cluster just to check whether a finished child's parent was still running.

Worth being explicit about what this doesn't do. It makes the walk bounded, not cheap. Recovery still visits the whole incomplete set, 200 payloads at a time rather than all at once. Filtering by ownership before loading payloads needs either an index-membership primitive or an attribute that answers ownership directly, and on a system that isn't pathological the incomplete set is a handful, so that's its own design rather than a fifth rev here.

#1166 has landed, which fixes the stale index entries that made this set look considerably bigger than it was. The two are the same fact seen from either end: the index naming things the store will not return. That one makes it stop being true; this one has to stay correct while it still is, which is why the paging carries its own defense against a page that resolves to nothing rather than waiting on the repair.

Part of MIR-1785

https://claude.ai/code/session_015bxhbDRnsP7uM37K2eQyNg

