### PR TITLE
Fix the flaky deployment-cancellation saga test

### DIFF
--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -437,6 +437,13 @@ func (m *MockStore) WatchFromRevsCopy() []int64 {
 	return append([]int64(nil), m.WatchFromRevs...)
 }
 
+// WatchIndex registers a watcher and delivers changes from that moment on.
+//
+// Unlike EtcdStore, it records fromRev for assertions but does not replay from
+// it, so a write landing between a caller's List and its WatchIndex is lost
+// rather than resumed. Consumers built on indexwatch.Watcher rely on that
+// replay for gap-free delivery, so a test that writes right after starting a
+// watch must wait for the watch to register first — see WaitForIndexWatcher.
 func (m *MockStore) WatchIndex(ctx context.Context, attr Attr, fromRev int64) (clientv3.WatchChan, error) {
 	m.indexWatchersMu.Lock()
 	m.WatchFromRevs = append(m.WatchFromRevs, fromRev)

--- a/servers/build/build_saga_deploy_test.go
+++ b/servers/build/build_saga_deploy_test.go
@@ -16,6 +16,7 @@ import (
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/deploylifecycle"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/saga"
@@ -368,7 +369,19 @@ func TestBuildSaga_Tracked_RecordCancellationCompensates(t *testing.T) {
 	records, err := h.builder.deploy.Store().List(ctx, deploylifecycle.Query{AppName: "demo"})
 	require.NoError(t, err)
 	require.Len(t, records, 1)
-	require.NoError(t, h.builder.deploy.Cancel(ctx, string(records[0].Deployment.ID), "operator cancelled"))
+
+	deploymentID := string(records[0].Deployment.ID)
+
+	// The cancellation watch is established asynchronously, and MockStore's
+	// WatchIndex ignores the resume revision that makes indexwatch gap-free
+	// against etcd. Cancelling before the watch registers means the update is
+	// never delivered and the build hangs, so wait for the watcher first.
+	watchCtx, cancelWatchWait := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelWatchWait()
+	require.NoError(t, h.inmem.Store.WaitForIndexWatcher(
+		watchCtx, entity.Ref(entity.DBId, entity.Id(deploymentID))))
+
+	require.NoError(t, h.builder.deploy.Cancel(ctx, deploymentID, "operator cancelled"))
 
 	select {
 	case err := <-done:


### PR DESCRIPTION
`TestBuildSaga_Tracked_RecordCancellationCompensates` went red on main and it wasn't the PR that tripped it ([run](https://github.com/mirendev/runtime/actions/runs/34288179181)). The test cancels a deployment record and waits for the build to compensate, but the cancellation only reaches the build through an index watch that starts in the background, and the test never waited for that watch to come up.

Against etcd the gap doesn't matter, since indexwatch resumes from the snapshot revision and etcd replays whatever landed in between. MockStore takes the same `fromRev` argument and ignores it, so a cancel that lands in the window just disappears and the build sits until its timeout. Give it enough CPU contention and that happens.

So the fix is `WaitForIndexWatcher`, which is what the controller, activator, and entityserver tests already do about this. The broader repair is giving MockStore a global revision so the resume actually works, filed as MIR-1796, and in the meantime the limitation is written down on `WatchIndex` where someone will find it.

Related to MIR-1796
