### PR TITLE
Clear out saga executions that get stuck forever

### DIFF
--- a/components/coordinate/entity_maintenance.go
+++ b/components/coordinate/entity_maintenance.go
@@ -70,6 +70,14 @@ func (c *EntityMaintenance) Start(ctx context.Context) error {
 	sagaConfig := sagagcctrl.DefaultGCConfig()
 	if c.SagaRetentionPeriod >= 0 {
 		sagaConfig.Retention = c.SagaRetentionPeriod
+		// The stalled sweep has no knob of its own on purpose. The one reason
+		// an operator turns saga GC off is to freeze the store while they
+		// investigate, and a sweep that rewrites in-flight records is not
+		// frozen. So retention zero means all of saga GC is paused, not just
+		// the half that deletes.
+		if c.SagaRetentionPeriod == 0 {
+			sagaConfig.StaleAfter = 0
+		}
 	}
 	c.sagaGC = &sagagcctrl.GCController{
 		Log:     c.Log.With("module", "saga-gc"),

--- a/controllers/sagagc/gc.go
+++ b/controllers/sagagc/gc.go
@@ -8,6 +8,10 @@
 // reached roughly 4,900 in a month of gentle use, and a single app that fails to
 // bind its declared port retries on a loop and writes thousands a day (MIR-1519).
 //
+// The same tick also drives the stalled-saga sweep, which handles the executions
+// retention cannot: ones still in flight that nothing will ever resume, so
+// nothing will ever move them into a state retention collects (MIR-1788).
+//
 // The policy itself lives in pkg/saga, which owns how executions are stored.
 // This package is the schedule: when to sweep, how much to do at once, and what
 // to tell an operator afterwards.
@@ -45,17 +49,49 @@ type GCConfig struct {
 	// SweepTimeout bounds a single sweep. A truncated sweep is fine; the next
 	// one picks up where this left off, since the pass is idempotent.
 	SweepTimeout time.Duration
+
+	// StaleAfter is how long an in-flight execution may sit without changing
+	// state before it is declared stranded and forced to failed. Zero disables
+	// the stalled sweep, leaving in-flight executions untouched at any age.
+	//
+	// There is no server config field behind this. The one reason an operator
+	// pauses saga GC is to freeze the store while they investigate, and that
+	// intent is already spelled saga.retention_period = 0, which the
+	// coordinator passes through to both windows. A second knob would ask them
+	// to know what an in-flight saga is in order to answer a question they had
+	// already answered.
+	StaleAfter time.Duration
+
+	// MaxForcesPerSweep caps stalled transitions per sweep, on the same
+	// reasoning as MaxDeletesPerSweep. Zero means unbounded.
+	MaxForcesPerSweep int
 }
 
 // DefaultGCConfig returns the default configuration. The seven-day retention is
 // what RFD-35 committed to. The per-sweep cap and interval together drain about
 // 48,000 executions a day, comfortably ahead of the worst observed write rate.
+//
+// StaleAfter reuses the same seven days, which is enormously generous against
+// what it is actually measuring: an execution writes a timestamp on every
+// transition and every action completion, so the gap this has to clear is one
+// action, not one saga. A forced execution then waits out Retention before its
+// bytes go, so a stranded record takes about a fortnight to disappear entirely.
+// That is the right trade for a population that has already been sitting for
+// months: the slow path costs nothing, and it leaves a week in which an
+// operator can still see what got forced and why.
+//
+// Nothing here is tuned separately in practice. The coordinator sets both
+// windows from one config field, so these two numbers move together or not at
+// all; they are separate fields because the sweeps are separate policies, not
+// because an operator is expected to play them against each other.
 func DefaultGCConfig() GCConfig {
 	return GCConfig{
 		Retention:          7 * 24 * time.Hour,
 		CheckInterval:      30 * time.Minute,
 		MaxDeletesPerSweep: 1000,
 		SweepTimeout:       10 * time.Minute,
+		StaleAfter:         7 * 24 * time.Hour,
+		MaxForcesPerSweep:  1000,
 	}
 }
 
@@ -71,17 +107,26 @@ type GCController struct {
 }
 
 // Start begins the periodic sweep.
+//
+// Zeroing a window disables that sweep, and there is only a controller to run
+// at all if at least one of them is on. An operator reaches this through one
+// config field that zeroes both together; the gate reads them separately
+// because a caller that wires only one of them is still a caller worth serving,
+// and because reading Retention alone here would silently take the stalled
+// sweep down with it.
 func (c *GCController) Start(ctx context.Context) {
-	if c.Config.Retention <= 0 {
-		c.Log.Info("saga retention GC disabled, executions will accumulate",
-			"reason", "retention is zero")
+	if c.Config.Retention <= 0 && c.Config.StaleAfter <= 0 {
+		c.Log.Info("saga GC disabled, executions will accumulate",
+			"reason", "retention and stale window are both zero")
 		return
 	}
 
-	c.Log.Info("starting saga retention GC controller",
+	c.Log.Info("starting saga GC controller",
 		"retention", c.Config.Retention,
+		"stale_after", c.Config.StaleAfter,
 		"check_interval", c.Config.CheckInterval,
-		"max_deletes_per_sweep", c.Config.MaxDeletesPerSweep)
+		"max_deletes_per_sweep", c.Config.MaxDeletesPerSweep,
+		"max_forces_per_sweep", c.Config.MaxForcesPerSweep)
 
 	ctx, c.cancel = context.WithCancel(ctx)
 	go c.run(ctx)
@@ -101,7 +146,7 @@ func (c *GCController) run(ctx context.Context) {
 	case <-time.After(initialDelay):
 		c.sweep(ctx)
 	case <-ctx.Done():
-		c.Log.Info("saga retention GC controller stopped")
+		c.Log.Info("saga GC controller stopped")
 		return
 	}
 
@@ -113,14 +158,22 @@ func (c *GCController) run(ctx context.Context) {
 		case <-ticker.C:
 			c.sweep(ctx)
 		case <-ctx.Done():
-			c.Log.Info("saga retention GC controller stopped")
+			c.Log.Info("saga GC controller stopped")
 			return
 		}
 	}
 }
 
-// sweep runs one bounded pass. It is best-effort: errors are logged, never
-// propagated, and never block a foreground operation.
+// sweep runs one bounded pass of each policy under a single deadline. It is
+// best-effort: errors are logged, never propagated, and never block a
+// foreground operation.
+//
+// The two share one deadline, so a slow retention pass can leave the stalled
+// sweep no time and it says so at Warn rather than running past the bound. That
+// is the acceptable direction: both passes are idempotent and resume from where
+// they stopped, retention is capped at MaxDeletesPerSweep so it cannot run away
+// on a backlog, and a stranded execution that waits another half hour has
+// already waited months.
 func (c *GCController) sweep(ctx context.Context) {
 	sweepCtx := ctx
 	if c.Config.SweepTimeout > 0 {
@@ -129,23 +182,18 @@ func (c *GCController) sweep(ctx context.Context) {
 		defer cancel()
 	}
 
-	result, err := saga.RunRetention(sweepCtx, c.Storage, saga.RetentionConfig{
+	c.sweepRetention(sweepCtx)
+	c.sweepStalled(sweepCtx)
+}
+
+func (c *GCController) sweepRetention(ctx context.Context) {
+	result, err := saga.RunRetention(ctx, c.Storage, saga.RetentionConfig{
 		Retention:  c.Config.Retention,
 		MaxDeletes: c.Config.MaxDeletesPerSweep,
 	}, c.Log)
 	if err != nil {
-		// A truncated sweep is two different events wearing one error. Hitting
-		// our own deadline or shutting down is expected and resumes next tick.
-		// Anything else means the store would not answer, which is the platform
-		// failing at a job it owns, and retention silently stops converging
-		// until someone notices.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			c.Log.Warn("saga retention sweep ended early", "error", err,
-				"scanned", result.Scanned, "deleted", result.Deleted)
-		} else {
-			c.Log.Error("saga retention sweep failed", "error", err,
-				"scanned", result.Scanned, "deleted", result.Deleted)
-		}
+		c.logSweepError(err, "saga retention sweep",
+			"scanned", result.Scanned, "deleted", result.Deleted)
 		return
 	}
 
@@ -159,5 +207,53 @@ func (c *GCController) sweep(ctx context.Context) {
 	} else {
 		c.Log.Debug("saga retention sweep complete, nothing expired",
 			"scanned", result.Scanned)
+	}
+}
+
+// sweepStalled forces stranded in-flight executions to failed.
+//
+// A sweep that forces anything logs at Info rather than Debug, and says how
+// many. On a cluster running v0.14.0 or later the expected number is zero: the
+// generated-name addon retries that created these stopped happening when
+// convergent IDs shipped. So a line here is either the historical backlog
+// draining, which ends, or a saga getting stranded by something we have not
+// found yet, which does not. An operator cannot tell those apart without seeing
+// the count, and cannot see the count if it never gets logged.
+func (c *GCController) sweepStalled(ctx context.Context) {
+	result, err := saga.RunStalledSweep(ctx, c.Storage, saga.StalledConfig{
+		StaleAfter: c.Config.StaleAfter,
+		MaxForces:  c.Config.MaxForcesPerSweep,
+	}, c.Log)
+	if err != nil {
+		c.logSweepError(err, "saga stalled sweep",
+			"scanned", result.Scanned, "forced", result.Forced)
+		return
+	}
+
+	if result.Forced > 0 || result.Failed > 0 {
+		c.Log.Info("saga stalled sweep complete",
+			"forced", result.Forced,
+			"failed", result.Failed,
+			"skipped", result.Skipped,
+			"recovered", result.Recovered,
+			"scanned", result.Scanned,
+			"capped", result.Capped)
+	} else {
+		c.Log.Debug("saga stalled sweep complete, nothing stranded",
+			"scanned", result.Scanned)
+	}
+}
+
+// logSweepError separates the two different events a truncated sweep wears as
+// one error. Hitting our own deadline or shutting down is expected and resumes
+// next tick. Anything else means the store would not answer, which is the
+// platform failing at a job it owns, and GC silently stops converging until
+// someone notices.
+func (c *GCController) logSweepError(err error, what string, counts ...any) {
+	args := append([]any{"error", err}, counts...)
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		c.Log.Warn(what+" ended early", args...)
+	} else {
+		c.Log.Error(what+" failed", args...)
 	}
 }

--- a/controllers/sagagc/gc.go
+++ b/controllers/sagagc/gc.go
@@ -52,14 +52,8 @@ type GCConfig struct {
 
 	// StaleAfter is how long an in-flight execution may sit without changing
 	// state before it is declared stranded and forced to failed. Zero disables
-	// the stalled sweep, leaving in-flight executions untouched at any age.
-	//
-	// There is no server config field behind this. The one reason an operator
-	// pauses saga GC is to freeze the store while they investigate, and that
-	// intent is already spelled saga.retention_period = 0, which the
-	// coordinator passes through to both windows. A second knob would ask them
-	// to know what an in-flight saga is in order to answer a question they had
-	// already answered.
+	// the stalled sweep. No config field sets this directly; see
+	// EntityMaintenance for why saga.retention_period drives both windows.
 	StaleAfter time.Duration
 
 	// MaxForcesPerSweep caps stalled transitions per sweep, on the same
@@ -71,19 +65,10 @@ type GCConfig struct {
 // what RFD-35 committed to. The per-sweep cap and interval together drain about
 // 48,000 executions a day, comfortably ahead of the worst observed write rate.
 //
-// StaleAfter reuses the same seven days, which is enormously generous against
-// what it is actually measuring: an execution writes a timestamp on every
-// transition and every action completion, so the gap this has to clear is one
-// action, not one saga. A forced execution then waits out Retention before its
-// bytes go, so a stranded record takes about a fortnight to disappear entirely.
-// That is the right trade for a population that has already been sitting for
-// months: the slow path costs nothing, and it leaves a week in which an
-// operator can still see what got forced and why.
-//
-// Nothing here is tuned separately in practice. The coordinator sets both
-// windows from one config field, so these two numbers move together or not at
-// all; they are separate fields because the sweeps are separate policies, not
-// because an operator is expected to play them against each other.
+// StaleAfter reuses the same seven days, which is generous against what it
+// measures: the gap between two steps of a saga, not the life of one. A forced
+// execution then waits out Retention, so a stranded record takes about a
+// fortnight to go entirely, and an operator has a week to see what was forced.
 func DefaultGCConfig() GCConfig {
 	return GCConfig{
 		Retention:          7 * 24 * time.Hour,
@@ -95,12 +80,25 @@ func DefaultGCConfig() GCConfig {
 	}
 }
 
-// GCController periodically deletes expired saga executions. It runs on the
-// coordinator, so exactly one process is sweeping and it never contends with
-// runners writing saga state through the entity-access client.
+// Storage is what this controller needs to sweep: retention's view plus the
+// conditional transition the stalled sweep writes through.
+//
+// Only the direct entity-store backend satisfies both, which is the point. The
+// controller was always coordinator-only, stated in a comment; requiring the
+// narrower interface makes an entity-access-backed storage fail to compile here
+// rather than fail to be safe at runtime.
+type Storage interface {
+	saga.Storage
+	saga.StalledStorage
+}
+
+// GCController periodically deletes expired saga executions and forces stranded
+// ones. It runs on the coordinator, so exactly one process is sweeping and it
+// never contends with runners writing saga state through the entity-access
+// client.
 type GCController struct {
 	Log     *slog.Logger
-	Storage saga.Storage
+	Storage Storage
 	Config  GCConfig
 
 	cancel context.CancelFunc
@@ -169,10 +167,8 @@ func (c *GCController) run(ctx context.Context) {
 // foreground operation.
 //
 // The two share one deadline, so a slow retention pass can leave the stalled
-// sweep no time and it says so at Warn rather than running past the bound. That
-// is the acceptable direction: both passes are idempotent and resume from where
-// they stopped, retention is capped at MaxDeletesPerSweep so it cannot run away
-// on a backlog, and a stranded execution that waits another half hour has
+// sweep no time and it says so at Warn rather than overrunning. Both resume
+// where they stopped, and a stranded execution that waits another half hour has
 // already waited months.
 func (c *GCController) sweep(ctx context.Context) {
 	sweepCtx := ctx
@@ -212,13 +208,10 @@ func (c *GCController) sweepRetention(ctx context.Context) {
 
 // sweepStalled forces stranded in-flight executions to failed.
 //
-// A sweep that forces anything logs at Info rather than Debug, and says how
-// many. On a cluster running v0.14.0 or later the expected number is zero: the
-// generated-name addon retries that created these stopped happening when
-// convergent IDs shipped. So a line here is either the historical backlog
-// draining, which ends, or a saga getting stranded by something we have not
-// found yet, which does not. An operator cannot tell those apart without seeing
-// the count, and cannot see the count if it never gets logged.
+// It logs at Info whenever it forces anything, because on v0.14.0 and later the
+// expected count is zero: convergent IDs closed the source. A line here is
+// either the historical backlog draining, which ends, or something still
+// stranding sagas, which does not.
 func (c *GCController) sweepStalled(ctx context.Context) {
 	result, err := saga.RunStalledSweep(ctx, c.Storage, saga.StalledConfig{
 		StaleAfter: c.Config.StaleAfter,

--- a/controllers/sagagc/gc_test.go
+++ b/controllers/sagagc/gc_test.go
@@ -1,0 +1,144 @@
+package sagagc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/saga"
+)
+
+func newTestController(t *testing.T, cfg GCConfig) (*GCController, saga.Storage) {
+	t.Helper()
+
+	storage := saga.NewMemoryStorage()
+	return &GCController{
+		Log:     testutils.TestLogger(t),
+		Storage: storage,
+		Config:  cfg,
+	}, storage
+}
+
+// save persists an execution whose last state change was `age` ago.
+func save(t *testing.T, storage saga.Storage, id string, status saga.Status, age time.Duration) {
+	t.Helper()
+
+	changed := time.Now().Add(-age)
+	require.NoError(t, storage.Save(context.Background(), &saga.Execution{
+		ID:              id,
+		DefinitionName:  "create-sandbox",
+		Status:          status,
+		InitialInputs:   map[string]any{},
+		ExecutedActions: map[string]*saga.ActionResult{},
+		ExecutionOrder:  []string{},
+		CreatedAt:       changed,
+		UpdatedAt:       changed,
+	}))
+}
+
+func statusOf(t *testing.T, storage saga.Storage, id string) saga.Status {
+	t.Helper()
+
+	exec, err := storage.Get(context.Background(), id)
+	require.NoError(t, err)
+	return exec.Status
+}
+
+func exists(t *testing.T, storage saga.Storage, id string) bool {
+	t.Helper()
+
+	_, err := storage.Get(context.Background(), id)
+	return err == nil
+}
+
+// TestSweep_RunsBothPolicies pins that a tick drives both sweeps. They deal
+// with disjoint populations that neither can reach on its own: retention only
+// looks at finished executions, and the stalled sweep only at in-flight ones.
+// A tick that ran one of them would leave the other's backlog growing with
+// nothing to say so.
+func TestSweep_RunsBothPolicies(t *testing.T) {
+	c, storage := newTestController(t, DefaultGCConfig())
+
+	save(t, storage, "expired", saga.StatusCompleted, 30*24*time.Hour)
+	save(t, storage, "stranded", saga.StatusPending, 30*24*time.Hour)
+	save(t, storage, "working", saga.StatusRunning, time.Hour)
+
+	c.sweep(context.Background())
+
+	assert.False(t, exists(t, storage, "expired"), "retention must have collected the finished execution")
+	assert.Equal(t, saga.StatusFailed, statusOf(t, storage, "stranded"),
+		"the stalled sweep must have forced the stranded one")
+	assert.Equal(t, saga.StatusRunning, statusOf(t, storage, "working"),
+		"neither sweep touches an execution that is genuinely in progress")
+}
+
+// TestSweep_EachWindowDisablesOnlyItsOwnPolicy pins that the two windows are
+// actually separate switches. An operator reaches both through one config
+// field, so in production they go dark together, but the controller must not
+// have quietly coupled them: the coupling is a decision the coordinator makes
+// and can revisit, not something baked in here.
+func TestSweep_EachWindowDisablesOnlyItsOwnPolicy(t *testing.T) {
+	t.Run("retention off, stalled sweep on", func(t *testing.T) {
+		cfg := DefaultGCConfig()
+		cfg.Retention = 0
+		c, storage := newTestController(t, cfg)
+
+		save(t, storage, "expired", saga.StatusCompleted, 30*24*time.Hour)
+		save(t, storage, "stranded", saga.StatusPending, 30*24*time.Hour)
+
+		c.sweep(context.Background())
+
+		assert.True(t, exists(t, storage, "expired"), "frozen history must stay frozen")
+		assert.Equal(t, saga.StatusFailed, statusOf(t, storage, "stranded"))
+	})
+
+	t.Run("stalled sweep off, retention on", func(t *testing.T) {
+		cfg := DefaultGCConfig()
+		cfg.StaleAfter = 0
+		c, storage := newTestController(t, cfg)
+
+		save(t, storage, "expired", saga.StatusCompleted, 30*24*time.Hour)
+		save(t, storage, "stranded", saga.StatusPending, 30*24*time.Hour)
+
+		c.sweep(context.Background())
+
+		assert.False(t, exists(t, storage, "expired"))
+		assert.Equal(t, saga.StatusPending, statusOf(t, storage, "stranded"),
+			"in-flight executions must be left exactly as they are")
+	})
+}
+
+// TestStart_RunsWhileEitherPolicyIsOn is the regression for the gate. It used to
+// read the retention window alone, which was the whole configuration at the
+// time. Left that way, a caller that had only the stalled sweep turned on would
+// get no controller at all and never be told.
+func TestStart_RunsWhileEitherPolicyIsOn(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		retention  time.Duration
+		staleAfter time.Duration
+		wantRun    bool
+	}{
+		{"both on", 7 * 24 * time.Hour, 7 * 24 * time.Hour, true},
+		{"retention off", 0, 7 * 24 * time.Hour, true},
+		{"stalled sweep off", 7 * 24 * time.Hour, 0, true},
+		{"both off", 0, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultGCConfig()
+			cfg.Retention = tc.retention
+			cfg.StaleAfter = tc.staleAfter
+
+			c, _ := newTestController(t, cfg)
+			c.Start(context.Background())
+			t.Cleanup(c.Stop)
+
+			assert.Equal(t, tc.wantRun, c.cancel != nil,
+				"the controller runs while either policy has work to do")
+		})
+	}
+}

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -243,15 +243,17 @@ On a frequently-deployed cluster this window can pin more image data than the di
 
 Miren records a saga execution for multi-step operations like creating a sandbox or running a build, so that a server crash mid-operation can resume or roll back cleanly instead of leaving things half-done. Each record holds the outputs of every step it ran.
 
-Once an execution finishes, that record is only useful for looking back at what happened, so Miren deletes it after `retention_period`. Successes and failures are treated the same way. Executions still in progress are never deleted regardless of age, including ones stuck retrying a rollback, since those are exactly what the server needs to recover.
+Once an execution finishes, that record is only useful for looking back at what happened, so Miren deletes it after `retention_period`. Successes and failures are treated the same way. An execution that is still in progress is never deleted at any age, including one stuck retrying a rollback, since those are exactly what the server needs to recover.
+
+That leaves one gap, which Miren closes on its own. An execution can end up with nothing driving it and no way for anything to find it again, and because it never reaches a finished state, retention never considers it either. It would sit in the store forever, and every recovery pass would pay to read it. So an execution that has gone a week without changing state is marked failed, which is both the honest description of it and what lets the ordinary rules take over: whoever owns the operation can retry it, and retention collects the record a `retention_period` later. There's no separate setting for this — a week is far longer than the gap between two steps of a saga that's actually running, and anything the server is working on, or retrying on a loop, stays well clear of it.
 
 :::warning[Indefinite retention grows without bound]
-Setting `retention_period` to `0` keeps finished executions forever. That's useful while investigating an incident, but a cluster where one app repeatedly fails to start can write thousands of executions a day, so it's worth putting back afterward.
+Setting `retention_period` to `0` freezes saga records: nothing is deleted, and nothing in progress is marked failed either. That's useful while investigating an incident, but a cluster where one app repeatedly fails to start can write thousands of executions a day, so it's worth putting back afterward.
 :::
 
 | Field | Type | Default | Description | Env Var | CLI Flag |
 |-------|------|---------|-------------|---------|----------|
-| `retention_period` | string | `7d` | Delete finished saga executions older than this (e.g. `7d`, `24h`). `0` keeps them indefinitely | `MIREN_SAGA_RETENTION_PERIOD` | `--saga-retention-period` |
+| `retention_period` | string | `7d` | Delete finished saga executions older than this (e.g. `7d`, `24h`). `0` freezes saga records entirely | `MIREN_SAGA_RETENTION_PERIOD` | `--saga-retention-period` |
 
 ## Workload Identity Anchor {#workload-identity}
 

--- a/pkg/saga/eac_storage.go
+++ b/pkg/saga/eac_storage.go
@@ -106,7 +106,7 @@ func (s *EACStorage) ListTerminalPage(ctx context.Context, q TerminalQuery) (*Te
 		switch verdict {
 		case summaryOK:
 			result = append(result, summary)
-		case summaryNotTerminal:
+		case summaryWrongStatus:
 			staleNonTerminal++
 		case summaryNoTimestamp:
 			s.log.Warn("terminal saga has no usable timestamp, skipping", "id", v.Id())
@@ -187,4 +187,51 @@ func (s *EACStorage) ListIncompletePage(ctx context.Context, q IncompleteQuery) 
 	logStaleIncomplete(s.log, staleTerminal)
 
 	return &IncompletePage{Executions: executions, Cursor: next}, nil
+}
+
+// ListIncompleteSummaryPage summarizes one bounded page of in-flight executions
+// via EAC.
+func (s *EACStorage) ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	stage, inner, err := decodeStageCursor(q.Cursor, len(incompleteStatuses))
+	if err != nil {
+		return nil, err
+	}
+
+	status := incompleteStatuses[stage]
+
+	resp, err := s.eac.ListPage(ctx, entity.Ref(saga_v1alpha.SagaStatusId, status), inner, int64(clampLimit(q.Limit)))
+	if err != nil {
+		return nil, fmt.Errorf("listing sagas with status %s: %w", status, err)
+	}
+
+	next := nextStageCursor(stage, resp.Cursor(), len(incompleteStatuses))
+
+	// See ListTerminalPage: an empty page still carries a cursor, and dropping
+	// it here would skip the rest of this status index.
+	if len(resp.Values()) == 0 {
+		return &IncompleteSummaryPage{Cursor: next}, nil
+	}
+
+	var result []IncompleteSummary
+	var staleTerminal int
+
+	for _, v := range resp.Values() {
+		summary, verdict := incompleteSummary(v.Entity())
+		switch verdict {
+		case summaryOK:
+			result = append(result, summary)
+		case summaryWrongStatus:
+			staleTerminal++
+		case summaryNoTimestamp:
+			s.log.Warn("in-flight saga has no usable timestamp, skipping", "id", v.Id())
+		}
+	}
+
+	logStaleIncomplete(s.log, staleTerminal)
+
+	return &IncompleteSummaryPage{Executions: result, Cursor: next}, nil
 }

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -84,6 +84,22 @@ type Storage interface {
 	// with ErrCompacted partway through a large backlog.
 	ListIncompletePage(ctx context.Context, q IncompleteQuery) (*IncompletePage, error)
 
+	// ListIncompleteSummaryPage returns one bounded page of summaries of the
+	// same set ListIncompletePage covers.
+	//
+	// Separate from ListIncompletePage because the two callers want different
+	// things from the same walk. Recovery resumes what it reads and needs whole
+	// executions; the stalled sweep only asks how long each has sat untouched,
+	// and it asks about the entire in-flight set rather than the handful it
+	// owns. Answering that with full payloads would pay recovery's cost without
+	// recovering anything.
+	//
+	// A summary also carries a timestamp the execution alone cannot supply.
+	// Sagas written before v0.14.0 have no updated_at field at all, so their
+	// age has to come from the entity store's own metadata, which decoding to
+	// an Execution discards.
+	ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error)
+
 	// ListTerminalPage returns one bounded page of executions that have
 	// finished (Completed or Failed). It deliberately returns summaries rather
 	// than executions: retention only needs an ID and an age, and a backend

--- a/pkg/saga/memory_storage.go
+++ b/pkg/saga/memory_storage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"time"
 )
 
 // MemoryStorage is a simple in-memory storage implementation for testing and examples.
@@ -43,11 +44,10 @@ func (m *MemoryStorage) Get(ctx context.Context, id string) (*Execution, error) 
 
 // cloneExecution copies an execution on the way into and back out of the map.
 //
-// Both directions, because the durable backends serialize in both directions
-// and a caller cannot tell which backend it has. Handing back the stored
-// pointer let a caller change stored state by mutating a value it had only
-// read, so a write this backend rejected still took effect and a memory-backed
-// test would see a state the entity stores would never have reached.
+// Both directions, because the durable backends serialize both ways and a
+// caller cannot tell which backend it has. Handing back the stored pointer let
+// a caller change stored state by mutating a value it had only read, reaching a
+// state the entity stores never could.
 func cloneExecution(exec *Execution) *Execution {
 	copied := *exec
 
@@ -106,10 +106,8 @@ func (m *MemoryStorage) ListIncompletePage(ctx context.Context, q IncompleteQuer
 // ListIncompleteSummaryPage summarizes one bounded page of in-flight
 // executions.
 //
-// This backend has only the execution's own UpdatedAt to offer, with no store
-// timestamp behind it to fall back to. That is the honest answer for a map: a
-// test that saves an execution with no timestamp really has told this backend
-// nothing about when it happened, and the sweep skips what it cannot date.
+// A map has no system timestamp to fall back on, so an execution saved without
+// one really is undatable here and gets skipped rather than guessed at.
 func (m *MemoryStorage) ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -205,6 +203,35 @@ func pageSortedIDs(ids []string, cursor string, limit int) ([]string, string) {
 	}
 
 	return ids, ""
+}
+
+// ForceFailed transitions an in-flight execution to failed, and reports whether
+// it did.
+//
+// The mutex stands in for the durable backends' revision check: held across the
+// read and the write, so no Save can land between them.
+func (m *MemoryStorage) ForceFailed(ctx context.Context, id string, cutoff time.Time, reason string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	exec, ok := m.executions[id]
+	if !ok {
+		return false, nil
+	}
+	if isTerminal(exec.Status) {
+		return false, nil
+	}
+	if exec.UpdatedAt.IsZero() || exec.UpdatedAt.After(cutoff) {
+		return false, nil
+	}
+
+	forced := cloneExecution(exec)
+	forced.Status = StatusFailed
+	forced.Error = reason
+	forced.UpdatedAt = time.Now()
+
+	m.executions[id] = forced
+	return true, nil
 }
 
 // Delete removes an execution. Deleting a missing execution is a no-op.

--- a/pkg/saga/memory_storage.go
+++ b/pkg/saga/memory_storage.go
@@ -25,17 +25,7 @@ func (m *MemoryStorage) Save(ctx context.Context, exec *Execution) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Deep copy to simulate real storage behavior
-	copied := *exec
-	copied.ExecutedActions = make(map[string]*ActionResult)
-	for k, v := range exec.ExecutedActions {
-		copiedResult := *v
-		copied.ExecutedActions[k] = &copiedResult
-	}
-	copied.ExecutionOrder = make([]string, len(exec.ExecutionOrder))
-	copy(copied.ExecutionOrder, exec.ExecutionOrder)
-
-	m.executions[exec.ID] = &copied
+	m.executions[exec.ID] = cloneExecution(exec)
 	return nil
 }
 
@@ -48,7 +38,34 @@ func (m *MemoryStorage) Get(ctx context.Context, id string) (*Execution, error) 
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrExecutionNotFound, id)
 	}
-	return exec, nil
+	return cloneExecution(exec), nil
+}
+
+// cloneExecution copies an execution on the way into and back out of the map.
+//
+// Both directions, because the durable backends serialize in both directions
+// and a caller cannot tell which backend it has. Handing back the stored
+// pointer let a caller change stored state by mutating a value it had only
+// read, so a write this backend rejected still took effect and a memory-backed
+// test would see a state the entity stores would never have reached.
+func cloneExecution(exec *Execution) *Execution {
+	copied := *exec
+
+	copied.ExecutedActions = make(map[string]*ActionResult, len(exec.ExecutedActions))
+	for k, v := range exec.ExecutedActions {
+		copiedResult := *v
+		copied.ExecutedActions[k] = &copiedResult
+	}
+
+	copied.ExecutionOrder = make([]string, len(exec.ExecutionOrder))
+	copy(copied.ExecutionOrder, exec.ExecutionOrder)
+
+	copied.InitialInputs = make(map[string]any, len(exec.InitialInputs))
+	for k, v := range exec.InitialInputs {
+		copied.InitialInputs[k] = v
+	}
+
+	return &copied
 }
 
 // ListIncompletePage returns one bounded page of executions needing recovery:
@@ -84,6 +101,50 @@ func (m *MemoryStorage) ListIncompletePage(ctx context.Context, q IncompleteQuer
 	}
 
 	return &IncompletePage{Executions: executions, Cursor: next}, nil
+}
+
+// ListIncompleteSummaryPage summarizes one bounded page of in-flight
+// executions.
+//
+// This backend has only the execution's own UpdatedAt to offer, with no store
+// timestamp behind it to fall back to. That is the honest answer for a map: a
+// test that saves an execution with no timestamp really has told this backend
+// nothing about when it happened, and the sweep skips what it cannot date.
+func (m *MemoryStorage) ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var ids []string
+	for id, exec := range m.executions {
+		switch exec.Status {
+		case StatusPending, StatusRunning, StatusUndoing:
+			ids = append(ids, id)
+		case StatusCompleted, StatusFailed:
+			// Terminal states are finished; the stalled sweep does not apply.
+		}
+	}
+
+	ids, next := pageSortedIDs(ids, q.Cursor, clampLimit(q.Limit))
+
+	result := make([]IncompleteSummary, 0, len(ids))
+	for _, id := range ids {
+		exec := m.executions[id]
+		if exec.UpdatedAt.IsZero() {
+			continue
+		}
+		result = append(result, IncompleteSummary{
+			ID:          exec.ID,
+			Status:      exec.Status,
+			LastChanged: exec.UpdatedAt,
+			ParentID:    exec.ParentExecutionID,
+		})
+	}
+
+	return &IncompleteSummaryPage{Executions: result, Cursor: next}, nil
 }
 
 // ListTerminalPage summarizes one bounded page of finished executions.

--- a/pkg/saga/retention.go
+++ b/pkg/saga/retention.go
@@ -20,11 +20,18 @@ import (
 // Most clusters run no nested sagas at all, so most sweeps ask nothing; and
 // where they do, children of one parent share the answer.
 type parentLiveness struct {
-	storage Storage
+	storage executionGetter
 	live    map[string]bool
 }
 
-func newParentLiveness(storage Storage) *parentLiveness {
+// executionGetter is all this needs of a storage, and taking the smaller
+// interface is what lets both sweeps share it: retention holds a full Storage,
+// the stalled sweep holds one narrowed to what it is allowed to write through.
+type executionGetter interface {
+	Get(ctx context.Context, id string) (*Execution, error)
+}
+
+func newParentLiveness(storage executionGetter) *parentLiveness {
 	return &parentLiveness{storage: storage, live: map[string]bool{}}
 }
 

--- a/pkg/saga/retention_test.go
+++ b/pkg/saga/retention_test.go
@@ -12,8 +12,15 @@ import (
 	"miren.dev/runtime/pkg/entity/testutils"
 )
 
+// executionSaver is all the seeding helpers need. Taking it rather than Storage
+// lets the stalled sweep's tests, whose backends are narrower by construction,
+// share them.
+type executionSaver interface {
+	Save(ctx context.Context, exec *Execution) error
+}
+
 // saveAged persists an execution whose last state change was `age` ago.
-func saveAged(t *testing.T, storage Storage, id string, status Status, age time.Duration) {
+func saveAged(t *testing.T, storage executionSaver, id string, status Status, age time.Duration) {
 	t.Helper()
 
 	finished := time.Now().Add(-age)
@@ -32,7 +39,7 @@ func saveAged(t *testing.T, storage Storage, id string, status Status, age time.
 	require.NoError(t, err)
 }
 
-func executionExists(t *testing.T, storage Storage, id string) bool {
+func executionExists(t *testing.T, storage executionGetter, id string) bool {
 	t.Helper()
 
 	_, err := storage.Get(context.Background(), id)
@@ -166,7 +173,7 @@ func TestRunRetention_ExactlyMaxDeletesIsNotCapped(t *testing.T) {
 }
 
 // saveChild persists a terminal child execution belonging to parentID.
-func saveChild(t *testing.T, storage Storage, id, parentID string, age time.Duration) {
+func saveChild(t *testing.T, storage executionSaver, id, parentID string, age time.Duration) {
 	t.Helper()
 
 	finished := time.Now().Add(-age)

--- a/pkg/saga/stalled.go
+++ b/pkg/saga/stalled.go
@@ -131,8 +131,9 @@ func RunStalledSweep(ctx context.Context, storage StalledStorage, cfg StalledCon
 			// parent re-finds its children by ID rather than re-running them,
 			// so failing one under a live parent fails the parent for a reason
 			// that was never true. A stranded parent is non-terminal and so
-			// reads as live, which means a stranded tree converges one level
-			// per sweep rather than all at once.
+			// reads as live, which means a stranded tree converges at least one
+			// level per sweep. Often more: a parent forced earlier in the same
+			// walk is already terminal by the time its child is read.
 			if summary.ParentID != "" && parents.isLive(ctx, summary.ParentID, log) {
 				result.Skipped++
 				continue
@@ -151,7 +152,12 @@ func RunStalledSweep(ctx context.Context, storage StalledStorage, cfg StalledCon
 				continue
 			}
 
-			log.Info("forced stalled saga execution to failed",
+			// Debug rather than Info: draining a backlog puts a full sweep's
+			// budget of these into the tier an operator reads, every tick, for
+			// hours. Retention logs per record only when a delete fails, and
+			// the sweep's summary carries the count worth noticing. The id is
+			// one -v away.
+			log.Debug("forced stalled saga execution to failed",
 				"id", summary.ID, "status", summary.Status,
 				"last_changed", summary.LastChanged)
 			result.Forced++

--- a/pkg/saga/stalled.go
+++ b/pkg/saga/stalled.go
@@ -1,0 +1,253 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// StalledError is the error recorded on an execution the sweep forces to
+// failed. It is deliberately a sentence rather than a code: it is read by
+// whoever runs `m debug saga show` on a forced record, and "this saga was never
+// going to finish" is the thing they need to know.
+const StalledError = "forced to failed by the stalled-saga sweep: this execution " +
+	"had not changed state for longer than the stall window, so nothing was " +
+	"driving it and nothing would have collected it"
+
+// StalledConfig tunes a stalled-saga sweep.
+type StalledConfig struct {
+	// StaleAfter is how long an execution may sit without changing state before
+	// the sweep declares it stranded. Zero disables the sweep, which is the
+	// escape hatch if a cluster needs its in-flight sagas left exactly as they
+	// are for an investigation.
+	//
+	// This is a measurement, not a guess about provenance. Save writes a
+	// timestamp on every transition and every action completion, so a saga that
+	// is being driven, or that is retrying its undos on a loop, keeps a recent
+	// one no matter how old the run is. What sits untouched for days is what
+	// nothing is driving.
+	StaleAfter time.Duration
+
+	// MaxForces caps transitions in one sweep so a backlog drains over several
+	// passes rather than one thundering herd of writes. Zero means unbounded.
+	MaxForces int
+}
+
+// StalledResult reports what one sweep did.
+type StalledResult struct {
+	// Scanned is how many in-flight executions were considered.
+	Scanned int
+
+	// Forced is how many were past the stall window and transitioned to failed.
+	Forced int
+
+	// Failed is how many transitions errored. A sweep does not abort on one bad
+	// write; the next pass retries it.
+	Failed int
+
+	// Skipped is how many stalled executions were held back because they are
+	// children of a saga still in flight. They become forceable as soon as
+	// their parent stops being live.
+	Skipped int
+
+	// Recovered is how many candidates turned out, on the re-read, to have
+	// moved on under us: finished, resumed, or deleted between the page and the
+	// write. Not an error and not a problem, but worth counting, because a
+	// sweep reporting a lot of them is reading pages that are too old to act
+	// on.
+	Recovered int
+
+	// Capped reports that MaxForces stopped the sweep before it had inspected
+	// every in-flight execution. It says the sweep did not finish looking, not
+	// that more transitions are certain.
+	Capped bool
+}
+
+// RunStalledSweep forces stranded executions to failed, and reports what it did.
+//
+// An execution can end up in a state where two independent things are true:
+// nothing will ever resume it, and nothing will ever delete it. Convergence
+// works by name, so an execution with a generated name has nobody who will ever
+// reconstruct that name to continue it; and RunRetention deliberately collects
+// only terminal executions, because a pending or undoing one is exactly what
+// recovery is supposed to find. Between those two rules a record sits in the
+// store forever, and every recovery pass pays to read it (MIR-1788).
+//
+// The sweep transitions rather than deletes, because failed composes with
+// machinery that already exists in both directions and needs no guess about
+// which kind of record it is looking at. An execution named after its entity is
+// cleared by the next reconcile's DropIfFailed and retried, which is the
+// healing we want. One with a generated name is collected by ordinary retention
+// a window later, and in the meantime an operator has a record to inspect. That
+// is worth the extra retention window: deleting on sight destroys the evidence
+// of exactly the thing the count is a signal about.
+//
+// Forcing is not free on a live cluster. A convergent-ID execution forced here
+// causes its owner to genuinely retry a real operation on the next pass. That
+// is the intent, but it is why the window wants to be generous and why a sweep
+// that forces anything at all says so at Info.
+//
+// The sweep is idempotent, so a caller that is interrupted or capped simply
+// runs again. A nil log falls back to the default logger.
+func RunStalledSweep(ctx context.Context, storage Storage, cfg StalledConfig, log *slog.Logger) (*StalledResult, error) {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	result := &StalledResult{}
+	if cfg.StaleAfter <= 0 {
+		return result, nil
+	}
+
+	parents := newParentLiveness(storage)
+	cutoff := time.Now().Add(-cfg.StaleAfter)
+
+	cursor := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+
+		page, err := storage.ListIncompleteSummaryPage(ctx, IncompleteSummaryQuery{Cursor: cursor})
+		if err != nil {
+			return result, err
+		}
+
+		for _, summary := range page.Executions {
+			if err := ctx.Err(); err != nil {
+				return result, err
+			}
+			result.Scanned++
+
+			if summary.LastChanged.After(cutoff) {
+				continue
+			}
+
+			// A stalled child whose parent is still in flight has to stay. The
+			// parent re-finds its children by deterministic ID rather than
+			// re-running them, so failing one out from under a live parent
+			// fails the parent for a reason that was never true.
+			//
+			// A stranded parent is non-terminal and so counts as live here,
+			// which means a stranded tree takes one sweep per level rather
+			// than one sweep: forcing the parent makes it terminal, which
+			// releases its children on the next pass. Slower, and it
+			// converges, which is the right trade against a check whose other
+			// failure mode is failing a saga that was fine.
+			if summary.ParentID != "" && parents.isLive(ctx, summary.ParentID, log) {
+				result.Skipped++
+				continue
+			}
+
+			forced, err := forceFailed(ctx, storage, summary.ID, cutoff)
+			switch {
+			case err != nil:
+				log.Warn("failed to force stalled saga execution",
+					"id", summary.ID, "status", summary.Status,
+					"last_changed", summary.LastChanged, "error", err)
+				result.Failed++
+				continue
+			case !forced:
+				result.Recovered++
+				continue
+			}
+
+			log.Info("forced stalled saga execution to failed",
+				"id", summary.ID, "status", summary.Status,
+				"last_changed", summary.LastChanged)
+			result.Forced++
+
+			if cfg.MaxForces > 0 && result.Forced >= cfg.MaxForces {
+				capped, err := stoppedEarlyStalled(ctx, storage, page, summary.ID)
+				if err != nil {
+					return result, err
+				}
+				result.Capped = capped
+				return result, nil
+			}
+		}
+
+		cursor = page.Cursor
+		if cursor == "" {
+			return result, nil
+		}
+	}
+}
+
+// forceFailed transitions one execution to failed, reporting false if it turned
+// out not to need it.
+//
+// The re-read is the point. A page is a snapshot of an index, and between
+// building it and reaching this execution the saga may have been resumed,
+// finished, or deleted. Writing failed from the summary alone would take a saga
+// that had just started running again and declare it dead, which is the one
+// way this sweep could cause the damage it exists to clean up. So the decision
+// is made against the record as it is at the moment of writing: still in
+// flight, and still older than the same cutoff the page was measured against.
+func forceFailed(ctx context.Context, storage Storage, id string, cutoff time.Time) (bool, error) {
+	exec, err := storage.Get(ctx, id)
+	if errors.Is(err, ErrExecutionNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("loading execution %q: %w", id, err)
+	}
+
+	if isTerminal(exec.Status) {
+		return false, nil
+	}
+
+	// A zero timestamp here is a legacy record whose age came from the entity
+	// store rather than the saga, and re-reading it as an Execution threw that
+	// away. It is not evidence the execution is fresh, so it does not veto a
+	// decision the page already made against a real timestamp.
+	if !exec.UpdatedAt.IsZero() && exec.UpdatedAt.After(cutoff) {
+		return false, nil
+	}
+
+	exec.Status = StatusFailed
+	exec.Error = StalledError
+	exec.UpdatedAt = time.Now()
+
+	if err := storage.Save(ctx, exec); err != nil {
+		return false, fmt.Errorf("saving execution %q: %w", id, err)
+	}
+
+	return true, nil
+}
+
+// stoppedEarlyStalled reports whether a sweep that just spent its force budget
+// left anything uninspected. It is stoppedEarly's counterpart for the
+// in-flight walk, and the same reasoning applies in full: spending the budget
+// is not the same as being cut short, a cursor alone cannot tell the two apart
+// because the walk covers several status indexes in sequence, and so the
+// lookahead reads forward until it finds something or the walk genuinely ends.
+func stoppedEarlyStalled(ctx context.Context, storage Storage, page *IncompleteSummaryPage, forcedID string) (bool, error) {
+	if len(page.Executions) == 0 {
+		return false, nil
+	}
+
+	if forcedID != page.Executions[len(page.Executions)-1].ID {
+		return true, nil
+	}
+
+	cursor := page.Cursor
+	for cursor != "" {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+
+		next, err := storage.ListIncompleteSummaryPage(ctx, IncompleteSummaryQuery{Cursor: cursor, Limit: 1})
+		if err != nil {
+			return false, err
+		}
+		if len(next.Executions) > 0 {
+			return true, nil
+		}
+		cursor = next.Cursor
+	}
+
+	return false, nil
+}

--- a/pkg/saga/stalled.go
+++ b/pkg/saga/stalled.go
@@ -2,32 +2,42 @@ package saga
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 )
 
-// StalledError is the error recorded on an execution the sweep forces to
-// failed. It is deliberately a sentence rather than a code: it is read by
-// whoever runs `m debug saga show` on a forced record, and "this saga was never
-// going to finish" is the thing they need to know.
+// StalledError is recorded on a forced execution, so it stays distinguishable
+// from one that genuinely ran and failed.
 const StalledError = "forced to failed by the stalled-saga sweep: this execution " +
 	"had not changed state for longer than the stall window, so nothing was " +
 	"driving it and nothing would have collected it"
 
+// StalledStorage is what the sweep needs of a storage: less than Storage, plus
+// a write conditional on the record not having changed since it was read.
+//
+// Separate from Storage because EACStorage cannot honour it. The entity-access
+// put RPC returns a revision but does not accept one, so a conditional write is
+// not expressible over it. Narrowing the parameter is what makes the sweep's
+// coordinator-only reach a compile error rather than a comment.
+type StalledStorage interface {
+	Get(ctx context.Context, id string) (*Execution, error)
+
+	ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error)
+
+	// ForceFailed transitions an in-flight execution to failed if it is still
+	// in flight and still untouched since cutoff, and reports whether it did.
+	//
+	// Deciding and writing are one operation on purpose: a runner resuming an
+	// aged saga in the gap between them would lose its progress to a stale copy.
+	ForceFailed(ctx context.Context, id string, cutoff time.Time, reason string) (bool, error)
+}
+
 // StalledConfig tunes a stalled-saga sweep.
 type StalledConfig struct {
 	// StaleAfter is how long an execution may sit without changing state before
-	// the sweep declares it stranded. Zero disables the sweep, which is the
-	// escape hatch if a cluster needs its in-flight sagas left exactly as they
-	// are for an investigation.
-	//
-	// This is a measurement, not a guess about provenance. Save writes a
-	// timestamp on every transition and every action completion, so a saga that
-	// is being driven, or that is retrying its undos on a loop, keeps a recent
-	// one no matter how old the run is. What sits untouched for days is what
-	// nothing is driving.
+	// the sweep declares it stranded. Every transition and action completion
+	// writes a timestamp, so this measures being driven rather than guessing at
+	// it. Zero disables the sweep.
 	StaleAfter time.Duration
 
 	// MaxForces caps transitions in one sweep so a backlog drains over several
@@ -52,16 +62,13 @@ type StalledResult struct {
 	// their parent stops being live.
 	Skipped int
 
-	// Recovered is how many candidates turned out, on the re-read, to have
-	// moved on under us: finished, resumed, or deleted between the page and the
-	// write. Not an error and not a problem, but worth counting, because a
-	// sweep reporting a lot of them is reading pages that are too old to act
-	// on.
+	// Recovered is how many refused the transition because they had moved on
+	// between the page that named them and the write. Not an error; a lot of
+	// them means the sweep is acting on pages that are too old.
 	Recovered int
 
 	// Capped reports that MaxForces stopped the sweep before it had inspected
-	// every in-flight execution. It says the sweep did not finish looking, not
-	// that more transitions are certain.
+	// everything, not that more transitions are certain.
 	Capped bool
 }
 
@@ -75,23 +82,18 @@ type StalledResult struct {
 // recovery is supposed to find. Between those two rules a record sits in the
 // store forever, and every recovery pass pays to read it (MIR-1788).
 //
-// The sweep transitions rather than deletes, because failed composes with
-// machinery that already exists in both directions and needs no guess about
-// which kind of record it is looking at. An execution named after its entity is
-// cleared by the next reconcile's DropIfFailed and retried, which is the
-// healing we want. One with a generated name is collected by ordinary retention
-// a window later, and in the meantime an operator has a record to inspect. That
-// is worth the extra retention window: deleting on sight destroys the evidence
-// of exactly the thing the count is a signal about.
+// Transitioning rather than deleting hands the record back to rules that
+// already exist, without having to tell the two kinds apart: one named after
+// its entity is cleared by the next reconcile's DropIfFailed and retried, one
+// with a generated name is collected by retention a window later. That retry is
+// real work on a live cluster, which is why the window is generous and why a
+// sweep that forces anything logs it.
 //
-// Forcing is not free on a live cluster. A convergent-ID execution forced here
-// causes its owner to genuinely retry a real operation on the next pass. That
-// is the intent, but it is why the window wants to be generous and why a sweep
-// that forces anything at all says so at Info.
-//
-// The sweep is idempotent, so a caller that is interrupted or capped simply
-// runs again. A nil log falls back to the default logger.
-func RunStalledSweep(ctx context.Context, storage Storage, cfg StalledConfig, log *slog.Logger) (*StalledResult, error) {
+// The sweep selects candidates but decides nothing: a page is a snapshot, so
+// ForceFailed re-decides against the record as it is when it writes. It is
+// idempotent, so a caller that is interrupted or capped runs again. A nil log
+// falls back to the default logger.
+func RunStalledSweep(ctx context.Context, storage StalledStorage, cfg StalledConfig, log *slog.Logger) (*StalledResult, error) {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -125,23 +127,18 @@ func RunStalledSweep(ctx context.Context, storage Storage, cfg StalledConfig, lo
 				continue
 			}
 
-			// A stalled child whose parent is still in flight has to stay. The
-			// parent re-finds its children by deterministic ID rather than
-			// re-running them, so failing one out from under a live parent
-			// fails the parent for a reason that was never true.
-			//
-			// A stranded parent is non-terminal and so counts as live here,
-			// which means a stranded tree takes one sweep per level rather
-			// than one sweep: forcing the parent makes it terminal, which
-			// releases its children on the next pass. Slower, and it
-			// converges, which is the right trade against a check whose other
-			// failure mode is failing a saga that was fine.
+			// A stalled child whose parent is still in flight has to stay: the
+			// parent re-finds its children by ID rather than re-running them,
+			// so failing one under a live parent fails the parent for a reason
+			// that was never true. A stranded parent is non-terminal and so
+			// reads as live, which means a stranded tree converges one level
+			// per sweep rather than all at once.
 			if summary.ParentID != "" && parents.isLive(ctx, summary.ParentID, log) {
 				result.Skipped++
 				continue
 			}
 
-			forced, err := forceFailed(ctx, storage, summary.ID, cutoff)
+			forced, err := storage.ForceFailed(ctx, summary.ID, cutoff, StalledError)
 			switch {
 			case err != nil:
 				log.Warn("failed to force stalled saga execution",
@@ -176,55 +173,9 @@ func RunStalledSweep(ctx context.Context, storage Storage, cfg StalledConfig, lo
 	}
 }
 
-// forceFailed transitions one execution to failed, reporting false if it turned
-// out not to need it.
-//
-// The re-read is the point. A page is a snapshot of an index, and between
-// building it and reaching this execution the saga may have been resumed,
-// finished, or deleted. Writing failed from the summary alone would take a saga
-// that had just started running again and declare it dead, which is the one
-// way this sweep could cause the damage it exists to clean up. So the decision
-// is made against the record as it is at the moment of writing: still in
-// flight, and still older than the same cutoff the page was measured against.
-func forceFailed(ctx context.Context, storage Storage, id string, cutoff time.Time) (bool, error) {
-	exec, err := storage.Get(ctx, id)
-	if errors.Is(err, ErrExecutionNotFound) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("loading execution %q: %w", id, err)
-	}
-
-	if isTerminal(exec.Status) {
-		return false, nil
-	}
-
-	// A zero timestamp here is a legacy record whose age came from the entity
-	// store rather than the saga, and re-reading it as an Execution threw that
-	// away. It is not evidence the execution is fresh, so it does not veto a
-	// decision the page already made against a real timestamp.
-	if !exec.UpdatedAt.IsZero() && exec.UpdatedAt.After(cutoff) {
-		return false, nil
-	}
-
-	exec.Status = StatusFailed
-	exec.Error = StalledError
-	exec.UpdatedAt = time.Now()
-
-	if err := storage.Save(ctx, exec); err != nil {
-		return false, fmt.Errorf("saving execution %q: %w", id, err)
-	}
-
-	return true, nil
-}
-
-// stoppedEarlyStalled reports whether a sweep that just spent its force budget
-// left anything uninspected. It is stoppedEarly's counterpart for the
-// in-flight walk, and the same reasoning applies in full: spending the budget
-// is not the same as being cut short, a cursor alone cannot tell the two apart
-// because the walk covers several status indexes in sequence, and so the
-// lookahead reads forward until it finds something or the walk genuinely ends.
-func stoppedEarlyStalled(ctx context.Context, storage Storage, page *IncompleteSummaryPage, forcedID string) (bool, error) {
+// stoppedEarlyStalled is stoppedEarly for the in-flight walk. See there for why
+// the lookahead reads forward rather than trusting one empty page.
+func stoppedEarlyStalled(ctx context.Context, storage StalledStorage, page *IncompleteSummaryPage, forcedID string) (bool, error) {
 	if len(page.Executions) == 0 {
 		return false, nil
 	}

--- a/pkg/saga/stalled_etcd_test.go
+++ b/pkg/saga/stalled_etcd_test.go
@@ -1,0 +1,131 @@
+package saga
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+// TestStalledSweep_AgainstRealEtcd is the smoke test for the part a mock store
+// cannot vouch for: that forcing an execution really moves it between status
+// indexes on a real EtcdStore.
+//
+// The index assertions are the point. The sweep finds its work through the
+// in-flight indexes, so a write that left the pending entry behind would have
+// every later sweep rediscover the same execution forever. That is the leak
+// MIR-1735 fixed in ReplaceEntity, and this sweep would notice first if it
+// came back.
+func TestStalledSweep_AgainstRealEtcd(t *testing.T) {
+	ctx := context.Background()
+	storage, store := newEtcdStorage(t)
+
+	saveAged(t, storage, "etcd-stranded-pending", StatusPending, 30*24*time.Hour)
+	saveAged(t, storage, "etcd-stranded-undoing", StatusUndoing, 30*24*time.Hour)
+	saveAged(t, storage, "etcd-working", StatusRunning, 1*time.Hour)
+	saveAged(t, storage, "etcd-finished", StatusCompleted, 90*24*time.Hour)
+
+	summaries, err := collectIncompleteSummaries(ctx, storage)
+	require.NoError(t, err)
+	require.Len(t, summaries, 3, "the three in-flight executions must be discoverable through the real status indexes")
+
+	result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Forced)
+	assert.Zero(t, result.Failed)
+
+	assert.Equal(t, StatusFailed, statusOf(t, storage, "etcd-stranded-pending"))
+	assert.Equal(t, StatusFailed, statusOf(t, storage, "etcd-stranded-undoing"))
+	assert.Equal(t, StatusRunning, statusOf(t, storage, "etcd-working"),
+		"an execution inside the window is still someone's work in progress")
+	assert.Equal(t, StatusCompleted, statusOf(t, storage, "etcd-finished"),
+		"the sweep must never rewrite a recorded success")
+
+	pendingIds, err := store.ListIndex(ctx, entity.Ref(
+		saga_v1alpha.SagaStatusId, saga_v1alpha.SagaStatusPendingId))
+	require.NoError(t, err)
+	assert.NotContains(t, pendingIds, entity.Id("etcd-stranded-pending"),
+		"forcing an execution must clear its old status index entry")
+
+	undoingIds, err := store.ListIndex(ctx, entity.Ref(
+		saga_v1alpha.SagaStatusId, saga_v1alpha.SagaStatusUndoingId))
+	require.NoError(t, err)
+	assert.NotContains(t, undoingIds, entity.Id("etcd-stranded-undoing"))
+
+	failedIds, err := store.ListIndex(ctx, entity.Ref(
+		saga_v1alpha.SagaStatusId, saga_v1alpha.SagaStatusFailedId))
+	require.NoError(t, err)
+	assert.Contains(t, failedIds, entity.Id("etcd-stranded-pending"),
+		"a forced execution must be findable where retention looks")
+	assert.Contains(t, failedIds, entity.Id("etcd-stranded-undoing"))
+
+	// A second sweep converges rather than rediscovering what it just forced.
+	result, err = RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+	require.NoError(t, err)
+	assert.Zero(t, result.Forced)
+	assert.Zero(t, result.Recovered, "a converged sweep must not keep re-reading records it already dealt with")
+	assert.Equal(t, 1, result.Scanned, "only the execution still legitimately in flight remains to scan")
+}
+
+// TestStalledSweep_HandsOffToRetentionAgainstRealEtcd is the reason the sweep
+// transitions instead of deleting: forcing moves an execution into the one
+// state that already has a rule for getting rid of it.
+func TestStalledSweep_HandsOffToRetentionAgainstRealEtcd(t *testing.T) {
+	ctx := context.Background()
+	storage, _ := newEtcdStorage(t)
+
+	saveAged(t, storage, "etcd-handoff", StatusPending, 90*24*time.Hour)
+
+	_, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+	require.NoError(t, err)
+
+	retained, err := RunRetention(ctx, storage, weekRetention(), testutils.TestLogger(t))
+	require.NoError(t, err)
+	assert.Zero(t, retained.Deleted,
+		"a just-forced execution is inside the retention window: the operator gets a week to see what was forced and why")
+	assert.Equal(t, 1, retained.Scanned, "but it is retention's to consider now")
+
+	// Once its window does pass, the ordinary rule collects it. Retention has
+	// no special case for a forced record and needs none: after the transition
+	// it is a terminal execution like any other, and only its recorded error
+	// still says how it got there.
+	expired, err := RunRetention(ctx, storage,
+		RetentionConfig{Retention: time.Nanosecond, MaxDeletes: 1000},
+		testutils.TestLogger(t))
+	require.NoError(t, err)
+	assert.Equal(t, 1, expired.Deleted)
+	assert.False(t, executionExists(t, storage, "etcd-handoff"))
+}
+
+// TestStalledSweep_UnblocksConvergentRetryAgainstRealEtcd is the other half of
+// the handoff. An execution named after its entity is stuck differently: its
+// owner keeps arriving under that name, and a pending record answers every
+// arrival with "still in flight". Forcing it is what lets DropIfFailed clear
+// the name so the next reconcile actually retries.
+func TestStalledSweep_UnblocksConvergentRetryAgainstRealEtcd(t *testing.T) {
+	ctx := context.Background()
+	storage, _ := newEtcdStorage(t)
+
+	const id = "deprovision-assoc-123"
+	saveAged(t, storage, id, StatusPending, 90*24*time.Hour)
+
+	// Before the sweep the name is occupied by a record nothing will resume,
+	// and its owner's own escape hatch cannot help: DropIfFailed only clears a
+	// failed record, and this one never got there.
+	require.NoError(t, DropIfFailed(ctx, storage, id))
+	assert.True(t, executionExists(t, storage, id),
+		"DropIfFailed must not touch a pending record, which is exactly why it was stuck")
+
+	_, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+	require.NoError(t, err)
+
+	require.NoError(t, DropIfFailed(ctx, storage, id))
+	assert.False(t, executionExists(t, storage, id),
+		"forcing to failed is what lets the owning controller clear the name and retry")
+}

--- a/pkg/saga/stalled_test.go
+++ b/pkg/saga/stalled_test.go
@@ -192,8 +192,13 @@ func TestRunStalledSweep_KeepsChildrenOfLiveParents(t *testing.T) {
 // TestRunStalledSweep_ConvergesOnStrandedTrees is the case a liveness check
 // alone would deadlock on. "Live" means not terminal, so a stranded parent
 // shields its own children from the sweep that is about to deal with it. The
-// property that matters is not that a tree goes in one sweep but that it goes,
-// one level at a time.
+// property that matters is not how fast a tree goes but that it goes.
+//
+// The per-sweep counts below depend on walk order: "stranded-child" sorts ahead
+// of "stranded-parent", so the child is read while its parent is still pending.
+// Reverse the names and both go in one sweep, which is a better outcome and a
+// failed assertion. If a rename breaks this, that is why, and the property to
+// keep asserting is that the tree is fully forced by the end.
 func TestRunStalledSweep_ConvergesOnStrandedTrees(t *testing.T) {
 	for _, backend := range stalledBackends() {
 		t.Run(backend.name, func(t *testing.T) {

--- a/pkg/saga/stalled_test.go
+++ b/pkg/saga/stalled_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 )
 
@@ -16,7 +17,35 @@ func weekStalled() StalledConfig {
 	return StalledConfig{StaleAfter: 7 * 24 * time.Hour, MaxForces: 1000}
 }
 
-func statusOf(t *testing.T, storage Storage, id string) Status {
+// stalledStorage is StalledStorage plus the Save a test needs to seed with.
+type stalledStorage interface {
+	StalledStorage
+	executionSaver
+}
+
+// stalledBackends returns every storage the sweep can be handed. EACStorage is
+// absent by construction rather than omission: it cannot express a conditional
+// write, so adding it here would not compile.
+func stalledBackends() []struct {
+	name string
+	make func(t *testing.T) stalledStorage
+} {
+	return []struct {
+		name string
+		make func(t *testing.T) stalledStorage
+	}{
+		{"MemoryStorage", func(t *testing.T) stalledStorage {
+			return NewMemoryStorage()
+		}},
+		{"EntityStorage", func(t *testing.T) stalledStorage {
+			inmem, cleanup := testutils.NewInMemEntityServer(t)
+			t.Cleanup(cleanup)
+			return NewEntityStorage(inmem.Store, testutils.TestLogger(t))
+		}},
+	}
+}
+
+func statusOf(t *testing.T, storage executionGetter, id string) Status {
 	t.Helper()
 
 	exec, err := storage.Get(context.Background(), id)
@@ -25,15 +54,14 @@ func statusOf(t *testing.T, storage Storage, id string) Status {
 }
 
 // TestRunStalledSweep_ForcesStrandedExecutions is the core of MIR-1788: an
-// in-flight execution that has not changed state for longer than the window is
-// the one thing neither convergence nor retention will ever deal with, so the
-// sweep transitions it into a state that has rules.
+// in-flight execution nothing has touched for longer than the window is what
+// neither convergence nor retention will ever deal with.
 //
-// All three in-flight statuses qualify. Undoing is the one worth naming: an
-// execution retrying its undos writes a timestamp on every attempt, so the only
-// undoing execution old enough to reach here is one where the retrying stopped.
+// Undoing qualifies too, which is worth naming: retrying undos writes a
+// timestamp on every attempt, so an undoing execution old enough to reach here
+// is one where the retrying stopped.
 func TestRunStalledSweep_ForcesStrandedExecutions(t *testing.T) {
-	for _, backend := range allStorageBackends() {
+	for _, backend := range stalledBackends() {
 		t.Run(backend.name, func(t *testing.T) {
 			ctx := context.Background()
 			storage := backend.make(t)
@@ -88,7 +116,7 @@ func TestRunStalledSweep_RecordsWhyItForced(t *testing.T) {
 // retention. The two sweeps must not both have an opinion about the same
 // execution: a terminal one is retention's, at any age.
 func TestRunStalledSweep_NeverTouchesTerminalExecutions(t *testing.T) {
-	for _, backend := range allStorageBackends() {
+	for _, backend := range stalledBackends() {
 		t.Run(backend.name, func(t *testing.T) {
 			ctx := context.Background()
 			storage := backend.make(t)
@@ -109,7 +137,7 @@ func TestRunStalledSweep_NeverTouchesTerminalExecutions(t *testing.T) {
 }
 
 // saveStalledChild persists an in-flight child execution belonging to parentID.
-func saveStalledChild(t *testing.T, storage Storage, id, parentID string, age time.Duration) {
+func saveStalledChild(t *testing.T, storage executionSaver, id, parentID string, age time.Duration) {
 	t.Helper()
 
 	changed := time.Now().Add(-age)
@@ -131,7 +159,7 @@ func saveStalledChild(t *testing.T, storage Storage, id, parentID string, age ti
 // re-finding its children rather than re-running them, so failing a child under
 // a live parent fails the parent for a reason that was never true.
 func TestRunStalledSweep_KeepsChildrenOfLiveParents(t *testing.T) {
-	for _, backend := range allStorageBackends() {
+	for _, backend := range stalledBackends() {
 		t.Run(backend.name, func(t *testing.T) {
 			ctx := context.Background()
 			storage := backend.make(t)
@@ -162,16 +190,12 @@ func TestRunStalledSweep_KeepsChildrenOfLiveParents(t *testing.T) {
 }
 
 // TestRunStalledSweep_ConvergesOnStrandedTrees is the case a liveness check
-// alone would deadlock on.
-//
-// "Live" means not terminal, so a stranded parent looks live to its own
-// children and shields them from the sweep that is about to deal with it. That
-// is the right answer for one pass and the wrong one forever, so the property
-// that matters is not that a tree goes in a single sweep but that it goes: the
-// parent is forced, which makes it terminal, which unshields the children on
-// the next pass. A tree converges in as many sweeps as it is deep.
+// alone would deadlock on. "Live" means not terminal, so a stranded parent
+// shields its own children from the sweep that is about to deal with it. The
+// property that matters is not that a tree goes in one sweep but that it goes,
+// one level at a time.
 func TestRunStalledSweep_ConvergesOnStrandedTrees(t *testing.T) {
-	for _, backend := range allStorageBackends() {
+	for _, backend := range stalledBackends() {
 		t.Run(backend.name, func(t *testing.T) {
 			ctx := context.Background()
 			storage := backend.make(t)
@@ -205,7 +229,7 @@ func TestRunStalledSweep_ConvergesOnStrandedTrees(t *testing.T) {
 // passes rather than one thundering herd of writes, and that hitting the cap is
 // reported rather than reading as a clean sweep.
 func TestRunStalledSweep_CapsForces(t *testing.T) {
-	for _, backend := range allStorageBackends() {
+	for _, backend := range stalledBackends() {
 		t.Run(backend.name, func(t *testing.T) {
 			ctx := context.Background()
 			storage := backend.make(t)
@@ -238,7 +262,7 @@ func TestRunStalledSweep_CapsForces(t *testing.T) {
 // same reason retention pins it: reporting a converged sweep as capped tells an
 // operator a backlog remains on a store that has none.
 func TestRunStalledSweep_ExactlyMaxForcesIsNotCapped(t *testing.T) {
-	for _, backend := range allStorageBackends() {
+	for _, backend := range stalledBackends() {
 		t.Run(backend.name, func(t *testing.T) {
 			ctx := context.Background()
 			storage := backend.make(t)
@@ -263,7 +287,7 @@ func TestRunStalledSweep_ExactlyMaxForcesIsNotCapped(t *testing.T) {
 // operator who wants in-flight sagas left exactly as they are during an
 // investigation sets the window to zero.
 func TestRunStalledSweep_ZeroStaleAfterForcesNothing(t *testing.T) {
-	for _, backend := range allStorageBackends() {
+	for _, backend := range stalledBackends() {
 		t.Run(backend.name, func(t *testing.T) {
 			ctx := context.Background()
 			storage := backend.make(t)
@@ -280,149 +304,159 @@ func TestRunStalledSweep_ZeroStaleAfterForcesNothing(t *testing.T) {
 	}
 }
 
-// resumeOnGetStorage revives an execution the moment the sweep re-reads it,
-// standing in for a runner that picked the saga back up between the page and
-// the write.
-type resumeOnGetStorage struct {
-	Storage
-	reviveID string
-	status   Status
+// changeAfterPageStorage mutates an execution the moment the sweep has a page
+// naming it, standing in for a runner that picked the saga back up between the
+// listing and the transition.
+type changeAfterPageStorage struct {
+	stalledStorage
+	targetID string
+	change   func(t *testing.T, s stalledStorage, id string)
+	t        *testing.T
 }
 
-func (r *resumeOnGetStorage) Get(ctx context.Context, id string) (*Execution, error) {
-	exec, err := r.Storage.Get(ctx, id)
-	if err != nil || id != r.reviveID {
-		return exec, err
-	}
-
-	exec.Status = r.status
-	exec.UpdatedAt = time.Now()
-	if err := r.Save(ctx, exec); err != nil {
+func (c *changeAfterPageStorage) ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error) {
+	page, err := c.stalledStorage.ListIncompleteSummaryPage(ctx, q)
+	if err != nil {
 		return nil, err
 	}
-	return exec, nil
+	for _, summary := range page.Executions {
+		if summary.ID == c.targetID {
+			c.change(c.t, c.stalledStorage, c.targetID)
+		}
+	}
+	return page, nil
 }
 
-// TestRunStalledSweep_RereadsBeforeForcing is the safety property that matters
-// most, and the one a summary read makes possible to get wrong.
-//
-// A page is a snapshot of an index. Between building it and reaching a given
-// execution, a runner may have resumed that saga, or it may have finished, or
-// it may be gone. Writing failed from the summary alone would take a saga that
-// had just started running again and declare it dead, which is the one way this
-// sweep could cause the damage it exists to clean up.
-func TestRunStalledSweep_RereadsBeforeForcing(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		status Status
-	}{
-		{"resumed under us", StatusRunning},
-		{"finished under us", StatusCompleted},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			storage := &resumeOnGetStorage{
-				Storage:  NewMemoryStorage(),
-				reviveID: "revived",
-				status:   tc.status,
+func resumeExecution(status Status) func(*testing.T, stalledStorage, string) {
+	return func(t *testing.T, s stalledStorage, id string) {
+		t.Helper()
+
+		exec, err := s.Get(context.Background(), id)
+		require.NoError(t, err)
+		exec.Status = status
+		exec.UpdatedAt = time.Now()
+		require.NoError(t, s.Save(context.Background(), exec))
+	}
+}
+
+// TestRunStalledSweep_RefusesCandidatesThatMovedAfterTheirPage is the safety
+// property that matters most. A page says an execution sat untouched for a
+// month; by the time the sweep reaches it, it may have been resumed, finished
+// or deleted. Forcing on the page's word alone would declare dead a saga that
+// had just started running again.
+func TestRunStalledSweep_RefusesCandidatesThatMovedAfterTheirPage(t *testing.T) {
+	for _, backend := range stalledBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name   string
+				status Status
+			}{
+				{"resumed after its page", StatusRunning},
+				{"finished after its page", StatusCompleted},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					ctx := context.Background()
+					inner := backend.make(t)
+
+					saveAged(t, inner, "moved", StatusPending, 30*24*time.Hour)
+					saveAged(t, inner, "genuinely-stranded", StatusPending, 30*24*time.Hour)
+
+					storage := &changeAfterPageStorage{
+						stalledStorage: inner,
+						targetID:       "moved",
+						change:         resumeExecution(tc.status),
+						t:              t,
+					}
+
+					result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+					require.NoError(t, err)
+
+					assert.Equal(t, 1, result.Recovered,
+						"an execution that moved after its page is counted, not forced")
+					assert.Equal(t, tc.status, statusOf(t, inner, "moved"),
+						"and its own progress is left exactly as it wrote it")
+
+					assert.Equal(t, 1, result.Forced)
+					assert.Equal(t, StatusFailed, statusOf(t, inner, "genuinely-stranded"),
+						"one candidate turning out to be alive must not spare the rest")
+				})
 			}
-
-			saveAged(t, storage, "revived", StatusPending, 30*24*time.Hour)
-			saveAged(t, storage, "genuinely-stranded", StatusPending, 30*24*time.Hour)
-
-			result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
-			require.NoError(t, err)
-
-			assert.Equal(t, 1, result.Recovered,
-				"an execution that moved on between the page and the write is counted, not forced")
-			assert.Equal(t, tc.status, statusOf(t, storage, "revived"))
-
-			assert.Equal(t, 1, result.Forced)
-			assert.Equal(t, StatusFailed, statusOf(t, storage, "genuinely-stranded"),
-				"one candidate turning out to be alive must not spare the rest")
 		})
 	}
 }
 
-// TestRunStalledSweep_DeletedUnderUsIsNotAnError keeps overlapping or retried
-// sweeps converging rather than erroring on work another pass already did.
-func TestRunStalledSweep_DeletedUnderUsIsNotAnError(t *testing.T) {
-	ctx := context.Background()
-	storage := &deleteOnGetStorage{Storage: NewMemoryStorage(), deleteID: "vanishing"}
+// TestRunStalledSweep_DeletedAfterItsPageIsNotAnError keeps overlapping or
+// retried sweeps converging rather than erroring on work another pass already
+// did.
+func TestRunStalledSweep_DeletedAfterItsPageIsNotAnError(t *testing.T) {
+	for _, backend := range stalledBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			inner := backend.make(t)
 
-	saveAged(t, storage, "vanishing", StatusPending, 30*24*time.Hour)
+			saveAged(t, inner, "vanishing", StatusPending, 30*24*time.Hour)
 
-	result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
-	require.NoError(t, err)
+			storage := &changeAfterPageStorage{
+				stalledStorage: inner,
+				targetID:       "vanishing",
+				change: func(t *testing.T, s stalledStorage, id string) {
+					t.Helper()
+					require.NoError(t, s.(Storage).Delete(context.Background(), id))
+				},
+				t: t,
+			}
 
-	assert.Zero(t, result.Failed)
-	assert.Zero(t, result.Forced)
-	assert.Equal(t, 1, result.Recovered)
-}
+			result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
 
-// deleteOnGetStorage removes an execution just as the sweep re-reads it.
-type deleteOnGetStorage struct {
-	Storage
-	deleteID string
-}
-
-func (d *deleteOnGetStorage) Get(ctx context.Context, id string) (*Execution, error) {
-	if id == d.deleteID {
-		if err := d.Delete(ctx, id); err != nil {
-			return nil, err
-		}
+			assert.Zero(t, result.Failed)
+			assert.Zero(t, result.Forced)
+			assert.Equal(t, 1, result.Recovered)
+		})
 	}
-	return d.Storage.Get(ctx, id)
 }
 
-// saveFailingStorage fails Save for one specific execution.
-type saveFailingStorage struct {
-	Storage
+// forceFailingStorage fails the transition for one specific execution.
+type forceFailingStorage struct {
+	stalledStorage
 	failID string
 }
 
-func (s *saveFailingStorage) Save(ctx context.Context, exec *Execution) error {
-	if exec.ID == s.failID && exec.Status == StatusFailed {
-		return errors.New("simulated save failure")
+func (f *forceFailingStorage) ForceFailed(ctx context.Context, id string, cutoff time.Time, reason string) (bool, error) {
+	if id == f.failID {
+		return false, errors.New("simulated write failure")
 	}
-	return s.Storage.Save(ctx, exec)
+	return f.stalledStorage.ForceFailed(ctx, id, cutoff, reason)
 }
 
-// TestRunStalledSweep_SaveFailureDoesNotAbortSweep pins the best-effort
+// TestRunStalledSweep_WriteFailureDoesNotAbortSweep pins the best-effort
 // behavior. Without it, a single execution the store will not accept a write
 // for would wedge the sweep for the whole cluster.
-func TestRunStalledSweep_SaveFailureDoesNotAbortSweep(t *testing.T) {
+func TestRunStalledSweep_WriteFailureDoesNotAbortSweep(t *testing.T) {
 	ctx := context.Background()
-	storage := &saveFailingStorage{Storage: NewMemoryStorage(), failID: "stubborn"}
+	inner := NewMemoryStorage()
+	storage := &forceFailingStorage{stalledStorage: inner, failID: "stubborn"}
 
 	for _, id := range []string{"first", "stubborn", "last"} {
-		saveAged(t, storage, id, StatusPending, 30*24*time.Hour)
+		saveAged(t, inner, id, StatusPending, 30*24*time.Hour)
 	}
 
 	result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
-	require.NoError(t, err, "a save failure must not fail the sweep")
+	require.NoError(t, err, "a write failure must not fail the sweep")
 
 	assert.Equal(t, 1, result.Failed)
 	assert.Equal(t, 2, result.Forced, "the other stranded executions must still be forced")
-	assert.Equal(t, StatusPending, statusOf(t, storage, "stubborn"))
-	assert.Equal(t, StatusFailed, statusOf(t, storage, "first"))
-	assert.Equal(t, StatusFailed, statusOf(t, storage, "last"))
+	assert.Equal(t, StatusPending, statusOf(t, inner, "stubborn"))
+	assert.Equal(t, StatusFailed, statusOf(t, inner, "first"))
+	assert.Equal(t, StatusFailed, statusOf(t, inner, "last"))
 }
 
 // TestStalledSweep_LegacyExecutionsUseStoreTimestamp is the upgrade path, and
-// the reason the sweep reads summaries rather than executions.
-//
-// The executions this sweep exists to drain were written by v0.11.1, whose saga
-// schema had no created_at or updated_at fields at all. Every one of them reads
-// back with a zero saga timestamp, so an age taken from the execution alone
-// would call the whole population infinitely old and force it on sight,
-// including whatever a runner on the old binary started seconds before the
-// upgrade. The entity-backed stores fall back to the store's own timestamp,
-// which is a real measurement of a real record.
-//
-// Deliberately not part of the conformance suite: MemoryStorage has no second
-// timestamp to fall back to, and the whole point is that the entity backends
-// do.
+// the reason the sweep reads summaries rather than executions. v0.11.1's saga
+// schema had no timestamp fields, so its executions read back with a zero one,
+// and an age taken from the execution alone would force the whole population on
+// sight. Not in the conformance suite because MemoryStorage has no second
+// timestamp to fall back to, which is the point.
 func TestStalledSweep_LegacyExecutionsUseStoreTimestamp(t *testing.T) {
 	ctx := context.Background()
 	inmem, cleanup := testutils.NewInMemEntityServer(t)
@@ -430,10 +464,9 @@ func TestStalledSweep_LegacyExecutionsUseStoreTimestamp(t *testing.T) {
 
 	for _, tc := range []struct {
 		name    string
-		storage Storage
+		storage stalledStorage
 	}{
 		{"EntityStorage", NewEntityStorage(inmem.Store, testutils.TestLogger(t))},
-		{"EACStorage", NewEACStorage(inmem.EAC, testutils.TestLogger(t))},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// A saga saved with no timestamps at all, exactly as v0.11.1 wrote
@@ -469,4 +502,85 @@ func TestStalledSweep_LegacyExecutionsUseStoreTimestamp(t *testing.T) {
 			assert.Equal(t, StatusPending, statusOf(t, tc.storage, id))
 		})
 	}
+}
+
+// mutateOnGetStore writes a new revision of an entity immediately after handing
+// it to a reader, so a caller that reads then writes always finds its read
+// stale. Wrapping the store rather than the storage is the only way to reach
+// the gap inside ForceFailed, between its read and its write.
+type mutateOnGetStore struct {
+	entity.Store
+	targetID entity.Id
+	mutate   func(t *testing.T, store entity.Store, ent *entity.Entity)
+	t        *testing.T
+	fired    bool
+}
+
+func (m *mutateOnGetStore) GetEntity(ctx context.Context, id entity.Id) (*entity.Entity, error) {
+	ent, err := m.Store.GetEntity(ctx, id)
+	if err != nil || id != m.targetID || m.fired {
+		return ent, err
+	}
+
+	// Once only: the mutation is itself a read-modify-write, and re-entering
+	// here would recurse.
+	m.fired = true
+	m.mutate(m.t, m.Store, ent)
+	return ent, nil
+}
+
+// TestEntityStorageForceFailed_RefusesAStaleWrite pins the conditional write.
+//
+// A runner can resume an aged execution after ForceFailed has read it and
+// decided but before it writes. An unconditional upsert would replace that
+// runner's status and action outputs with a stale copy marked failed, and the
+// retry a recorded failure unblocks would re-run actions that already ran.
+func TestEntityStorageForceFailed_RefusesAStaleWrite(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	const id = "raced-execution"
+
+	seed := NewEntityStorage(inmem.Store, testutils.TestLogger(t))
+	saveAged(t, seed, id, StatusPending, 30*24*time.Hour)
+
+	// The runner's resume: fresh status, fresh outputs, fresh timestamp,
+	// landing between our read and our write.
+	resumed := &Execution{
+		ID:             id,
+		DefinitionName: "create-sandbox",
+		Status:         StatusRunning,
+		InitialInputs:  map[string]any{"app": "demo"},
+		ExecutedActions: map[string]*ActionResult{
+			"allocate-ip": {Output: []byte(`{"ip":"10.0.0.9"}`), ExecutedAt: time.Now()},
+		},
+		ExecutionOrder: []string{"allocate-ip"},
+		CreatedAt:      time.Now().Add(-30 * 24 * time.Hour),
+		UpdatedAt:      time.Now(),
+	}
+
+	racing := &mutateOnGetStore{
+		Store:    inmem.Store,
+		targetID: entity.Id(id),
+		t:        t,
+		mutate: func(t *testing.T, store entity.Store, _ *entity.Entity) {
+			t.Helper()
+			require.NoError(t, NewEntityStorage(store, testutils.TestLogger(t)).Save(ctx, resumed))
+		},
+	}
+
+	storage := NewEntityStorage(racing, testutils.TestLogger(t))
+
+	forced, err := storage.ForceFailed(ctx, id, time.Now().Add(-7*24*time.Hour), StalledError)
+	require.NoError(t, err, "losing the race is an ordinary outcome, not an error")
+	assert.False(t, forced, "a record that changed under us must refuse the transition")
+
+	after, err := seed.Get(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, StatusRunning, after.Status,
+		"the resuming runner's status must survive")
+	assert.Empty(t, after.Error, "and it must not be carrying our failure message")
+	assert.Contains(t, after.ExecutedActions, "allocate-ip",
+		"nor may its recorded action outputs be replaced by our stale copy")
 }

--- a/pkg/saga/stalled_test.go
+++ b/pkg/saga/stalled_test.go
@@ -1,0 +1,472 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+func weekStalled() StalledConfig {
+	return StalledConfig{StaleAfter: 7 * 24 * time.Hour, MaxForces: 1000}
+}
+
+func statusOf(t *testing.T, storage Storage, id string) Status {
+	t.Helper()
+
+	exec, err := storage.Get(context.Background(), id)
+	require.NoError(t, err)
+	return exec.Status
+}
+
+// TestRunStalledSweep_ForcesStrandedExecutions is the core of MIR-1788: an
+// in-flight execution that has not changed state for longer than the window is
+// the one thing neither convergence nor retention will ever deal with, so the
+// sweep transitions it into a state that has rules.
+//
+// All three in-flight statuses qualify. Undoing is the one worth naming: an
+// execution retrying its undos writes a timestamp on every attempt, so the only
+// undoing execution old enough to reach here is one where the retrying stopped.
+func TestRunStalledSweep_ForcesStrandedExecutions(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := backend.make(t)
+
+			saveAged(t, storage, "stranded-pending", StatusPending, 30*24*time.Hour)
+			saveAged(t, storage, "stranded-running", StatusRunning, 8*24*time.Hour)
+			saveAged(t, storage, "stranded-undoing", StatusUndoing, 90*24*time.Hour)
+			saveAged(t, storage, "working-pending", StatusPending, 1*time.Hour)
+			saveAged(t, storage, "working-undoing", StatusUndoing, 6*24*time.Hour)
+
+			result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
+
+			assert.Equal(t, 3, result.Forced)
+			assert.Equal(t, 5, result.Scanned)
+			assert.Zero(t, result.Failed)
+			assert.Zero(t, result.Recovered)
+
+			for _, id := range []string{"stranded-pending", "stranded-running", "stranded-undoing"} {
+				assert.Equal(t, StatusFailed, statusOf(t, storage, id),
+					"%s had sat untouched past the window and must be forced", id)
+			}
+			assert.Equal(t, StatusPending, statusOf(t, storage, "working-pending"),
+				"an execution inside the window is still someone's work in progress")
+			assert.Equal(t, StatusUndoing, statusOf(t, storage, "working-undoing"),
+				"an undoing execution that is still retrying keeps a recent timestamp and must survive")
+		})
+	}
+}
+
+// TestRunStalledSweep_RecordsWhyItForced covers what an operator sees. A forced
+// execution is indistinguishable from one that genuinely ran and failed unless
+// the record says otherwise, and the week before retention collects it is
+// exactly when someone would go looking.
+func TestRunStalledSweep_RecordsWhyItForced(t *testing.T) {
+	ctx := context.Background()
+	storage := NewMemoryStorage()
+
+	saveAged(t, storage, "stranded", StatusPending, 30*24*time.Hour)
+
+	_, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+	require.NoError(t, err)
+
+	exec, err := storage.Get(ctx, "stranded")
+	require.NoError(t, err)
+	assert.Equal(t, StalledError, exec.Error)
+	assert.WithinDuration(t, time.Now(), exec.UpdatedAt, time.Minute,
+		"the transition is a state change and must be stamped like one, so retention dates it from here")
+}
+
+// TestRunStalledSweep_NeverTouchesTerminalExecutions is the boundary with
+// retention. The two sweeps must not both have an opinion about the same
+// execution: a terminal one is retention's, at any age.
+func TestRunStalledSweep_NeverTouchesTerminalExecutions(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := backend.make(t)
+
+			saveAged(t, storage, "ancient-completed", StatusCompleted, 90*24*time.Hour)
+			saveAged(t, storage, "ancient-failed", StatusFailed, 90*24*time.Hour)
+
+			result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
+
+			assert.Zero(t, result.Forced)
+			assert.Zero(t, result.Scanned, "terminal executions must not even be scanned")
+			assert.Equal(t, StatusCompleted, statusOf(t, storage, "ancient-completed"),
+				"the sweep must never rewrite a recorded success")
+			assert.Equal(t, StatusFailed, statusOf(t, storage, "ancient-failed"))
+		})
+	}
+}
+
+// saveStalledChild persists an in-flight child execution belonging to parentID.
+func saveStalledChild(t *testing.T, storage Storage, id, parentID string, age time.Duration) {
+	t.Helper()
+
+	changed := time.Now().Add(-age)
+	require.NoError(t, storage.Save(context.Background(), &Execution{
+		ID:                id,
+		DefinitionName:    "ensure-shared-server",
+		ParentExecutionID: parentID,
+		Status:            StatusPending,
+		InitialInputs:     map[string]any{},
+		ExecutedActions:   map[string]*ActionResult{},
+		ExecutionOrder:    []string{},
+		CreatedAt:         changed,
+		UpdatedAt:         changed,
+	}))
+}
+
+// TestRunStalledSweep_KeepsChildrenOfLiveParents covers the nested-saga hole,
+// which is retention's hole pointing the other way. A parent resumes by
+// re-finding its children rather than re-running them, so failing a child under
+// a live parent fails the parent for a reason that was never true.
+func TestRunStalledSweep_KeepsChildrenOfLiveParents(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := backend.make(t)
+
+			saveAged(t, storage, "live-parent", StatusRunning, 1*time.Hour)
+			saveStalledChild(t, storage, "child-of-live", "live-parent", 30*24*time.Hour)
+
+			saveAged(t, storage, "done-parent", StatusCompleted, 30*24*time.Hour)
+			saveStalledChild(t, storage, "child-of-done", "done-parent", 30*24*time.Hour)
+
+			saveStalledChild(t, storage, "child-of-ghost", "never-existed", 30*24*time.Hour)
+
+			result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
+
+			assert.Equal(t, StatusPending, statusOf(t, storage, "child-of-live"),
+				"a child must outlive a parent that can still re-find it")
+			assert.Equal(t, 1, result.Skipped, "holding a child back must be reported, not silent")
+
+			assert.Equal(t, StatusFailed, statusOf(t, storage, "child-of-done"),
+				"a terminal parent will never resume, so its stranded child is nobody's work")
+			assert.Equal(t, StatusFailed, statusOf(t, storage, "child-of-ghost"),
+				"a child whose parent is gone has nothing left to re-find it")
+			assert.Equal(t, StatusRunning, statusOf(t, storage, "live-parent"),
+				"the live parent is inside the window and must not be touched")
+		})
+	}
+}
+
+// TestRunStalledSweep_ConvergesOnStrandedTrees is the case a liveness check
+// alone would deadlock on.
+//
+// "Live" means not terminal, so a stranded parent looks live to its own
+// children and shields them from the sweep that is about to deal with it. That
+// is the right answer for one pass and the wrong one forever, so the property
+// that matters is not that a tree goes in a single sweep but that it goes: the
+// parent is forced, which makes it terminal, which unshields the children on
+// the next pass. A tree converges in as many sweeps as it is deep.
+func TestRunStalledSweep_ConvergesOnStrandedTrees(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := backend.make(t)
+
+			saveAged(t, storage, "stranded-parent", StatusPending, 30*24*time.Hour)
+			saveStalledChild(t, storage, "stranded-child", "stranded-parent", 30*24*time.Hour)
+
+			result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.Forced)
+			assert.Equal(t, 1, result.Skipped)
+			assert.Equal(t, StatusFailed, statusOf(t, storage, "stranded-parent"))
+			assert.Equal(t, StatusPending, statusOf(t, storage, "stranded-child"),
+				"the child is shielded while its parent is still non-terminal")
+
+			result, err = RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.Forced)
+			assert.Zero(t, result.Skipped)
+			assert.Equal(t, StatusFailed, statusOf(t, storage, "stranded-child"),
+				"forcing the parent is what releases the child on the next pass")
+
+			result, err = RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
+			assert.Zero(t, result.Forced, "and then the tree is done")
+		})
+	}
+}
+
+// TestRunStalledSweep_CapsForces proves a large backlog drains over several
+// passes rather than one thundering herd of writes, and that hitting the cap is
+// reported rather than reading as a clean sweep.
+func TestRunStalledSweep_CapsForces(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := backend.make(t)
+
+			for _, id := range []string{"a", "b", "c", "d", "e"} {
+				saveAged(t, storage, id, StatusPending, 30*24*time.Hour)
+			}
+
+			cfg := StalledConfig{StaleAfter: 7 * 24 * time.Hour, MaxForces: 3}
+
+			result, err := RunStalledSweep(ctx, storage, cfg, testutils.TestLogger(t))
+			require.NoError(t, err)
+			assert.Equal(t, 3, result.Forced)
+			assert.True(t, result.Capped, "hitting the cap must be reported, not silently truncated")
+
+			result, err = RunStalledSweep(ctx, storage, cfg, testutils.TestLogger(t))
+			require.NoError(t, err)
+			assert.Equal(t, 2, result.Forced)
+			assert.False(t, result.Capped)
+
+			result, err = RunStalledSweep(ctx, storage, cfg, testutils.TestLogger(t))
+			require.NoError(t, err)
+			assert.Zero(t, result.Forced, "a converged store must be a no-op sweep")
+			assert.Zero(t, result.Scanned, "and there is nothing in flight left to scan")
+		})
+	}
+}
+
+// TestRunStalledSweep_ExactlyMaxForcesIsNotCapped pins the boundary, for the
+// same reason retention pins it: reporting a converged sweep as capped tells an
+// operator a backlog remains on a store that has none.
+func TestRunStalledSweep_ExactlyMaxForcesIsNotCapped(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := backend.make(t)
+
+			for _, id := range []string{"a", "b", "c"} {
+				saveAged(t, storage, id, StatusPending, 30*24*time.Hour)
+			}
+
+			result, err := RunStalledSweep(ctx, storage,
+				StalledConfig{StaleAfter: 7 * 24 * time.Hour, MaxForces: 3},
+				testutils.TestLogger(t))
+			require.NoError(t, err)
+
+			assert.Equal(t, 3, result.Forced)
+			assert.False(t, result.Capped,
+				"consuming the budget on the final execution left nothing uninspected")
+		})
+	}
+}
+
+// TestRunStalledSweep_ZeroStaleAfterForcesNothing is the escape hatch: an
+// operator who wants in-flight sagas left exactly as they are during an
+// investigation sets the window to zero.
+func TestRunStalledSweep_ZeroStaleAfterForcesNothing(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := backend.make(t)
+
+			saveAged(t, storage, "ancient", StatusPending, 90*24*time.Hour)
+
+			result, err := RunStalledSweep(ctx, storage, StalledConfig{StaleAfter: 0}, testutils.TestLogger(t))
+			require.NoError(t, err)
+
+			assert.Zero(t, result.Forced)
+			assert.Zero(t, result.Scanned, "a disabled sweep must not read the store at all")
+			assert.Equal(t, StatusPending, statusOf(t, storage, "ancient"))
+		})
+	}
+}
+
+// resumeOnGetStorage revives an execution the moment the sweep re-reads it,
+// standing in for a runner that picked the saga back up between the page and
+// the write.
+type resumeOnGetStorage struct {
+	Storage
+	reviveID string
+	status   Status
+}
+
+func (r *resumeOnGetStorage) Get(ctx context.Context, id string) (*Execution, error) {
+	exec, err := r.Storage.Get(ctx, id)
+	if err != nil || id != r.reviveID {
+		return exec, err
+	}
+
+	exec.Status = r.status
+	exec.UpdatedAt = time.Now()
+	if err := r.Save(ctx, exec); err != nil {
+		return nil, err
+	}
+	return exec, nil
+}
+
+// TestRunStalledSweep_RereadsBeforeForcing is the safety property that matters
+// most, and the one a summary read makes possible to get wrong.
+//
+// A page is a snapshot of an index. Between building it and reaching a given
+// execution, a runner may have resumed that saga, or it may have finished, or
+// it may be gone. Writing failed from the summary alone would take a saga that
+// had just started running again and declare it dead, which is the one way this
+// sweep could cause the damage it exists to clean up.
+func TestRunStalledSweep_RereadsBeforeForcing(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status Status
+	}{
+		{"resumed under us", StatusRunning},
+		{"finished under us", StatusCompleted},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := &resumeOnGetStorage{
+				Storage:  NewMemoryStorage(),
+				reviveID: "revived",
+				status:   tc.status,
+			}
+
+			saveAged(t, storage, "revived", StatusPending, 30*24*time.Hour)
+			saveAged(t, storage, "genuinely-stranded", StatusPending, 30*24*time.Hour)
+
+			result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
+
+			assert.Equal(t, 1, result.Recovered,
+				"an execution that moved on between the page and the write is counted, not forced")
+			assert.Equal(t, tc.status, statusOf(t, storage, "revived"))
+
+			assert.Equal(t, 1, result.Forced)
+			assert.Equal(t, StatusFailed, statusOf(t, storage, "genuinely-stranded"),
+				"one candidate turning out to be alive must not spare the rest")
+		})
+	}
+}
+
+// TestRunStalledSweep_DeletedUnderUsIsNotAnError keeps overlapping or retried
+// sweeps converging rather than erroring on work another pass already did.
+func TestRunStalledSweep_DeletedUnderUsIsNotAnError(t *testing.T) {
+	ctx := context.Background()
+	storage := &deleteOnGetStorage{Storage: NewMemoryStorage(), deleteID: "vanishing"}
+
+	saveAged(t, storage, "vanishing", StatusPending, 30*24*time.Hour)
+
+	result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+	require.NoError(t, err)
+
+	assert.Zero(t, result.Failed)
+	assert.Zero(t, result.Forced)
+	assert.Equal(t, 1, result.Recovered)
+}
+
+// deleteOnGetStorage removes an execution just as the sweep re-reads it.
+type deleteOnGetStorage struct {
+	Storage
+	deleteID string
+}
+
+func (d *deleteOnGetStorage) Get(ctx context.Context, id string) (*Execution, error) {
+	if id == d.deleteID {
+		if err := d.Delete(ctx, id); err != nil {
+			return nil, err
+		}
+	}
+	return d.Storage.Get(ctx, id)
+}
+
+// saveFailingStorage fails Save for one specific execution.
+type saveFailingStorage struct {
+	Storage
+	failID string
+}
+
+func (s *saveFailingStorage) Save(ctx context.Context, exec *Execution) error {
+	if exec.ID == s.failID && exec.Status == StatusFailed {
+		return errors.New("simulated save failure")
+	}
+	return s.Storage.Save(ctx, exec)
+}
+
+// TestRunStalledSweep_SaveFailureDoesNotAbortSweep pins the best-effort
+// behavior. Without it, a single execution the store will not accept a write
+// for would wedge the sweep for the whole cluster.
+func TestRunStalledSweep_SaveFailureDoesNotAbortSweep(t *testing.T) {
+	ctx := context.Background()
+	storage := &saveFailingStorage{Storage: NewMemoryStorage(), failID: "stubborn"}
+
+	for _, id := range []string{"first", "stubborn", "last"} {
+		saveAged(t, storage, id, StatusPending, 30*24*time.Hour)
+	}
+
+	result, err := RunStalledSweep(ctx, storage, weekStalled(), testutils.TestLogger(t))
+	require.NoError(t, err, "a save failure must not fail the sweep")
+
+	assert.Equal(t, 1, result.Failed)
+	assert.Equal(t, 2, result.Forced, "the other stranded executions must still be forced")
+	assert.Equal(t, StatusPending, statusOf(t, storage, "stubborn"))
+	assert.Equal(t, StatusFailed, statusOf(t, storage, "first"))
+	assert.Equal(t, StatusFailed, statusOf(t, storage, "last"))
+}
+
+// TestStalledSweep_LegacyExecutionsUseStoreTimestamp is the upgrade path, and
+// the reason the sweep reads summaries rather than executions.
+//
+// The executions this sweep exists to drain were written by v0.11.1, whose saga
+// schema had no created_at or updated_at fields at all. Every one of them reads
+// back with a zero saga timestamp, so an age taken from the execution alone
+// would call the whole population infinitely old and force it on sight,
+// including whatever a runner on the old binary started seconds before the
+// upgrade. The entity-backed stores fall back to the store's own timestamp,
+// which is a real measurement of a real record.
+//
+// Deliberately not part of the conformance suite: MemoryStorage has no second
+// timestamp to fall back to, and the whole point is that the entity backends
+// do.
+func TestStalledSweep_LegacyExecutionsUseStoreTimestamp(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	for _, tc := range []struct {
+		name    string
+		storage Storage
+	}{
+		{"EntityStorage", NewEntityStorage(inmem.Store, testutils.TestLogger(t))},
+		{"EACStorage", NewEACStorage(inmem.EAC, testutils.TestLogger(t))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A saga saved with no timestamps at all, exactly as v0.11.1 wrote
+			// it, and still in flight right now.
+			id := "legacy-just-started-" + tc.name
+			require.NoError(t, tc.storage.Save(ctx, &Execution{
+				ID:              id,
+				DefinitionName:  "create-sandbox",
+				Status:          StatusPending,
+				InitialInputs:   map[string]any{},
+				ExecutedActions: map[string]*ActionResult{},
+				ExecutionOrder:  []string{},
+			}))
+
+			summaries, err := collectIncompleteSummaries(ctx, tc.storage)
+			require.NoError(t, err)
+
+			var found *IncompleteSummary
+			for i := range summaries {
+				if summaries[i].ID == id {
+					found = &summaries[i]
+					break
+				}
+			}
+			require.NotNil(t, found, "the legacy execution must be summarized, not dropped for lacking a timestamp")
+			assert.False(t, found.LastChanged.IsZero(),
+				"the store timestamp should have supplied an age")
+
+			result, err := RunStalledSweep(ctx, tc.storage, weekStalled(), testutils.TestLogger(t))
+			require.NoError(t, err)
+			assert.Zero(t, result.Forced,
+				"a legacy saga the store stamped just now must not be treated as infinitely old")
+			assert.Equal(t, StatusPending, statusOf(t, tc.storage, id))
+		})
+	}
+}

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
 	"miren.dev/runtime/pkg/cond"
@@ -190,6 +191,62 @@ func (s *EntityStorage) decodeIncomplete(entities []*entity.Entity) ([]*Executio
 	return executions, stale
 }
 
+// ListIncompleteSummaryPage summarizes one bounded page of in-flight
+// executions.
+//
+// It walks the same three status indexes ListIncompletePage does, in the same
+// order and with the same cursor encoding, and differs only in keeping a
+// summary instead of a whole execution. The sweep that reads this is looking
+// for records nothing will ever resume, which by definition means walking every
+// in-flight execution in the cluster, and doing that with full payloads would
+// cost what recovery costs without recovering anything.
+func (s *EntityStorage) ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	stage, inner, err := decodeStageCursor(q.Cursor, len(incompleteStatuses))
+	if err != nil {
+		return nil, err
+	}
+
+	attr := entity.Ref(saga_v1alpha.SagaStatusId, incompleteStatuses[stage])
+
+	page, err := s.store.ListIndexEntitiesPage(ctx, attr, inner, int64(clampLimit(q.Limit)))
+	if err != nil {
+		return nil, fmt.Errorf("listing sagas with status %s: %w", incompleteStatuses[stage], err)
+	}
+
+	next := nextStageCursor(stage, page.Cursor, len(incompleteStatuses))
+
+	if len(page.Entities) == 0 {
+		return &IncompleteSummaryPage{Cursor: next}, nil
+	}
+
+	var result []IncompleteSummary
+	var staleTerminal int
+
+	for _, ent := range page.Entities {
+		if ent == nil {
+			// Deleted between the listing and the fetch. Nothing to summarize.
+			continue
+		}
+		summary, verdict := incompleteSummary(ent)
+		switch verdict {
+		case summaryOK:
+			result = append(result, summary)
+		case summaryWrongStatus:
+			staleTerminal++
+		case summaryNoTimestamp:
+			s.log.Warn("in-flight saga has no usable timestamp, skipping", "id", ent.Id())
+		}
+	}
+
+	logStaleIncomplete(s.log, staleTerminal)
+
+	return &IncompleteSummaryPage{Executions: result, Cursor: next}, nil
+}
+
 // ListTerminalPage summarizes one bounded page of finished executions.
 //
 // The store's index lookups are equality-only, so there is no range query over
@@ -231,7 +288,7 @@ func (s *EntityStorage) ListTerminalPage(ctx context.Context, q TerminalQuery) (
 		switch verdict {
 		case summaryOK:
 			result = append(result, summary)
-		case summaryNotTerminal:
+		case summaryWrongStatus:
 			staleNonTerminal++
 		case summaryNoTimestamp:
 			s.log.Warn("terminal saga has no usable timestamp, skipping", "id", ent.Id())
@@ -254,55 +311,94 @@ func (s *EntityStorage) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-// summaryVerdict says why terminalSummary rejected an entity. The two reasons
+// summaryVerdict says why a summary read rejected an entity. The two reasons
 // want different handling: stale index entries arrive in bulk, while a missing
 // timestamp is a one-off worth naming the entity for.
 type summaryVerdict int
 
 const (
 	summaryOK summaryVerdict = iota
-	// summaryNotTerminal means the decoded status is not terminal, so the index
-	// entry that produced this entity is stale.
-	summaryNotTerminal
-	// summaryNoTimestamp means the entity carries no usable finish time.
+	// summaryWrongStatus means the decoded status is not the kind of status the
+	// index that produced this entity is for, so that entry is stale. Both
+	// directions land here: a terminal execution under a pending index, and a
+	// running one under a completed index.
+	summaryWrongStatus
+	// summaryNoTimestamp means the entity carries no usable timestamp.
 	summaryNoTimestamp
 )
+
+// lastChanged resolves when an execution last changed state.
+//
+// It prefers the saga's own updated_at and falls back to the entity store's
+// system timestamps, which is what makes both sweeps safe across an upgrade.
+// v0.11.1's saga schema had no created_at or updated_at at all, so every
+// execution written by it reads back with a zero saga timestamp. Treating that
+// as infinitely old would let retention delete a saga a runner on the old
+// binary finished seconds ago, and would let the stalled sweep force one that
+// is actively running.
+//
+// The false return is deliberately not a "just use now": an execution we cannot
+// date is one we must not act on, and the callers skip it and say so.
+func lastChanged(ent *entity.Entity, s *saga_v1alpha.Saga) (time.Time, bool) {
+	switch {
+	case !s.UpdatedAt.IsZero():
+		return s.UpdatedAt, true
+	case !ent.GetUpdatedAt().IsZero():
+		return ent.GetUpdatedAt(), true
+	case !ent.GetCreatedAt().IsZero():
+		return ent.GetCreatedAt(), true
+	default:
+		return time.Time{}, false
+	}
+}
 
 // terminalSummary reduces a saga entity to what retention needs.
 //
 // The status index is a hint, not the truth: an entry can outlive the status it
 // was written for, so the decoded status decides whether this is terminal.
-//
-// The finish time prefers the saga's own updated_at but falls back to the
-// entity store's system timestamp, which is what makes retention safe across an
-// upgrade: every execution written before saga timestamps were persisted reads
-// back with a zero updated_at, and treating that as infinitely old would delete
-// a saga a runner on the old binary finished seconds ago.
 func terminalSummary(ent *entity.Entity) (TerminalExecution, summaryVerdict) {
 	var s saga_v1alpha.Saga
 	s.Decode(ent)
 
 	if !isTerminal(statusFromEntity(s.Status)) {
-		return TerminalExecution{}, summaryNotTerminal
+		return TerminalExecution{}, summaryWrongStatus
 	}
 
-	summary := TerminalExecution{
-		ID:       string(ent.Id()),
-		ParentID: string(s.ParentExecutionId),
-	}
-
-	switch {
-	case !s.UpdatedAt.IsZero():
-		summary.FinishedAt = s.UpdatedAt
-	case !ent.GetUpdatedAt().IsZero():
-		summary.FinishedAt = ent.GetUpdatedAt()
-	case !ent.GetCreatedAt().IsZero():
-		summary.FinishedAt = ent.GetCreatedAt()
-	default:
+	finished, ok := lastChanged(ent, &s)
+	if !ok {
 		return TerminalExecution{}, summaryNoTimestamp
 	}
 
-	return summary, summaryOK
+	return TerminalExecution{
+		ID:         string(ent.Id()),
+		ParentID:   string(s.ParentExecutionId),
+		FinishedAt: finished,
+	}, summaryOK
+}
+
+// incompleteSummary reduces a saga entity to what the stalled sweep needs, and
+// is terminalSummary's mirror image in every respect including which way it
+// distrusts the index.
+func incompleteSummary(ent *entity.Entity) (IncompleteSummary, summaryVerdict) {
+	var s saga_v1alpha.Saga
+	s.Decode(ent)
+
+	status := statusFromEntity(s.Status)
+	if isTerminal(status) {
+		return IncompleteSummary{}, summaryWrongStatus
+	}
+
+	changed, ok := lastChanged(ent, &s)
+	if !ok {
+		return IncompleteSummary{}, summaryNoTimestamp
+	}
+
+	return IncompleteSummary{
+		ID:          string(ent.Id()),
+		Status:      status,
+		ParentID:    string(s.ParentExecutionId),
+		LastChanged: changed,
+	}, summaryOK
 }
 
 // isTerminal reports whether a status is one of the two finished states.

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -194,12 +194,10 @@ func (s *EntityStorage) decodeIncomplete(entities []*entity.Entity) ([]*Executio
 // ListIncompleteSummaryPage summarizes one bounded page of in-flight
 // executions.
 //
-// It walks the same three status indexes ListIncompletePage does, in the same
-// order and with the same cursor encoding, and differs only in keeping a
-// summary instead of a whole execution. The sweep that reads this is looking
-// for records nothing will ever resume, which by definition means walking every
-// in-flight execution in the cluster, and doing that with full payloads would
-// cost what recovery costs without recovering anything.
+// Same indexes and cursor encoding as ListIncompletePage, keeping a summary
+// rather than a whole execution. Its caller walks every in-flight execution in
+// the cluster, and doing that with full payloads would cost what recovery costs
+// without recovering anything.
 func (s *EntityStorage) ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -300,6 +298,68 @@ func (s *EntityStorage) ListTerminalPage(ctx context.Context, q TerminalQuery) (
 	return &TerminalPage{Executions: result, Cursor: next}, nil
 }
 
+// ForceFailed transitions an in-flight execution to failed, and reports whether
+// it did.
+//
+// The decision lives here rather than in the caller because the write has to be
+// conditional on the read it was made against, and only this layer sees the
+// revision. A caller that read, decided, then asked us to save could overwrite
+// a runner that resumed the saga in the gap, replacing its status and action
+// outputs with a stale copy marked failed.
+//
+// So the transition is refused, without error, whenever the record moved: gone,
+// already terminal, touched since cutoff, or a changed revision. Each means
+// something else is dealing with it, and the next pass looks again.
+//
+// The age test goes through lastChanged rather than the execution's updated_at,
+// because a record written before v0.14.0 carries its age only on the entity.
+func (s *EntityStorage) ForceFailed(ctx context.Context, id string, cutoff time.Time, reason string) (bool, error) {
+	ent, err := s.store.GetEntity(ctx, entity.Id(id))
+	if err != nil {
+		if errors.Is(err, entity.ErrEntityNotFound) || errors.Is(err, cond.ErrNotFound{}) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getting saga entity: %w", err)
+	}
+
+	sagaEntity, ok := entity.As[saga_v1alpha.Saga](ent)
+	if !ok {
+		return false, fmt.Errorf("entity %s is not a saga", id)
+	}
+
+	if isTerminal(statusFromEntity(sagaEntity.Status)) {
+		return false, nil
+	}
+
+	changed, ok := lastChanged(ent, sagaEntity)
+	if !ok || changed.After(cutoff) {
+		return false, nil
+	}
+
+	exec, err := entityToExecution(sagaEntity)
+	if err != nil {
+		return false, fmt.Errorf("decoding execution %q: %w", id, err)
+	}
+
+	exec.Status = StatusFailed
+	exec.Error = reason
+	exec.UpdatedAt = time.Now()
+
+	forced, err := executionToEntity(exec)
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := s.store.ReplaceEntity(ctx, forced, entity.WithFromRevision(ent.GetRevision())); err != nil {
+		if errors.Is(err, cond.ErrConflict{}) {
+			return false, nil
+		}
+		return false, fmt.Errorf("forcing execution %q to failed: %w", id, err)
+	}
+
+	return true, nil
+}
+
 // Delete removes a saga execution entity.
 func (s *EntityStorage) Delete(ctx context.Context, id string) error {
 	if err := s.store.DeleteEntity(ctx, entity.Id(id)); err != nil {
@@ -330,15 +390,13 @@ const (
 // lastChanged resolves when an execution last changed state.
 //
 // It prefers the saga's own updated_at and falls back to the entity store's
-// system timestamps, which is what makes both sweeps safe across an upgrade.
-// v0.11.1's saga schema had no created_at or updated_at at all, so every
-// execution written by it reads back with a zero saga timestamp. Treating that
-// as infinitely old would let retention delete a saga a runner on the old
-// binary finished seconds ago, and would let the stalled sweep force one that
-// is actively running.
+// system timestamps, which is what makes both sweeps safe across an upgrade:
+// v0.11.1's schema had neither field, so its executions read back with a zero
+// saga timestamp, and treating that as infinitely old would collect a saga
+// finished seconds ago or force one that is actively running.
 //
-// The false return is deliberately not a "just use now": an execution we cannot
-// date is one we must not act on, and the callers skip it and say so.
+// The false return is not a "just use now". An execution we cannot date is one
+// we must not act on, and both callers skip it and say so.
 func lastChanged(ent *entity.Entity, s *saga_v1alpha.Saga) (time.Time, bool) {
 	switch {
 	case !s.UpdatedAt.IsZero():

--- a/pkg/saga/storage_conformance_test.go
+++ b/pkg/saga/storage_conformance_test.go
@@ -381,6 +381,23 @@ func collectIncomplete(ctx context.Context, s Storage) ([]*Execution, error) {
 	return nil, fmt.Errorf("incomplete walk did not terminate")
 }
 
+func collectIncompleteSummaries(ctx context.Context, s Storage) ([]IncompleteSummary, error) {
+	var all []IncompleteSummary
+	cursor := ""
+	for range 1000 {
+		page, err := s.ListIncompleteSummaryPage(ctx, IncompleteSummaryQuery{Cursor: cursor})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page.Executions...)
+		cursor = page.Cursor
+		if cursor == "" {
+			return all, nil
+		}
+	}
+	return nil, fmt.Errorf("incomplete summary walk did not terminate")
+}
+
 func collectTerminal(ctx context.Context, s Storage) ([]TerminalExecution, error) {
 	var all []TerminalExecution
 	cursor := ""
@@ -453,6 +470,42 @@ func TestStorageConformance_Paging(t *testing.T) {
 				assert.Equal(t, "", cursor, "the walk must terminate")
 				assert.Equal(t, want, seen, "the pages together must cover the set")
 				assert.Greater(t, pages, 1, "15 executions at 2 per page must take more than one page")
+			})
+
+			t.Run("covers the incomplete summary set exactly once across pages", func(t *testing.T) {
+				storage := backend.make(t)
+
+				want := map[string]bool{}
+				for i := range 5 {
+					for _, status := range []Status{StatusPending, StatusRunning, StatusUndoing} {
+						id := fmt.Sprintf("page-%s-%02d", status, i)
+						saveWithStatus(t, storage, id, status)
+						want[id] = true
+					}
+				}
+
+				seen := map[string]bool{}
+				cursor := ""
+
+				for range 100 {
+					page, err := storage.ListIncompleteSummaryPage(ctx, IncompleteSummaryQuery{Cursor: cursor, Limit: 2})
+					require.NoError(t, err)
+					require.LessOrEqual(t, len(page.Executions), 2,
+						"a page must never exceed the limit it was given")
+
+					for _, summary := range page.Executions {
+						require.False(t, seen[summary.ID], "paging returned %s twice", summary.ID)
+						seen[summary.ID] = true
+					}
+
+					cursor = page.Cursor
+					if cursor == "" {
+						break
+					}
+				}
+
+				assert.Equal(t, "", cursor, "the walk must terminate")
+				assert.Equal(t, want, seen, "the pages together must cover the set")
 			})
 
 			t.Run("covers the terminal set exactly once across pages", func(t *testing.T) {
@@ -667,4 +720,63 @@ func TestStorageConformance_PagingPastStaleEntries(t *testing.T) {
 				"a page that resolved to nothing must not end the walk of its index")
 		})
 	}
+}
+
+// TestStorageConformance_IncompleteSummaryAgreesWithIncompleteList pins the two
+// in-flight reads to the same set.
+//
+// They exist for different callers and return different shapes, which is
+// exactly how they could drift: a status added to one list and not the other
+// would leave the stalled sweep blind to a whole class of execution while
+// recovery kept resuming it, and nothing would fail.
+func TestStorageConformance_IncompleteSummaryAgreesWithIncompleteList(t *testing.T) {
+	for _, backend := range allStorageBackends() {
+		t.Run(backend.name, func(t *testing.T) {
+			ctx := context.Background()
+			storage := backend.make(t)
+
+			for _, status := range []Status{StatusPending, StatusRunning, StatusUndoing, StatusCompleted, StatusFailed} {
+				saveWithStatus(t, storage, "agree-"+string(status), status)
+			}
+
+			executions, err := collectIncomplete(ctx, storage)
+			require.NoError(t, err)
+			summaries, err := collectIncompleteSummaries(ctx, storage)
+			require.NoError(t, err)
+
+			fromExecutions := map[string]Status{}
+			for _, exec := range executions {
+				fromExecutions[exec.ID] = exec.Status
+			}
+			fromSummaries := map[string]Status{}
+			for _, summary := range summaries {
+				fromSummaries[summary.ID] = summary.Status
+				assert.False(t, summary.LastChanged.IsZero(),
+					"a summary the sweep will act on must carry a timestamp")
+			}
+
+			assert.Equal(t, fromExecutions, fromSummaries,
+				"both in-flight reads must see the same executions in the same states")
+			assert.Len(t, fromSummaries, 3, "the three in-flight statuses, and only those")
+		})
+	}
+}
+
+// TestStorageConformance_IncompleteSummaryIgnoresStaleIndex is the same guard
+// ListIncompletePage has, with a different consequence: the stalled sweep
+// writes to what this returns, so trusting a stale pending entry would mean
+// re-failing an execution that already finished.
+func TestStorageConformance_IncompleteSummaryIgnoresStaleIndex(t *testing.T) {
+	runIndexBackedConformance(t, func(t *testing.T, storage Storage, store *entity.MockStore) {
+		ctx := context.Background()
+
+		saveAged(t, storage, "teardown-postgres", StatusCompleted, time.Hour)
+		seedStaleStatusIndex(t, store, "teardown-postgres", StatusPending)
+		seedStaleStatusIndex(t, store, "teardown-postgres", StatusRunning)
+
+		summaries, err := collectIncompleteSummaries(ctx, storage)
+		require.NoError(t, err)
+		assert.Empty(t, summaries,
+			"a completed execution must not be offered to the stalled sweep because stale in-flight index entries survived")
+	})
 }

--- a/pkg/saga/storage_conformance_test.go
+++ b/pkg/saga/storage_conformance_test.go
@@ -381,7 +381,13 @@ func collectIncomplete(ctx context.Context, s Storage) ([]*Execution, error) {
 	return nil, fmt.Errorf("incomplete walk did not terminate")
 }
 
-func collectIncompleteSummaries(ctx context.Context, s Storage) ([]IncompleteSummary, error) {
+// summaryLister is all the summary walk needs, so both the full Storage and the
+// narrower StalledStorage can be walked with it.
+type summaryLister interface {
+	ListIncompleteSummaryPage(ctx context.Context, q IncompleteSummaryQuery) (*IncompleteSummaryPage, error)
+}
+
+func collectIncompleteSummaries(ctx context.Context, s summaryLister) ([]IncompleteSummary, error) {
 	var all []IncompleteSummary
 	cursor := ""
 	for range 1000 {

--- a/pkg/saga/types.go
+++ b/pkg/saga/types.go
@@ -163,3 +163,51 @@ type TerminalPage struct {
 	// ending, only an empty cursor is.
 	Cursor string
 }
+
+// IncompleteSummary summarizes an execution that is still in flight: which one,
+// what it is doing, when it last changed, and whose child it is.
+//
+// Separate from Execution because the stalled sweep walks the whole in-flight
+// set to ask one question about each. Materializing every action-output blob in
+// a six-figure backlog to read a timestamp is the unbounded read MIR-1785
+// removed, reintroduced for a worse reason.
+type IncompleteSummary struct {
+	// ID identifies the execution.
+	ID string
+
+	// Status is the decoded status, not the index the entry came from.
+	Status Status
+
+	// LastChanged is when the execution last changed state, resolved by
+	// lastChanged. The fallback matters more here than it does for retention:
+	// v0.11.1's saga schema had no updated_at at all, so the records this sweep
+	// exists to drain would otherwise all read as infinitely old.
+	LastChanged time.Time
+
+	// ParentID is set when this execution ran as a nested child, and matters
+	// for the same reason it does to retention: a live parent re-finds its
+	// child rather than re-running it.
+	ParentID string
+}
+
+// IncompleteSummaryQuery selects one page of in-flight execution summaries.
+type IncompleteSummaryQuery struct {
+	// Cursor resumes after the last execution of a previous page. Empty starts
+	// at the beginning.
+	Cursor string
+
+	// Limit caps how many executions the page summarizes. Zero or less means
+	// the backend's own cap.
+	Limit int
+}
+
+// IncompleteSummaryPage is one bounded page of in-flight execution summaries.
+type IncompleteSummaryPage struct {
+	// Executions summarizes the in-flight executions in this page.
+	Executions []IncompleteSummary
+
+	// Cursor resumes the walk after this page, empty once the walk is done.
+	// The same caveat as IncompletePage.Cursor applies: a short page is not an
+	// ending, only an empty cursor is.
+	Cursor string
+}


### PR DESCRIPTION
Some saga executions get stuck where nothing will ever finish them and nothing will ever delete them. A retry finds its earlier attempt by name, so one with a generated name has nobody left who can name it again. And retention only deletes executions that have finished, because one still in progress is exactly what crash recovery goes looking for. The record stays in the store forever, and every recovery pass pays to read it. One pre-upgrade snapshot has about 19,964 of them for a single addon association. Nothing new is piling up, since convergent IDs shipped in v0.14.0, so this is about clearing out what older versions left behind and it can afford to be slow and careful.

Rather than delete these, the sweep marks them failed. That hands them back to rules we already have, and it works whichever kind of record it hits: one named after its entity gets cleared and retried on the next reconcile, and one with a generated name gets deleted by ordinary retention a week later. Marking also leaves a week where someone can still look at what got cleared and why.

To decide what is stuck, we ask how long an execution has gone without changing. Every step writes a timestamp, so anything actually running stays well clear of a seven-day window. The catch is that v0.11.1's saga schema had no timestamp fields at all, so the very records we are clearing read back with nothing. That is what the first rev is for: a summary read of the in-progress set that keeps the entity store's own timestamps, which get dropped when you decode into an `Execution`.

No new config. Setting `saga.retention_period` to 0 already means leave saga records alone while I investigate, and it now stops both sweeps instead of just the deleting half.

Closes MIR-1788

https://claude.ai/code/session_01SZsBA225fbbLveUiDGmn1W
