### PR TITLE
Count service traffic without a named counter

### DIFF
--- a/controllers/service/chain_body_test.go
+++ b/controllers/service/chain_body_test.go
@@ -16,21 +16,22 @@ import (
 	"miren.dev/runtime/pkg/testutils"
 )
 
-// TestChainBodyLandsWhenCounterUndeclared is the production failure against real
-// nftables. A chain body names a counter; nft answers ENOENT if that counter
-// does not exist and rolls the whole batch back, leaving the chain empty while
-// the verdict map still routes to it -- a service IP that is a black hole.
+// TestChainBodyDependsOnNoNamedObjects applies a chain body against real
+// nftables in a table where no named counter exists at all.
 //
-// Init declares the counters once at startup, so a body written against kernel
-// state where that never took effect hits exactly this. The body must therefore
-// carry its own declaration.
+// This is the production failure. The body used to open with
+// `counter name "services"`, the nftables objref expression, which needs
+// CONFIG_NFT_OBJREF. On a kernel built without it nft rejects that rule with
+// ENOENT pointing at the name -- indistinguishable from "the counter is
+// missing" -- and rolls back the whole batch, so the chain stayed empty while
+// the verdict map went on routing to it. Every service IP on such a host was a
+// black hole, permanently, because every reconcile failed identically.
 //
