### PR TITLE
Keep cloud-sync watch revision accurate after resnapshot

### DIFF
--- a/pkg/entitysync/diagnostics.go
+++ b/pkg/entitysync/diagnostics.go
@@ -214,6 +214,7 @@ func (d *Diagnostics) finishSnapshot(cursor int64) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.status.CloudCursor = cursor
+	d.status.NextWatchRevision = cursor + 1
 	d.status.Snapshot = nil
 }
 

--- a/pkg/entitysync/diagnostics_test.go
+++ b/pkg/entitysync/diagnostics_test.go
@@ -42,6 +42,16 @@ func TestDiagnosticsTracksNegotiatedSessionAndExporterProgress(t *testing.T) {
 	require.Nil(t, status.Snapshot)
 }
 
+func TestDiagnosticsFinishingQuietSnapshotAdvancesWatchRevision(t *testing.T) {
+	diagnostics := NewDiagnostics("schema")
+	diagnostics.setNextWatchRevision(1)
+	diagnostics.beginSnapshot("snapshot-1", 64, 65)
+
+	diagnostics.finishSnapshot(64)
+
+	require.Equal(t, int64(65), diagnostics.SnapshotStatus().NextWatchRevision)
+}
+
 func TestDiagnosticsSnapshotDoesNotAliasMutableState(t *testing.T) {
 	diagnostics := NewDiagnostics("schema")
 	diagnostics.beginSnapshot("snapshot-1", 10, 11)


### PR DESCRIPTION
The first live force-resnapshot smoke test showed `miren debug cloud-sync` retaining `next_watched_revision=1` after the snapshot committed. The watcher was already positioned at the snapshot cursor plus one, and its next advancing response would correct the display, but a quiet cluster could leave the diagnostic stale until then.

Publish the next watch revision alongside the committed cursor when a snapshot finishes, with a regression assertion for that handoff. Sync behavior is unchanged.

Related to MIR-1711