### PR TITLE
Pin the connect spread so apphealthsync tests stop rolling dice

### DIFF
--- a/pkg/apphealthsync/reporter.go
+++ b/pkg/apphealthsync/reporter.go
@@ -40,14 +40,20 @@ type samplingSession struct {
 }
 
 type Reporter struct {
-	log     *slog.Logger
-	source  Source
+	log    *slog.Logger
+	source Source
+
+	// spread defers the opening sample so a reconnecting fleet does not sample
+	// as one spike. Injectable because a randomly timed first sample makes
+	// every later assertion about sampling times a dice roll.
+	spread func(time.Duration) time.Duration
+
 	mu      sync.Mutex
 	session *samplingSession
 }
 
 func NewReporter(log *slog.Logger, source Source) *Reporter {
-	return &Reporter{log: log, source: source}
+	return &Reporter{log: log, source: source, spread: uplink.SpreadOnConnect}
 }
 
 func (r *Reporter) Register(_ context.Context, link Link) error {
@@ -106,7 +112,7 @@ func (r *Reporter) run(active *samplingSession, link Link, background time.Durat
 	ctx := active.ctx
 	r.log.Info("app health sampling started", "background_interval", background)
 	// Spread unsolicited connection samples; viewing a panel bypasses this wait.
-	next := time.Now().Add(uplink.SpreadOnConnect(time.Minute))
+	next := time.Now().Add(r.spread(time.Minute))
 	var last, until time.Time
 	derivationFailed := false
 	interval := background

--- a/pkg/apphealthsync/reporter_test.go
+++ b/pkg/apphealthsync/reporter_test.go
@@ -121,11 +121,26 @@ func (f *fakeSource) derivations() int {
 
 func (f *fakeLink) Handle(_ string, handler uplink.MessageHandler) { f.handler = handler }
 
+// testSpread pins the connect spread. The real one puts the opening sample at a
+// random point in the first minute, which makes every later assertion about
+// when a sample happened a dice roll: a draw above 59s lands that sample within
+// the reporter's own one-second floor, so a demand at t=60s is deferred rather
+// than answered. It stays non-zero because
+// TestDemandBypassesConnectSpreadAndReconnectDropsLease needs a real wait to
+// bypass, and uplink's own tests already cover the randomness.
+const testSpread = 30 * time.Second
+
+func newTestReporter(source Source) *Reporter {
+	reporter := NewReporter(slog.New(slog.DiscardHandler), source)
+	reporter.spread = func(time.Duration) time.Duration { return testSpread }
+	return reporter
+}
+
 func startSampler(t *testing.T) (*Reporter, *fakeSource, *fakeLink, context.CancelFunc) {
 	t.Helper()
 	source := &fakeSource{apps: []apphealth.State{{Name: "web", Health: apphealth.Crashed, InCooldown: true, CooldownSeconds: 0}}}
 	link := newFakeLink()
-	reporter := NewReporter(slog.New(slog.DiscardHandler), source)
+	reporter := newTestReporter(source)
 	require.NoError(t, reporter.Register(context.Background(), link))
 	ctx, cancel := context.WithCancel(context.Background())
 	link.sessions[0](ctx, uplink.Session{ID: "s1", Capabilities: []uplink.CapabilitySelection{{Name: uplink.CapabilityAppHealth, Version: Version1, Config: json.RawMessage(`{"background_seconds":300}`)}}})
@@ -209,7 +224,7 @@ func TestSamplesRecoverAfterReadAndSendFailures(t *testing.T) {
 func TestBatchesShareObservationTime(t *testing.T) {
 	source := &fakeSource{apps: make([]apphealth.State, 205)}
 	link := newFakeLink()
-	require.NoError(t, NewReporter(slog.New(slog.DiscardHandler), source).sample(context.Background(), link))
+	require.NoError(t, newTestReporter(source).sample(context.Background(), link))
 	batches := link.allBatches()
 	require.Len(t, batches, 3)
 	require.Len(t, batches[0].Apps, 100)
@@ -220,7 +235,7 @@ func TestBatchesShareObservationTime(t *testing.T) {
 func TestUnselectedCapabilityAndInvalidDemand(t *testing.T) {
 	source := &fakeSource{}
 	link := newFakeLink()
-	require.NoError(t, NewReporter(slog.New(slog.DiscardHandler), source).Register(context.Background(), link))
+	require.NoError(t, newTestReporter(source).Register(context.Background(), link))
 	require.Equal(t, uplink.CapabilityAppHealth, link.offers[0].Name)
 	link.sessions[0](context.Background(), uplink.Session{ID: "s1"})
 	require.Zero(t, source.derivations())
@@ -233,7 +248,7 @@ func TestDemandBypassesConnectSpreadAndReconnectDropsLease(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		source := &fakeSource{apps: []apphealth.State{{Name: "web", Health: apphealth.Healthy}}}
 		link := newFakeLink()
-		reporter := NewReporter(slog.New(slog.DiscardHandler), source)
+		reporter := newTestReporter(source)
 		require.NoError(t, reporter.Register(context.Background(), link))
 		ctx, cancel := context.WithCancel(context.Background())
 		session := uplink.Session{ID: "first", Capabilities: []uplink.CapabilitySelection{{Name: uplink.CapabilityAppHealth, Version: Version1}}}
@@ -257,7 +272,7 @@ func TestNegotiatedBackgroundCadence(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		source := &fakeSource{apps: []apphealth.State{{Name: "web"}}}
 		link := newFakeLink()
-		reporter := NewReporter(slog.New(slog.DiscardHandler), source)
+		reporter := newTestReporter(source)
 		require.NoError(t, reporter.Register(context.Background(), link))
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
`TestSamplingFollowsDemandAndExpires` has been flaking in CI, and the interesting part is that it runs under `synctest`, which is supposed to make that impossible. The bubble was doing its job. The reporter picks its opening sample time from `SpreadOnConnect(1m)`, a random draw, and the test sleeps exactly one minute before demanding a sample. When the draw lands in the last second of that window the opening sample is under a second old, so the reporter's deliberate one-second floor between samples defers the demanded one. Every goroutine is durably blocked, `synctest.Wait()` returns, and the count is one instead of two. That's a 1-in-60 shot, which matched the rate we were seeing.

So there's no product bug here: the reporter behaved as designed and the assertion sat on its boundary. The narrow fix is to sleep past the spread window, but the flake isn't really about that one line. Every synctest test in the package quietly assumes the draw came in under a minute, so the next one to reason about when the opening sample landed inherits the same latent flake. `Reporter` now takes an injectable spread func and the tests pin it.

Pinned to a fixed 30 seconds rather than zero, because `TestDemandBypassesConnectSpreadAndReconnectDropsLease` asserts that a viewer doesn't wait for the spread, and it needs a real wait to bypass or it proves nothing. `pkg/uplink` already covers the randomness itself. 3000 runs of the package, clean.

Closes MIR-1794

https://claude.ai/code/session_01YFZYxKfVELx2QVWTi6dqeT