-// Uses a counter name that has never been declared rather than deleting the
-// real ones: the table is shared by every test in this package's iso
-// environment, and nft refuses to delete a named counter while any rule still
-// references it (EBUSY), so removing them is both hostile to neighbouring tests
-// and not reliably possible.
-func TestChainBodyLandsWhenCounterUndeclared(t *testing.T) {
+// This test cannot reproduce the missing kernel option, since the kernel under
+// iso has it. What it does pin is the property that makes the option
+// irrelevant: the body references no named object, so there is nothing for a
+// kernel to fail to look up.
+func TestChainBodyDependsOnNoNamedObjects(t *testing.T) {
 	r := require.New(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -42,33 +43,27 @@ func TestChainBodyLandsWhenCounterUndeclared(t *testing.T) {
 	r.NoError(err)
 	r.NoError(sc.Init(ctx))
 
-	chain := "service_probe_" + idgen.GenNS("c")
-	counter := "probe_" + idgen.GenNS("k")
-
 	counters, err := sc.nft.ListCounters(ctx)
 	r.NoError(err)
-	for _, c := range counters {
-		r.NotEqual(counter, c.Name, "the probe counter must not already exist")
-	}
+	r.Empty(counters, "Init must not create named counters; nothing may depend on objref")
 
+	chain := "service_probe_" + idgen.GenNS("c")
 	t.Cleanup(func() {
-		// Chain first: nft refuses to delete a counter a rule still
-		// references. Both leak into the package's shared table otherwise.
 		tx := sc.nft.NewTransaction()
 		tx.Add(&knftables.Table{})
 		tx.Delete(&knftables.Chain{Name: chain})
-		tx.Delete(&knftables.Counter{Name: counter})
 		_ = sc.nft.Run(context.Background(), tx)
 	})
 
 	tx := sc.nft.NewTransaction()
 	tx.Add(&knftables.Table{})
 	tx.Add(&knftables.Chain{Name: chain})
-	sc.writeChainBody(tx, chain, counter, nil)
+	sc.writeChainBody(tx, chain, nil)
 
-	r.NoError(sc.nft.Run(ctx, tx),
-		"a chain body naming an undeclared counter must still apply; nft rejects the whole batch otherwise")
+	r.NotContains(tx.String(), "counter name",
+		"a named-counter reference needs CONFIG_NFT_OBJREF, which some kernels lack")
 
+	r.NoError(sc.nft.Run(ctx, tx))
 	r.NotZero(nftRuleCount(t, ctx, sc, chain),
 		"the chain must have rules: an empty one is a black hole, since the verdict map routes to it regardless")
 }

--- a/controllers/service/chain_cache_test.go
+++ b/controllers/service/chain_cache_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/netip"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,23 +37,26 @@ func (r *rejectingNFT) Run(ctx context.Context, tx *knftables.Transaction) error
 	return r.Interface.Run(ctx, tx)
 }
 
-// TestChainBodyDeclaresItsCounter: nft rejects a rule naming a counter that does
-// not exist, and rolls the whole batch back. The chain body must therefore
-// declare the counter it references rather than assuming Init got there first.
-func TestChainBodyDeclaresItsCounter(t *testing.T) {
+// TestChainBodyUsesAnonymousCounter guards the fix for the production outage:
+// the body must count with a plain `counter`, never `counter name`. The latter
+// is the nftables objref expression and needs CONFIG_NFT_OBJREF, which the
+// affected host's kernel was built without -- so every batch containing it was
+// rejected and no service chain body ever installed.
+func TestChainBodyUsesAnonymousCounter(t *testing.T) {
 	s := newTestController(knftables.NewFake(knftables.InetFamily, tableName))
 	tx := s.nft.NewTransaction()
 	tx.Add(&knftables.Table{})
 
-	s.writeChainBody(tx, "service_test", "services", []string{"endpoint_a"})
+	s.writeChainBody(tx, "service_test", []string{"endpoint_a"})
 
 	body := tx.String()
 
-	declare := strings.Index(body, `add counter inet `+tableName+` services`)
-	reference := strings.Index(body, `counter name "services"`)
-
-	require.NotEqual(t, -1, declare, "the batch must declare the counter it names:\n%s", body)
-	require.Less(t, declare, reference, "the counter must be declared before it is referenced:\n%s", body)
+	require.NotContains(t, body, "counter name",
+		"referencing a named counter needs CONFIG_NFT_OBJREF:\n%s", body)
+	require.NotContains(t, body, "add counter",
+		"the body must not depend on a named object existing:\n%s", body)
+	require.Contains(t, body, "add rule inet "+tableName+" service_test counter\n",
+		"the body still has to count traffic, anonymously:\n%s", body)
 }
 
 // TestRejectedGCBatchLeavesCacheAlone is the reason an empty service chain used
@@ -125,12 +127,12 @@ func TestUnchangedEndpointsStillSkipRebuild(t *testing.T) {
 
 	pending := map[string][]string{}
 	tx1 := s.nft.NewTransaction()
-	s.setEndpoints(tx1, pending, chain, "services", []string{"endpoint_a"})
+	s.setEndpoints(tx1, pending, chain, []string{"endpoint_a"})
 	require.NotEmpty(t, tx1.String())
 	s.commitChainCache(pending)
 
 	tx2 := s.nft.NewTransaction()
-	s.setEndpoints(tx2, map[string][]string{}, chain, "services", []string{"endpoint_a"})
+	s.setEndpoints(tx2, map[string][]string{}, chain, []string{"endpoint_a"})
 	require.Equal(t, 0, tx2.NumOperations(), "an unchanged endpoint set must skip the rebuild")
 }
 

--- a/controllers/service/gc.go
+++ b/controllers/service/gc.go
@@ -357,7 +357,7 @@ func (s *ServiceController) reconcileLiveChains(tx *knftables.Transaction, targe
 	}
 	for _, sp := range target.serviceSpecs {
 		s.addServiceChain(tx, sp.ip, int(sp.port), sp.proto)
-		s.writeChainBody(tx, s.serviceChain(sp.ip, sp.port, sp.proto), "services", sp.endpoints)
+		s.writeChainBody(tx, s.serviceChain(sp.ip, sp.port, sp.proto), sp.endpoints)
 	}
 	for _, sp := range target.nodePortSpecs {
 		chain := s.nodeportChain(sp.nport, sp.proto)
@@ -367,7 +367,7 @@ func (s *ServiceController) reconcileLiveChains(tx *knftables.Transaction, targe
 			Key:   []string{sp.proto, strconv.Itoa(sp.nport)},
 			Value: []string{"goto " + chain},
 		})
-		s.writeChainBody(tx, chain, "nodeports", sp.endpoints)
+		s.writeChainBody(tx, chain, sp.endpoints)
 	}
 }
 

--- a/controllers/service/gc_test.go
+++ b/controllers/service/gc_test.go
@@ -394,7 +394,7 @@ func TestServicePeriodic(t *testing.T) {
 		// Inject the kind of stacked-duplicate state that the pre-#795
 		// append-without-flush code would leave behind across redeploys.
 		injectTx := sc.nft.NewTransaction()
-		injectTx.Add(&knftables.Rule{Chain: parentChain, Rule: `counter name "services"`})
+		injectTx.Add(&knftables.Rule{Chain: parentChain, Rule: "counter"})
 		injectTx.Add(&knftables.Rule{Chain: parentChain, Rule: "ip saddr 10.123.0.0/16 jump mark-for-masq"})
 		injectTx.Add(&knftables.Rule{Chain: parentChain, Rule: "ip saddr 10.124.0.0/16 jump mark-for-masq"})
 		r.NoError(sc.nft.Run(ctx, injectTx))

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -293,9 +293,9 @@ func (s *ServiceController) addServiceChain(tx *knftables.Transaction, ip netip.
 }
 
 // setEndpoints fills in the body of a service-IP or nodeport chain. Skips the
-// flush+rebuild when the endpoint set hasn't changed from the cache to avoid
-// resetting the named counter on each event-driven reconcile. For the
-// unconditional-rebuild path used by Periodic, see writeChainBody.
+// flush+rebuild when the endpoint set hasn't changed from the cache, which also
+// spares the chain's counter from being zeroed on each event-driven reconcile.
+// For the unconditional-rebuild path used by Periodic, see writeChainBody.
 //
 // Anything it writes is recorded in pending rather than in the cache. A cache
 // entry has to mean "nft accepted this body", so the caller commits pending
@@ -345,7 +345,9 @@ func (s *ServiceController) writeChainBody(tx *knftables.Transaction, chain stri
 	// cannot look one up". That rejection rolled back the whole batch, so on
 	// such a kernel no service chain body ever installed and every service IP
 	// was a black hole. A per-chain counter needs no kernel option beyond the
-	// nf_tables core and reports per service rather than one global total.
+	// nf_tables core and reports per service rather than one global total. That
+	// is a rolling window, not a running total -- Periodic rebuilds every body
+	// on its five minute tick, and an anonymous counter goes away with its rule.
 	tx.Add(&knftables.Rule{Chain: chain, Rule: "counter"})
 
 	if len(endpoints) == 0 {

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -204,12 +204,6 @@ func (s *ServiceController) Init(ctx context.Context) error {
 		Type: "inet_proto . inet_service : verdict",
 	})
 
-	// Named counters that the per-service and per-nodeport chains reference
-	// for traffic visibility. Created here so chain bodies can `counter name`
-	// them without races.
-	tx.Add(&knftables.Counter{Name: "services"})
-	tx.Add(&knftables.Counter{Name: "nodeports"})
-
 	// Static chains. We Add to ensure existence and Flush to wipe stale rules
 	// from prior controller versions, then re-add the canonical rule set.
 	// The duplicate `jump services` rules the bug report flagged came from old
@@ -306,7 +300,7 @@ func (s *ServiceController) addServiceChain(tx *knftables.Transaction, ip netip.
 // Anything it writes is recorded in pending rather than in the cache. A cache
 // entry has to mean "nft accepted this body", so the caller commits pending
 // with commitChainCache once the batch applies -- see Create.
-func (s *ServiceController) setEndpoints(tx *knftables.Transaction, pending map[string][]string, chain, counterName string, endpoints []string) {
+func (s *ServiceController) setEndpoints(tx *knftables.Transaction, pending map[string][]string, chain string, endpoints []string) {
 	sorted := append([]string(nil), endpoints...)
 	slices.Sort(sorted)
 
@@ -318,7 +312,7 @@ func (s *ServiceController) setEndpoints(tx *knftables.Transaction, pending map[
 	}
 
 	pending[chain] = sorted
-	s.writeChainBody(tx, chain, counterName, sorted)
+	s.writeChainBody(tx, chain, sorted)
 }
 
 // commitChainCache records chain bodies that nft has accepted. Until this
@@ -341,18 +335,18 @@ func (s *ServiceController) commitChainCache(pending map[string][]string) {
 // just `counter + drop` so traffic to a service with no backends is dropped
 // rather than DNAT'd to a stale address. Bypasses the chainEndpoints cache;
 // callers that want the cached fast path should go through setEndpoints.
-func (s *ServiceController) writeChainBody(tx *knftables.Transaction, chain, counterName string, endpoints []string) {
-	// Declare the counter in the same transaction that references it. Init
-	// declares it too, but nft answers a rule naming an absent counter with
-	// ENOENT and rolls the whole batch back, so a body that assumes Init got
-	// there first leaves the chain empty behind a live verdict map. How the
-	// counter went missing in the field was never established; declaring it
-	// here means the body depends on no prior state at all. `add` is idempotent
-	// and does not reset an existing counter's totals, so it costs nothing.
-	tx.Add(&knftables.Counter{Name: counterName})
-
+func (s *ServiceController) writeChainBody(tx *knftables.Transaction, chain string, endpoints []string) {
 	tx.Flush(&knftables.Chain{Name: chain})
-	tx.Add(&knftables.Rule{Chain: chain, Rule: knftables.Concat("counter name", `"`+counterName+`"`)})
+
+	// An anonymous counter, not `counter name "services"`. Referencing a named
+	// counter is the nftables objref expression, which needs CONFIG_NFT_OBJREF;
+	// kernels built without it reject the rule with ENOENT pointing at the
+	// name, which reads as "the counter is missing" but means "this kernel
+	// cannot look one up". That rejection rolled back the whole batch, so on
+	// such a kernel no service chain body ever installed and every service IP
+	// was a black hole. A per-chain counter needs no kernel option beyond the
+	// nf_tables core and reports per service rather than one global total.
+	tx.Add(&knftables.Rule{Chain: chain, Rule: "counter"})
 
 	if len(endpoints) == 0 {
 		// `drop` rather than `reject` because the calling path includes
@@ -395,7 +389,7 @@ func (s *ServiceController) addNodePort(tx *knftables.Transaction, pending map[s
 		Key:   []string{proto, strconv.Itoa(nport)},
 		Value: []string{"goto " + chain},
 	})
-	s.setEndpoints(tx, pending, chain, "nodeports", endpoints)
+	s.setEndpoints(tx, pending, chain, endpoints)
 }
 
 func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Service, meta *entity.Meta) error {
@@ -462,7 +456,7 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 			key := portKey{Port: tp.Port, Proto: proto}
 
 			s.addServiceChain(tx, ip, int(tp.Port), proto)
-			s.setEndpoints(tx, pending, s.serviceChain(ip, uint16(tp.Port), proto), "services", epChainsByPort[key])
+			s.setEndpoints(tx, pending, s.serviceChain(ip, uint16(tp.Port), proto), epChainsByPort[key])
 		}
 	}
 


### PR DESCRIPTION
Fixes MIR-1795.

Every service and nodeport chain body opened with `counter name "services"`. That is the nftables objref expression, and it needs `CONFIG_NFT_OBJREF`. The affected host runs 6.1.158+ built without it, so nft rejected that rule and rolled back the batch carrying it.

## What this broke

`Init` references no counters, so it succeeded: the table, the three verdict maps and the static chains all installed. Every batch after that carries a chain body, so every batch was rejected in full — no endpoint chains, no service chain bodies, no DNAT.

The result is a service IP that resolves to nothing. `addServiceChain` and its verdict-map element are in the same rejected batch, so on a host in this state the chain may not exist at all; where an earlier build had already created it, the map routed traffic into an empty chain. Either way the connection hangs rather than being refused. Nothing ever repaired it, because every reconcile and every GC pass failed identically.

## Why it was misread as a missing counter

nft reports the failure like this:

```
Error: Could not process rule: No such file or directory
add rule inet miren service_9yATg4... counter name "services"
                                                   ^^^^^^^^^^
```

ENOENT pointing at an object name reads as "that counter does not exist". It actually means "this kernel cannot look one up". The two are indistinguishable from the error text, and #1165 took the first reading — it declared the counter in the same transaction that referenced it, guarding an absence that was never real. On the affected host `nft list counters table inet miren` showed both counters present the whole time.

The distinction is directly visible there:

- `nft add counter inet ktest c1` succeeds. Named counters can be created.
- `nft add rule inet ktest ch1 counter name "c1"` returns ENOENT — against a counter that demonstrably exists.
- `zcat /proc/config.gz | grep NFT_OBJREF` gives `# CONFIG_NFT_OBJREF is not set`.

Everything else the controller depends on is present on that kernel: `NFT_NUMGEN`, `NFT_NAT`, `NFT_MASQ`, `NF_NAT`, `NF_TABLES_INET`. `OBJREF` is the only gap, and it is one rule.

## The fix

Use an anonymous `counter`. It needs nothing beyond the nf_tables core — there is no `CONFIG_NFT_COUNTER` to be missing, since the expression is built into nf_tables in 6.1 — and it counts per service chain instead of summing every service into one figure, which is more useful when the question is which service is taking traffic. Nothing in the tree read the aggregate.

Per service does not mean cumulative. `Periodic` flushes and rebuilds every chain body on its five minute tick, and an anonymous counter goes away with its rule, so what you read is a rolling window rather than a running total. The named counter lived in the table and survived those flushes. That trade seems right for what these counters are actually used for — during an incident the question is whether traffic is reaching this chain now, which a large cumulative number does not answer — but it is a real difference and worth stating rather than implying. Making the rebuild conditional would need something to diff a live body against, and knftables' `ListRules` exposes `Comment` and `Handle` but not `Rule`; that is follow-up work, not this PR.

`Init` stops creating the two named counters. Tables that already have them keep two inert objects; deleting them would fail on any table that doesn't have them.

Kernels that do have `OBJREF` are unaffected. An anonymous counter works everywhere the named one did.

This removes the counter-declaration half of #1165 and leaves its cache-ordering fix in place. That one stands on its own: a rejected batch should not leave the chain cache asserting rules the kernel never took, whatever the reason for the rejection.

## Verification

By hand on the affected host, in a scratch table mirroring the real chain shapes:

- the old body shape reproduces the production ENOENT and rolls back
- the new body shape applies, giving `counter`, the mark-for-masq jump and the numgen vmap
- a full datapath check — service IP, verdict map, `nat-output` hook, DNAT to a real listener — returns HTTP 200, with the anonymous counter incrementing

`controllers/service` under iso: 30 tests. `make lint`: clean.

The suite cannot reproduce the missing kernel option, because the kernel under iso has `OBJREF`. What it pins instead is the property that makes the option irrelevant. `TestChainBodyDependsOnNoNamedObjects` applies a body in a table where no named counter exists and asserts `Init` creates none; `TestChainBodyUsesAnonymousCounter` fails if `counter name` ever returns.

The two test files are renamed, because their old names described a cause that turned out not to exist.

## Follow-up

`Init` should refuse to start, loudly, when a required nftables expression is missing, rather than writing batches that can never apply. Every expression it emits is load-bearing, and any of them could be absent on the next unusual kernel. A missing kernel config line cost days of investigation purely because the failure was silent and looked like state corruption.

