### PR TITLE
Drain HTTP/3 against our own connection census, not quic-go's count

### DIFF
--- a/pkg/rpc/drain.go
+++ b/pkg/rpc/drain.go
@@ -1,0 +1,199 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+// Graceful HTTP/3 shutdown needs a second opinion.
+//
+// http3.Server.Shutdown decides it is finished from an internal connection
+// count that it does not export. That count has a race: the channel a stalled
+// Shutdown waits on is closed only when the count reaches zero *while* the
+// server's grace context is already cancelled, so a final connection that
+// closes just before Shutdown cancels that context leaves nobody to close it.
+// Shutdown then waits out its whole deadline with no connections open and no
+// requests running, and reports the timeout as a failure to drain.
+//
+// We saw this on a coordinator whose every peer had already disconnected: ten
+// seconds of shutdown latency and a spurious error, reproducible about one run
+// in five once the machine was short enough of cores to lose the race. The
+// logic is identical in every quic-go release we have looked at, so this is not
+// something an upgrade settles.
+//
+// countingListener below is the second opinion. An idle listener is a stronger
+// signal than quic-go's count: a request can only exist on a connection, so
+// zero open connections means nothing is left to drain, whatever the count
+// says.
+
+// drainPollInterval is how often a drain in progress re-checks whether the
+// listener has gone idle. Short enough that a completed drain is not held open
+// noticeably, long enough that the poll costs nothing over a real drain.
+const drainPollInterval = 25 * time.Millisecond
+
+// countingListener wraps the QUIC listener handed to an http3.Server so we can
+// tell whether a drain still has work to do. It costs one atomic increment per
+// accepted connection, on a path that has just finished a QUIC handshake.
+type countingListener struct {
+	*quic.EarlyListener
+
+	accepted atomic.Int64
+	open     atomic.Int64
+}
+
+func (l *countingListener) Accept(ctx context.Context) (*quic.Conn, error) {
+	conn, err := l.EarlyListener.Accept(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	l.accepted.Add(1)
+	l.open.Add(1)
+	go func() {
+		<-conn.Context().Done()
+		l.open.Add(-1)
+	}()
+
+	return conn, nil
+}
+
+// idle reports that no accepted connection is still open, and therefore that no
+// request handler can still be running on one.
+func (l *countingListener) idle() bool {
+	return l.open.Load() <= 0
+}
+
+func (l *countingListener) describe() string {
+	if l == nil {
+		return "no listener"
+	}
+	return fmt.Sprintf("%d accepted, %d still open", l.accepted.Load(), l.open.Load())
+}
+
+// drainQUIC gracefully shuts down an HTTP/3 server, stopping the wait as soon
+// as its listener has no open connections left rather than trusting quic-go's
+// own idea of when the drain is complete.
+//
+// Cancelling the drain early is not a shortcut past in-flight work: quic-go
+// responds to the cancellation by closing the server, which is the same
+// teardown it would perform on its own, and we only do it once the listener
+// says there is nothing left to close. A drain that misses its deadline with
+// connections still open is still reported as the failure it is.
+//
+// It takes the server's Shutdown as a function rather than the server itself so
+// the policy can be exercised against a drain that stalls on demand, which a
+// real QUIC stack only does by losing a race.
+func drainQUIC(ctx context.Context, shutdown func(context.Context) error, ln *countingListener) error {
+	if ln == nil {
+		return shutdown(ctx)
+	}
+
+	drainCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// The poll checks before it waits, so a listener that is already idle on
+	// entry cancels drainCtx before shutdown is even called. That is the
+	// intended path and not a degenerate one: quic-go still cancels its grace
+	// context and closes its listeners before it looks at the context, so the
+	// teardown happens in full and only the waiting is skipped.
+	go func() {
+		ticker := time.NewTicker(drainPollInterval)
+		defer ticker.Stop()
+		for {
+			if ln.idle() {
+				cancel()
+				return
+			}
+			select {
+			case <-drainCtx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
+	err := shutdown(drainCtx)
+	if ln.idle() && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		// Every connection is closed, so the drain finished even though
+		// quic-go could not observe it. Reporting the cutoff here would be
+		// reporting a failure that did not happen. Only a context-shaped error
+		// is absorbed: a drain that failed for its own reasons still says so.
+		return nil
+	}
+	return err
+}
+
+// drainStackPackages are the packages a stalled HTTP/3 drain lives in. A
+// goroutine touching none of them is almost never the reason a handler has not
+// returned, and printing every one of them would bury the few that matter.
+var drainStackPackages = []string{
+	"github.com/quic-go/",
+	"miren.dev/runtime/pkg/rpc",
+}
+
+// drainStacks renders the goroutines worth reading when a graceful shutdown
+// misses its deadline with connections still open: those running in the RPC and
+// QUIC stacks, plus any the runtime has annotated with how long it has been
+// parked, since a goroutine blocked for minutes is interesting wherever it
+// lives. Everything else is counted rather than printed, so this stays a
+// readable log line on a busy process instead of a wall of text.
+//
+// Nothing here runs on a healthy shutdown, which is what makes it affordable to
+// keep: the one moment it costs anything is the moment its absence would leave
+// an operator with an unattributable timeout and no way back to the cause.
+func drainStacks() string {
+	buf := make([]byte, 64<<10)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) || len(buf) >= 4<<20 {
+			buf = buf[:n]
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+
+	var kept []string
+	var elided int
+	for g := range strings.SplitSeq(string(buf), "\n\n") {
+		g = strings.TrimSpace(g)
+		if g == "" {
+			continue
+		}
+		if keepGoroutine(g) {
+			kept = append(kept, g)
+			continue
+		}
+		elided++
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d goroutines shown, %d elided\n\n", len(kept), elided)
+	b.WriteString(strings.Join(kept, "\n\n"))
+	return b.String()
+}
+
+func keepGoroutine(stack string) bool {
+	header, _, _ := strings.Cut(stack, "\n")
+	// The runtime annotates a goroutine parked long enough as
+	// "goroutine 12 [select, 10 minutes]:". Anything it thinks is worth timing
+	// is worth reading during a shutdown that will not finish. It only annotates
+	// waits over a minute, so on a drain with a short deadline this clause
+	// matches nothing and the package list below does all the work; it earns its
+	// place on the long production drains, which are the ones nobody can rerun.
+	if strings.Contains(header, " minutes]:") {
+		return true
+	}
+	for _, pkg := range drainStackPackages {
+		if strings.Contains(stack, pkg) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/rpc/drain_test.go
+++ b/pkg/rpc/drain_test.go
@@ -1,0 +1,178 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingShutdown stands in for quic-go's graceful shutdown after it has lost
+// the connCount race: it will wait forever unless its context ends.
+func blockingShutdown(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestDrainQUICStopsOnceListenerIsIdle(t *testing.T) {
+	ln := &countingListener{}
+	ln.open.Store(1)
+
+	// The last connection closes shortly after the drain begins, which is the
+	// transition quic-go can miss.
+	go func() {
+		time.Sleep(2 * drainPollInterval)
+		ln.open.Store(0)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := drainQUIC(ctx, blockingShutdown, ln)
+	took := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("drain of an idle listener returned %v", err)
+	}
+	if took > time.Second {
+		t.Fatalf("drain waited %s after the listener went idle", took)
+	}
+	if ctx.Err() != nil {
+		t.Fatal("drain consumed the caller's deadline instead of finishing early")
+	}
+}
+
+func TestDrainQUICReportsStallWhileConnectionsRemain(t *testing.T) {
+	ln := &countingListener{}
+	ln.open.Store(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := drainQUIC(ctx, blockingShutdown, ln)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("a drain that stalled with a connection open returned %v, want DeadlineExceeded", err)
+	}
+}
+
+func TestDrainQUICPassesThroughAnOrdinaryDrain(t *testing.T) {
+	ln := &countingListener{}
+	want := errors.New("listener exploded")
+
+	err := drainQUIC(context.Background(), func(context.Context) error { return want }, ln)
+	if !errors.Is(err, want) {
+		t.Fatalf("drain returned %v, want the underlying error", err)
+	}
+}
+
+func TestKeepGoroutineSelectsTheRelevantStacks(t *testing.T) {
+	cases := []struct {
+		name  string
+		stack string
+		keep  bool
+	}{
+		{
+			name:  "quic-go frame",
+			stack: "goroutine 12 [select]:\ngithub.com/quic-go/quic-go.(*Transport).listen(...)",
+			keep:  true,
+		},
+		{
+			name:  "rpc frame",
+			stack: "goroutine 13 [chan receive]:\nmiren.dev/runtime/pkg/rpc.(*State).Shutdown(...)",
+			keep:  true,
+		},
+		{
+			name:  "parked long enough for the runtime to time it",
+			stack: "goroutine 14 [select, 10 minutes]:\nsomewhere/else.Loop(...)",
+			keep:  true,
+		},
+		{
+			name:  "unrelated and not parked",
+			stack: "goroutine 15 [chan receive]:\nsomewhere/else.Loop(...)",
+			keep:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := keepGoroutine(tc.stack); got != tc.keep {
+				t.Fatalf("keepGoroutine = %v, want %v", got, tc.keep)
+			}
+		})
+	}
+}
+
+func TestDrainStacksReportsWhatItElided(t *testing.T) {
+	out := drainStacks()
+	if !strings.Contains(out, "elided") {
+		t.Fatalf("dump does not account for elided goroutines: %q", out)
+	}
+	// The calling goroutine is itself in pkg/rpc, so it must survive the filter.
+	if !strings.Contains(out, "miren.dev/runtime/pkg/rpc.drainStacks") {
+		t.Fatal("dump filtered out its own caller")
+	}
+}
+
+func TestCountingListenerDescribesItsOwnConnections(t *testing.T) {
+	// A stalled drain reports the census of the surface that stalled. Reporting
+	// another listener's numbers would be worse than reporting none, since the
+	// census is the only evidence available at that moment.
+	primary := &countingListener{}
+	primary.accepted.Store(19)
+	primary.open.Store(0)
+
+	local := &countingListener{}
+	local.accepted.Store(2)
+	local.open.Store(1)
+
+	if got, want := primary.describe(), "19 accepted, 0 still open"; got != want {
+		t.Fatalf("primary census = %q, want %q", got, want)
+	}
+	if got, want := local.describe(), "2 accepted, 1 still open"; got != want {
+		t.Fatalf("local census = %q, want %q", got, want)
+	}
+	if primary.idle() == local.idle() {
+		t.Fatal("an idle listener and a busy one report the same idleness")
+	}
+	if got, want := (*countingListener)(nil).describe(), "no listener"; got != want {
+		t.Fatalf("nil census = %q, want %q", got, want)
+	}
+}
+
+// reportStalledDrainSpy is the part of State.Shutdown's error handling under
+// test: which drain failures are allowed to spend the one-shot goroutine dump.
+type reportStalledDrainSpy struct {
+	once  sync.Once
+	dumps int
+}
+
+func (r *reportStalledDrainSpy) report(err error) {
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		return
+	}
+	r.once.Do(func() { r.dumps++ })
+}
+
+func TestOnlyATimedOutDrainSpendsTheStackDump(t *testing.T) {
+	// A REST or WebSocket surface failing fast must not consume the dump that a
+	// genuinely stalled HTTP/3 drain will need later in the same shutdown.
+	var r reportStalledDrainSpy
+
+	r.report(errors.New("rest listener already closed"))
+	if r.dumps != 0 {
+		t.Fatalf("an ordinary drain failure spent the dump (%d)", r.dumps)
+	}
+
+	r.report(context.DeadlineExceeded)
+	if r.dumps != 1 {
+		t.Fatalf("a stalled drain did not produce a dump (%d)", r.dumps)
+	}
+
+	r.report(context.DeadlineExceeded)
+	if r.dumps != 1 {
+		t.Fatalf("a second stall dumped again (%d)", r.dumps)
+	}
+}

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -126,9 +126,9 @@ type State struct {
 	server    *Server
 	hs        *http3.Server
 	ws        *webtransport.Server
-	li        *quic.EarlyListener
+	li        *countingListener
 	localHS   *http3.Server
-	localLI   *quic.EarlyListener
+	localLI   *countingListener
 	localLn   net.Listener
 	localPath string
 
@@ -152,6 +152,11 @@ type State struct {
 	// HTTP/3 Shutdown after the ordered boot stop has already drained it.
 	explicitStop     chan struct{}
 	explicitStopOnce sync.Once
+
+	// stalledDrainOnce keeps the four drains below, which run concurrently and
+	// share one deadline, from each dumping the same goroutines when they all
+	// time out together.
+	stalledDrainOnce sync.Once
 
 	// A State is both an RPC server and the owner of clients dialed through its
 	// shared QUIC transport. Those clients can call back into the same State.
@@ -646,7 +651,7 @@ func (s *State) setupServer(so *stateOptions) error {
 		return err
 	}
 
-	s.li = ec
+	s.li = &countingListener{EarlyListener: ec}
 	s.server.state = s
 	s.server.restEnabled = so.restBindAddr != ""
 
@@ -745,30 +750,46 @@ func (s *State) Shutdown(ctx context.Context) error {
 		mu   sync.Mutex
 		wg   sync.WaitGroup
 	)
-	shutdown := func(name string, fn func(context.Context) error) {
+	// ln is the listener behind this surface, or nil for one that does not have
+	// a QUIC listener of its own. It has to be the surface's own listener: a
+	// stalled local drain reported against the primary listener's census would
+	// print the wrong numbers, and print them at the one moment they are the
+	// only evidence anyone has.
+	shutdown := func(name string, ln *countingListener, fn func(context.Context) error) {
 		if fn == nil {
 			return
 		}
 		wg.Go(func() {
-			if err := fn(ctx); err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Errorf("shutting down %s: %w", name, err))
-				mu.Unlock()
+			err := fn(ctx)
+			if err == nil {
+				return
 			}
+			// Reaching here means the drain missed its deadline with work
+			// genuinely outstanding, so say what was still connected.
+			conns := s.reportStalledDrain(name, ln, err)
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("shutting down %s: %w (%s)", name, err, conns))
+			mu.Unlock()
 		})
 	}
 
+	// Both HTTP/3 surfaces drain against their own listener census rather than
+	// quic-go's internal count. See drainQUIC.
 	if s.hs != nil {
-		shutdown("HTTP/3", s.hs.Shutdown)
+		shutdown("HTTP/3", s.li, func(ctx context.Context) error {
+			return drainQUIC(ctx, s.hs.Shutdown, s.li)
+		})
 	}
 	if s.localHS != nil {
-		shutdown("local HTTP/3", s.localHS.Shutdown)
+		shutdown("local HTTP/3", s.localLI, func(ctx context.Context) error {
+			return drainQUIC(ctx, s.localHS.Shutdown, s.localLI)
+		})
 	}
 	if s.httpSrv != nil {
-		shutdown("WebSocket", s.httpSrv.Shutdown)
+		shutdown("WebSocket", nil, s.httpSrv.Shutdown)
 	}
 	if s.restSrv != nil {
-		shutdown("REST", s.restSrv.Shutdown)
+		shutdown("REST", nil, s.restSrv.Shutdown)
 	}
 	if s.msgLn != nil {
 		_ = s.msgLn.Close()
@@ -873,6 +894,39 @@ func (s *State) closeOutboundConnections() {
 	for _, conn := range conns {
 		_ = conn.CloseWithError(0, "state shutting down")
 	}
+}
+
+// reportStalledDrain records a graceful shutdown that missed its deadline and
+// returns the in-flight request census for the caller to fold into its error.
+//
+// A daemon that cannot drain is the system failing at something it owns, so
+// this logs at Error. It fires at most once per State, only on a drain that has
+// already failed, which is what makes carrying the goroutine dump permanently
+// affordable: the expensive part never runs on a healthy shutdown.
+func (s *State) reportStalledDrain(name string, ln *countingListener, err error) string {
+	conns := ln.describe()
+
+	// Only a drain that ran out of time is a stall. A surface that failed for
+	// its own reasons, fast, is a different event, and letting it spend the
+	// one-shot dump would leave a genuine stall later in the same shutdown with
+	// no census and no stacks: precisely the surface that needed them.
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		s.log.Error("graceful shutdown failed",
+			"surface", name,
+			"error", err,
+			"connections", conns)
+		return conns
+	}
+
+	s.stalledDrainOnce.Do(func() {
+		s.log.Error("graceful shutdown did not finish before its deadline",
+			"surface", name,
+			"error", err,
+			"connections", conns,
+			"stacks", drainStacks())
+	})
+
+	return conns
 }
 
 func (s *State) disableContextShutdown() {

--- a/pkg/rpc/state_local.go
+++ b/pkg/rpc/state_local.go
@@ -151,9 +151,12 @@ func (s *State) startLocalListener(ctx context.Context, addr string) error {
 		Logger:  subS.log.With("module", "http3-local"),
 	}
 
+	cl := &countingListener{EarlyListener: ec}
+
 	subS.hs = serv
+	subS.li = cl
 	s.localHS = serv
-	s.localLI = ec
+	s.localLI = cl
 	s.localPath = addr
 
 	go func() {
@@ -165,7 +168,7 @@ func (s *State) startLocalListener(ctx context.Context, addr string) error {
 	}()
 
 	s.log.Debug("starting local listener", "addr", addr)
-	go subS.hs.ServeListener(ec)
+	go subS.hs.ServeListener(cl)
 
 	return nil
 }


### PR DESCRIPTION
`TestControlPlaneParse` had been failing in CI every so often with `shutting down HTTP/3: context deadline exceeded`, and the issue said it never reproduced locally. It reproduces fine at `GOMAXPROCS=2`, about one run in five. A 24-core laptop just always wins a race that a loaded CI runner loses.

The blame was misplaced, though. When it fires, the coordinator being drained has no peers left at all: zero open connections, zero requests in flight, nothing handling a connection. quic-go's `http3.Server.Shutdown` decides it is finished from an internal connection count, and the channel it waits on is only closed if that count reaches zero *after* the grace context is cancelled. Lose that race and nobody closes it, so Shutdown sits for the full ten seconds and then reports a drain failure for a drain that had already finished. The guard responsible was added upstream to fix a double-close panic, so it is the other side of a deliberate trade, and it is still there on quic-go master. No version bump gets us out of this one.

So we stop taking quic-go's word for it. A wrapper around the QUIC listener tracks how many accepted connections are still open, which is the stronger signal: a request can only live on a connection, so an idle listener means there is genuinely nothing left to drain. The graceful wait ends once the listener goes idle. That is not a shortcut past in-flight work, since quic-go answers the cancellation by closing the server exactly as it would have anyway, and we only cancel once there is nothing left to close. Only a context-shaped error is absorbed, and only while idle, so a drain that stalls with peers still connected fails as loudly as it did before.

A stalled drain now also logs the connection census and a goroutine dump filtered to the RPC and QUIC stacks. None of it runs on a healthy shutdown, and its absence is most of why this took a while to pin down.

There is no existing upstream report for the underlying bug, so I will file one separately.

Closes MIR-1792

https://claude.ai/code/session_0165vZQb1iWS3mZfeiQvEwEn
