### PR TITLE
Generate llms output from the released docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           persist-credentials: false
           # hack/docs-snapshot resolves the released docs from a tag or from
-          # docs-latest, and reads the version label off the tags reachable
+          # release/X.Y, and reads the version label off the tags reachable
           # from it. A shallow, tagless checkout can see none of that.
           fetch-depth: 0
 
@@ -59,9 +59,8 @@ jobs:
         working-directory: docs
 
       # Materializes the released docs so the build serves them at the site
-      # root with this branch's docs at /next. Skipped on pull requests: a
-      # preview build wants the branch's own docs at the root, where the
-      # reviewer will look for them.
+      # root with this branch's docs at /next. Skipped on pull requests, which
+      # publish nothing and only check that the docs still compile.
       - name: Snapshot released docs
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: hack/docs-snapshot

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -55,8 +55,20 @@ const configDir = typeof __dirname === 'string' ? __dirname : process.cwd();
 // hack/docs-snapshot materializes the released docs into version-latest, which
 // then serves at the site root while main serves at /next. The snapshot isn't
 // checked in, so a plain checkout has no versions at all and builds main at the
-// root: that's what local development and PR preview builds want.
-const releasedDocs = existsSync(`${configDir}/versioned_docs/version-latest`)
+// root, which is what local development wants and what PR builds get.
+const releasedDocsDir = `${configDir}/versioned_docs/version-latest`;
+const hasReleasedDocs = existsSync(releasedDocsDir);
+
+// docusaurus-plugin-llms reads the docs tree itself rather than going through
+// the docs plugin, so it has no idea versioning exists. Left alone it publishes
+// main's markdown at the released URLs: /observability.md would serve
+// unreleased docs with none of the banner the HTML page carries, and llms.txt
+// would advertise pages that 404 at the root. Point it at the same snapshot the
+// site root is built from. preserveDirectoryStructure: false already strips the
+// configured docsDir prefix, so the emitted paths stay root-relative.
+const llmsDocsDir = hasReleasedDocs ? 'versioned_docs/version-latest' : 'docs';
+
+const releasedDocs = hasReleasedDocs
   ? {
       lastVersion: 'latest',
       // The navbar dropdown already names the version on every page, and /next
@@ -136,6 +148,7 @@ const config: Config = {
         generateLLMsTxt: true,
         generateLLMsFullTxt: true,
         generateMarkdownFiles: true,
+        docsDir: llmsDocsDir,
         // Docs are served from the site root, so emit Markdown beside the
         // corresponding HTML route rather than under build/docs/.
         preserveDirectoryStructure: false,


### PR DESCRIPTION
Follow-up to #1175, which moved miren.md to serving the released docs with main at `/next`. The HTML site got versioned correctly; the LLM-facing surface didn't.

`docusaurus-plugin-llms` reads the docs tree directly instead of going through the docs plugin, so it never learned that versioning exists. Since the deploy earlier today it's been publishing main's markdown at the released URLs: `https://miren.md/observability.md` served unreleased content with none of the banner its HTML page carries, and `llms.txt` advertised `/command/cluster-available.md`, a page whose HTML correctly 404s at the root. Agents reading the raw markdown were getting exactly the unreleased docs the whole exercise was meant to keep off the site root.

The plugin takes a `docsDir` option, so it now points at the same materialized snapshot the root is built from, switching on the same condition the docs plugin already uses. `preserveDirectoryStructure: false` was already stripping the configured prefix, so the emitted paths stay root-relative and no `versioned_docs/` leaks into a URL.

Also fixes two stale comments: pull requests publish nothing and only check that the docs compile, and the released docs come from `release/X.Y` rather than the `docs-latest` branch an earlier draft of #1175 used.

Verified against a build with the snapshot materialized: `llms.txt` no longer lists the main-only page, `observability.md` matches the v0.14.0 headings rather than main's, `command/cluster-available.md` is correctly absent, and the URLs still read `https://miren.md/addons.md`. The no-snapshot build is unchanged, so local development still describes the branch you're on.

https://claude.ai/code/session_01Ky7UvV3FqVcNtAPQBHi9kB
