### PR TITLE
Bound HTTP metrics cardinality without corrupting TopPaths

### DIFF
--- a/metrics/http.go
+++ b/metrics/http.go
@@ -1,15 +1,70 @@
 package metrics
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/oklog/ulid/v2"
+)
+
+// Cardinality bounds for the counter map. Both path and method come from the
+// client, so without a cap the map grows for as long as the process runs: a
+// 0.14.0 heap dump had it holding ~780k keys and 83MB, 70% of the live heap.
+const (
+	// maxPathBoundCounters is how many counters carrying a real path and method
+	// are kept. Everything else folds into the overflow entries.
+	//
+	// This is one budget shared by every app on the node, not a per-app
+	// allowance, so it has to cover the busy routes of all of them at once.
+	// Each entry is one path -- statuses and durations live inside it -- and
+	// costs roughly 3KB, most of that the per-minute ring TopPaths reads, so
+	// the whole table is a few hundred KB against the 83MB it replaces.
+	maxPathBoundCounters = 100
+
+	// maxCandidates bounds the side table that spots an untracked key busier
+	// than one already tracked. Once full it stops accepting new keys until the
+	// next window, but keeps counting the ones it already holds.
+	maxCandidates = 100
+
+	// promotionWindow is how many counter touches pass between promotion
+	// passes. Deliberately a measure of traffic and not of distinct keys: tying
+	// it to cardinality lets a client walking unique URLs close windows as fast
+	// as it likes, and since every window decays the tracked hits, that drives
+	// every real path to zero and hands all 25 slots to the scan.
+	promotionWindow = 10_000
+
+	// minPromotionHits is the floor a candidate has to clear before it can take
+	// a slot, however quiet the slot's current occupant is. A scan sees each URL
+	// once; real traffic repeats. Without this, once decay drives the weakest
+	// tracked entry to zero, any one-hit URL outranks it.
+	minPromotionHits = 8
+
+	// overflowLabel stands in for the path and method of untracked traffic.
+	// That traffic is still counted, just not per path. The labels left on an
+	// overflow entry are app and status, neither of which the client chooses,
+	// so these entries are bounded without needing a cap of their own.
+	overflowLabel = "other"
+
+	// maxKeyPathBytes truncates the path before it reaches a key or a label.
+	// The cap above counts entries, but a key embeds the path verbatim and the
+	// ingress leaves MaxHeaderBytes at Go's 1MB default, so 100 candidates
+	// holding megabyte paths is ~100MB -- the same order as the leak this file
+	// exists to bound. Counting entries only bounds memory if an entry has a
+	// bounded size.
+	maxKeyPathBytes = 256
+
+	// recentMinutes is the span TopPaths reports over, kept as a ring of
+	// per-minute buckets. It matches the [1h] the VictoriaMetrics query it
+	// replaced used, so `miren app status` keeps meaning "busiest in the last
+	// hour" rather than "busiest since this process started".
+	recentMinutes = 60
 )
 
 // HTTPMetrics tracks HTTP request metrics for applications using VictoriaMetrics
@@ -18,15 +73,106 @@ type HTTPMetrics struct {
 	Writer *VictoriaMetricsWriter
 	Reader *VictoriaMetricsReader
 
-	mu       sync.Mutex
-	counters map[string]*counterState
+	mu sync.Mutex
+	// counters holds at most maxPathBoundCounters entries carrying a real path,
+	// plus the overflow entries everything else accumulates into.
+	counters  map[string]*counterState
+	pathBound int
+	// candidates counts hits for keys that missed the cap, so a path that turns
+	// busy can take a slot from one that has gone quiet.
+	candidates map[string]uint64
+	// touches counts counter lookups, and closes a promotion window every
+	// promotionWindow of them.
+	touches  uint64
 	instance string
+
+	// now is time.Now in production; tests set it to drive the rolling window.
+	now func() time.Time
 }
 
+// counterState is everything known about one app/method/path. Statuses and
+// durations live together deliberately: when they were separate map entries
+// they were admitted and evicted independently, so a path could keep its 200
+// counter while its 500 counter fell into the overflow bucket. TopPaths then
+// reported that path's error rate as zero -- and since error statuses are rarer
+// than successes, they were the weakest entries and the first evicted, which
+// meant the paths that had errors were exactly the ones whose errors vanished.
 type counterState struct {
-	requestCount  float64
+	// app, method and path are held rather than parsed back out of the map key,
+	// so TopPaths can report without splitting strings.
+	app    string
+	method string
+	path   string
+
+	// requests is the cumulative count per status, one exported series each.
+	requests      map[string]float64
 	durationSum   float64
 	durationCount float64
+
+	// recent is a ring of per-minute buckets covering recentMinutes, which is
+	// what TopPaths reads. The cumulative fields above stay monotonic for
+	// VictoriaMetrics; these expire.
+	recent [recentMinutes]minuteBucket
+
+	// hits ranks entries for eviction. It counts every touch rather than any
+	// one reported value, and is halved each promotion window so a path that
+	// was busy once cannot hold a slot forever.
+	hits uint64
+
+	// pathBound marks the entries the cap applies to. Overflow entries are
+	// exempt: they are the sink untracked traffic lands in.
+	pathBound bool
+}
+
+// minuteBucket is one minute of the rolling window. minute records which
+// absolute minute the bucket holds, so a stale bucket reads as empty instead of
+// as an hour-old count, and gaps in traffic need no sweeping.
+type minuteBucket struct {
+	minute        int64
+	count         int64
+	errors        int64
+	durationSum   float64
+	durationCount int64
+}
+
+// observe folds one request into both the cumulative totals and the rolling
+// window. Callers must hold h.mu.
+func (c *counterState) observe(status string, statusCode int, durationMs int64, now time.Time) {
+	if c.requests == nil {
+		c.requests = make(map[string]float64, 4)
+	}
+	c.requests[status]++
+
+	seconds := float64(durationMs) / 1000.0
+	c.durationSum += seconds
+	c.durationCount++
+
+	minute := now.Unix() / 60
+	b := &c.recent[minute%recentMinutes]
+	if b.minute != minute {
+		*b = minuteBucket{minute: minute}
+	}
+	b.count++
+	if statusCode >= 400 {
+		b.errors++
+	}
+	b.durationSum += seconds
+	b.durationCount++
+}
+
+// window sums the buckets still inside recentMinutes of now.
+func (c *counterState) window(now time.Time) minuteBucket {
+	oldest := now.Unix()/60 - recentMinutes + 1
+	var total minuteBucket
+	for i := range c.recent {
+		if b := c.recent[i]; b.minute >= oldest {
+			total.count += b.count
+			total.errors += b.errors
+			total.durationSum += b.durationSum
+			total.durationCount += b.durationCount
+		}
+	}
+	return total
 }
 
 // NewHTTPMetrics creates a new HTTPMetrics with the given dependencies.
@@ -43,6 +189,8 @@ func (h *HTTPMetrics) Setup() error {
 	// For VictoriaMetrics, we don't need to create tables/schemas
 	// The metrics are created dynamically when first written
 	h.counters = make(map[string]*counterState)
+	h.pathBound = 0
+	h.candidates = make(map[string]uint64, maxCandidates)
 
 	// Generate unique instance ID using ULID
 	h.instance = ulid.MustNew(ulid.Now(), rand.Reader).String()
@@ -62,15 +210,19 @@ type HTTPRequest struct {
 	ResponseSize int64
 }
 
-// RecordRequest records an HTTP request as metrics in VictoriaMetrics
+// RecordRequest records an HTTP request as metrics in VictoriaMetrics.
+//
+// Only maxPathBoundCounters counters are kept for real paths. Anything beyond
+// that is still counted, but reported with path and method "other", so an app
+// serving unique URLs -- or a client walking random ones -- costs a fixed
+// amount of memory here and a fixed number of series downstream.
 func (h *HTTPMetrics) RecordRequest(ctx context.Context, req HTTPRequest) error {
 	if h == nil || h.Writer == nil {
 		return nil
 	}
 
-	// Create keys for counter lookups
-	requestKey := fmt.Sprintf("%s:%s:%s:%d", req.App, req.Method, req.Path, req.StatusCode)
-	durationKey := fmt.Sprintf("%s:%s:%s", req.App, req.Method, req.Path)
+	status := strconv.Itoa(req.StatusCode)
+	method, path := req.Method, truncatePath(req.Path)
 
 	h.mu.Lock()
 
@@ -78,27 +230,27 @@ func (h *HTTPMetrics) RecordRequest(ctx context.Context, req HTTPRequest) error 
 		h.counters = make(map[string]*counterState)
 	}
 
-	// Get or create request counter
-	reqCounter, ok := h.counters[requestKey]
-	if !ok {
-		reqCounter = &counterState{}
-		h.counters[requestKey] = reqCounter
+	// One entry per path now, so a request either gets tracked with everything
+	// it carries or with nothing. Labels follow whichever counter it landed in,
+	// or the exported series would name a path the memory bound just refused.
+	c, tracked := h.trackCounter(counterKey(req.App, method, path))
+	if !tracked {
+		method, path = overflowLabel, overflowLabel
+		c = h.overflowCounter(counterKey(req.App, method, path))
 	}
-	reqCounter.requestCount++
-	requestCount := reqCounter.requestCount
+	if c.app == "" {
+		c.app, c.method, c.path = req.App, method, path
+	}
+	c.observe(status, req.StatusCode, req.DurationMs, h.clock())
 
-	// Get or create duration counter
-	durCounter, ok := h.counters[durationKey]
-	if !ok {
-		durCounter = &counterState{}
-		h.counters[durationKey] = durCounter
-	}
-	durCounter.durationSum += float64(req.DurationMs) / 1000.0 // Convert ms to seconds
-	durCounter.durationCount++
-	durationSum := durCounter.durationSum
-	durationCount := durCounter.durationCount
+	requestCount := c.requests[status]
+	durationSum := c.durationSum
+	durationCount := c.durationCount
 
 	h.mu.Unlock()
+
+	reqMethod, reqPath := method, path
+	durMethod, durPath := method, path
 
 	// Write cumulative counter values and individual duration sample
 	points := []MetricPoint{
@@ -106,9 +258,9 @@ func (h *HTTPMetrics) RecordRequest(ctx context.Context, req HTTPRequest) error 
 			Name: "http_requests_total",
 			Labels: map[string]string{
 				"app":      req.App,
-				"method":   req.Method,
-				"path":     req.Path,
-				"status":   strconv.Itoa(req.StatusCode),
+				"method":   reqMethod,
+				"path":     reqPath,
+				"status":   status,
 				"instance": h.instance,
 			},
 			Value:     requestCount,
@@ -118,8 +270,8 @@ func (h *HTTPMetrics) RecordRequest(ctx context.Context, req HTTPRequest) error 
 			Name: "http_request_duration_seconds_sum",
 			Labels: map[string]string{
 				"app":      req.App,
-				"method":   req.Method,
-				"path":     req.Path,
+				"method":   durMethod,
+				"path":     durPath,
 				"instance": h.instance,
 			},
 			Value:     durationSum,
@@ -129,8 +281,8 @@ func (h *HTTPMetrics) RecordRequest(ctx context.Context, req HTTPRequest) error 
 			Name: "http_request_duration_seconds_count",
 			Labels: map[string]string{
 				"app":      req.App,
-				"method":   req.Method,
-				"path":     req.Path,
+				"method":   durMethod,
+				"path":     durPath,
 				"instance": h.instance,
 			},
 			Value:     durationCount,
@@ -140,8 +292,8 @@ func (h *HTTPMetrics) RecordRequest(ctx context.Context, req HTTPRequest) error 
 			Name: "http_request_duration_seconds",
 			Labels: map[string]string{
 				"app":      req.App,
-				"method":   req.Method,
-				"path":     req.Path,
+				"method":   durMethod,
+				"path":     durPath,
 				"instance": h.instance,
 			},
 			Value:     float64(req.DurationMs) / 1000.0,
@@ -150,6 +302,148 @@ func (h *HTTPMetrics) RecordRequest(ctx context.Context, req HTTPRequest) error 
 	}
 
 	return h.Writer.WritePoints(ctx, points)
+}
+
+// counterKey identifies one app/method/path. The separator is NUL rather than
+// ":" because a path may contain a colon: with ":" the old request key for
+// ("/x", status 200) and duration key for path "/x:200" were the same string.
+func counterKey(app, method, path string) string {
+	return app + "\x00" + method + "\x00" + path
+}
+
+// truncatePath bounds the client-chosen part of a key. Truncating rather than
+// hashing keeps the label readable, and a path this long is already not a route
+// anyone is reading off a dashboard.
+func truncatePath(path string) string {
+	if len(path) <= maxKeyPathBytes {
+		return path
+	}
+	return path[:maxKeyPathBytes] + "..."
+}
+
+// clock is time.Now unless a test replaced it.
+func (h *HTTPMetrics) clock() time.Time {
+	if h.now != nil {
+		return h.now()
+	}
+	return time.Now()
+}
+
+// trackCounter returns the counter for key, admitting it while there is room
+// under the cap. When there is not, it records the key as a promotion candidate
+// and reports false, and the caller falls back to the overflow entry.
+//
+// Callers must hold h.mu.
+func (h *HTTPMetrics) trackCounter(key string) (*counterState, bool) {
+	h.touches++
+	if h.touches%promotionWindow == 0 {
+		h.promoteCandidate()
+	}
+
+	if c, ok := h.counters[key]; ok {
+		c.hits++
+		return c, true
+	}
+
+	if h.pathBound < maxPathBoundCounters {
+		c := &counterState{hits: 1, pathBound: true}
+		h.counters[key] = c
+		h.pathBound++
+		return c, true
+	}
+
+	h.noteCandidate(key)
+	return nil, false
+}
+
+// overflowCounter returns the entry untracked traffic accumulates into. These
+// are exempt from the cap because their labels carry no client input: how many
+// exist is decided by how many apps and status codes there are.
+//
+// Callers must hold h.mu.
+func (h *HTTPMetrics) overflowCounter(key string) *counterState {
+	c, ok := h.counters[key]
+	if !ok {
+		c = &counterState{}
+		h.counters[key] = c
+	}
+	return c
+}
+
+// noteCandidate counts a key that missed the cap, so promoteCandidate can see
+// which untracked path is actually busy. Callers must hold h.mu.
+func (h *HTTPMetrics) noteCandidate(key string) {
+	if h.candidates == nil {
+		h.candidates = make(map[string]uint64, maxCandidates)
+	}
+	if _, seen := h.candidates[key]; !seen && len(h.candidates) >= maxCandidates {
+		// Full. Keep counting what is already here rather than making room:
+		// evicting to admit would let a scan cycle the table endlessly, which
+		// is the behaviour the window is being kept away from cardinality to
+		// avoid in the first place.
+		return
+	}
+	h.candidates[key]++
+}
+
+// promoteCandidate hands the busiest candidate the slot of the least busy
+// tracked entry, if it has out-earned it, then decays the survivors and starts
+// a fresh window.
+//
+// One promotion per window, deliberately. A promoted key starts counting from
+// zero, since the requests it saw while a candidate were already reported under
+// the overflow entry, and a demoted key loses its total outright. Both read
+// downstream as a counter reset, so swapping several at once would turn one
+// busy window into a wave of resets across every dashboard.
+//
+// Callers must hold h.mu.
+func (h *HTTPMetrics) promoteCandidate() {
+	defer clear(h.candidates)
+
+	var (
+		bestKey  string
+		bestHits uint64
+	)
+	for key, hits := range h.candidates {
+		if hits > bestHits {
+			bestKey, bestHits = key, hits
+		}
+	}
+
+	var (
+		weakestKey  string
+		weakestHits uint64
+	)
+	for key, c := range h.counters {
+		if !c.pathBound {
+			continue
+		}
+		if weakestKey == "" || c.hits < weakestHits {
+			weakestKey, weakestHits = key, c.hits
+		}
+	}
+
+	// The insert below has to create a slot, not land on one. Overwriting an
+	// existing entry would leave pathBound counting a slot that no longer
+	// exists, and the effective cap would drift down every time it happened.
+	// A candidate is by definition a key that missed the counter map, so this
+	// only guards against a collision with an overflow key.
+	_, occupied := h.counters[bestKey]
+
+	if bestKey != "" && weakestKey != "" && !occupied &&
+		bestHits >= minPromotionHits && bestHits > weakestHits {
+		delete(h.counters, weakestKey)
+		h.counters[bestKey] = &counterState{hits: bestHits, pathBound: true}
+	}
+
+	// Halve rather than reset. A genuinely busy path keeps its lead across
+	// windows, while one that has gone quiet falls far enough to be displaced
+	// within a few of them.
+	for _, c := range h.counters {
+		if c.pathBound {
+			c.hits /= 2
+		}
+	}
 }
 
 // RPSLastMinute returns requests per second for the last minute
@@ -312,51 +606,61 @@ type PathStats struct {
 	ErrorRate     float64
 }
 
-// TopPaths returns the most frequently accessed paths for an app
+// TopPaths returns the busiest paths for an app over the last recentMinutes.
+//
+// Served from the in-process counters rather than from VictoriaMetrics. The
+// query it replaced asked for topk by path and then issued two more queries per
+// path for the average duration and the error rate, all of them reading the
+// `path` label -- the same label the cardinality cap collapses to "other". So
+// the cap and this view could not both be right. Reading the counters directly
+// removes the conflict, and removes 1+2N round trips per `miren app status`.
+//
+// Only this node's ingress traffic is counted. That is the whole cluster today,
+// since the ingress runs on the coordinator alone; it stops being true the day
+// runners serve ingress, and this has to aggregate across them then.
 func (h *HTTPMetrics) TopPaths(app string, limit int) ([]PathStats, error) {
-	if h.Reader == nil {
-		return nil, fmt.Errorf("reader not initialized")
+	if limit <= 0 {
+		return nil, nil
 	}
 
-	// Query for top paths by count
-	query := fmt.Sprintf(`topk(%d, sum by(path) (increase(http_requests_total{app="%s"}[1h])))`, limit, app)
-	result, err := h.Reader.InstantQuery(context.Background(), query, time.Time{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to query top paths: %w", err)
-	}
+	now := h.clock()
 
+	h.mu.Lock()
 	var paths []PathStats
-	for _, r := range result.Data.Result {
-		path := r.Metric["path"]
-		countStr, _ := r.Value[1].(string)
-		count, _ := strconv.ParseInt(countStr, 10, 64)
-
-		// Query average duration for this path in milliseconds
-		avgQuery := fmt.Sprintf(`(sum(rate(http_request_duration_seconds_sum{app="%s",path="%s"}[1h])) / sum(rate(http_request_duration_seconds_count{app="%s",path="%s"}[1h]))) * 1000`, app, path, app, path)
-		avgResult, err := h.Reader.InstantQuery(context.Background(), avgQuery, time.Time{})
-		var avgDuration float64
-		if err == nil && len(avgResult.Data.Result) > 0 {
-			avgStr, _ := avgResult.Data.Result[0].Value[1].(string)
-			avgDuration, _ = strconv.ParseFloat(avgStr, 64)
+	for _, c := range h.counters {
+		// Overflow entries are skipped: "other" is not a path anyone can act
+		// on, and it would outrank every real one on any busy app.
+		if !c.pathBound || c.app != app {
+			continue
 		}
 
-		// Query error rate for this path
-		errorQuery := fmt.Sprintf(`sum(rate(http_requests_total{app="%s",path="%s",status=~"[45].."}[1h])) / sum(rate(http_requests_total{app="%s",path="%s"}[1h]))`, app, path, app, path)
-		errorResult, err := h.Reader.InstantQuery(context.Background(), errorQuery, time.Time{})
-		var errorRate float64
-		if err == nil && len(errorResult.Data.Result) > 0 {
-			errStr, _ := errorResult.Data.Result[0].Value[1].(string)
-			errorRate, _ = strconv.ParseFloat(errStr, 64)
+		w := c.window(now)
+		if w.count == 0 {
+			continue
 		}
 
-		paths = append(paths, PathStats{
-			Path:          path,
-			Count:         count,
-			AvgDurationMs: avgDuration,
-			ErrorRate:     errorRate,
-		})
+		stats := PathStats{
+			Path:  c.path,
+			Count: w.count,
+		}
+		if w.durationCount > 0 {
+			stats.AvgDurationMs = (w.durationSum / float64(w.durationCount)) * 1000.0
+		}
+		stats.ErrorRate = float64(w.errors) / float64(w.count)
+		paths = append(paths, stats)
 	}
+	h.mu.Unlock()
 
+	slices.SortFunc(paths, func(a, b PathStats) int {
+		if a.Count != b.Count {
+			return cmp.Compare(b.Count, a.Count)
+		}
+		return cmp.Compare(a.Path, b.Path) // stable across calls, unlike map order
+	})
+
+	if len(paths) > limit {
+		paths = paths[:limit]
+	}
 	return paths, nil
 }
 

--- a/metrics/http_cardinality_test.go
+++ b/metrics/http_cardinality_test.go
@@ -1,0 +1,298 @@
+package metrics
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newCappedMetrics() *HTTPMetrics {
+	return &HTTPMetrics{
+		counters:   map[string]*counterState{},
+		candidates: map[string]uint64{},
+	}
+}
+
+// newRecordingMetrics wires up enough to drive RecordRequest. An unstarted
+// writer buffers points instead of sending them, which is what lets a test read
+// back the labels that would have reached VictoriaMetrics.
+func newRecordingMetrics(now func() time.Time) *HTTPMetrics {
+	h := newCappedMetrics()
+	h.Log = slog.New(slog.DiscardHandler)
+	h.Writer = &VictoriaMetricsWriter{}
+	h.instance = "test-instance"
+	h.now = now
+	return h
+}
+
+// hit is one request's worth of admission for a path. One entry per path now,
+// so this is a single lookup, not the request/duration pair it used to be.
+func hit(h *HTTPMetrics, path string) {
+	h.trackCounter(counterKey("app", "GET", path))
+}
+
+func isTracked(h *HTTPMetrics, path string) bool {
+	c, ok := h.counters[counterKey("app", "GET", path)]
+	return ok && c.pathBound
+}
+
+func record(t *testing.T, h *HTTPMetrics, path string, status int, durationMs int64) {
+	t.Helper()
+	require.NoError(t, h.RecordRequest(context.Background(), HTTPRequest{
+		App: "app", Method: "GET", Path: path, StatusCode: status, DurationMs: durationMs,
+	}))
+}
+
+// TestCounterMapStaysBounded is the whole point of the cap. Path comes from the
+// client, so a walk over unique URLs used to grow the map for as long as the
+// process lived -- 780k keys and 83MB in the 0.14.0 heap dump.
+func TestCounterMapStaysBounded(t *testing.T) {
+	h := newCappedMetrics()
+
+	for i := range 10_000 {
+		hit(h, "/scan/"+strconv.Itoa(i))
+	}
+
+	require.Equal(t, maxPathBoundCounters, h.pathBound,
+		"tracked counters must stop at the cap no matter how many paths arrive")
+	require.LessOrEqual(t, len(h.counters), maxPathBoundCounters)
+	require.LessOrEqual(t, len(h.candidates), maxCandidates)
+}
+
+// TestCounterMapStaysBoundedAcrossWindows: promotion runs only every
+// promotionWindow touches, so check the map does not creep upward between
+// passes. It cannot -- the cap is enforced on every admission, and the window
+// only decides which keys hold the slots, never how many there are.
+func TestCounterMapStaysBoundedAcrossWindows(t *testing.T) {
+	h := newCappedMetrics()
+
+	maxCounters, maxCands := 0, 0
+	for i := range 500_000 {
+		hit(h, "/scan/"+strconv.Itoa(i))
+		maxCounters = max(maxCounters, len(h.counters))
+		maxCands = max(maxCands, len(h.candidates))
+	}
+
+	require.Greater(t, h.touches, uint64(promotionWindow*10), "the run has to cross many windows")
+	require.LessOrEqual(t, maxCounters, maxPathBoundCounters)
+	require.LessOrEqual(t, maxCands, maxCandidates)
+}
+
+// TestFloodDoesNotEvictBusyPaths is the attack the eviction policy exists to
+// survive. An earlier version closed its promotion window once the candidate
+// table filled, which a client walking unique URLs controls completely: windows
+// closed continuously, per-window decay drove every real path's score to zero,
+// and a one-hit URL then outranked all of them. It took 25 of 25 busy paths.
+//
+// The flood is long enough to decay a score of 100 to zero -- seven halvings,
+// so seven windows -- and then some. A shorter flood passes even with
+// minPromotionHits removed, and so proves nothing about the floor.
+func TestFloodDoesNotEvictBusyPaths(t *testing.T) {
+	h := newCappedMetrics()
+
+	for range 100 {
+		for i := range maxPathBoundCounters {
+			hit(h, "/real/"+strconv.Itoa(i))
+		}
+	}
+	for i := range maxPathBoundCounters {
+		require.True(t, isTracked(h, "/real/"+strconv.Itoa(i)), "busy paths should start tracked")
+	}
+
+	for i := range 100_000 {
+		hit(h, "/junk/"+strconv.Itoa(i))
+	}
+
+	survivors := 0
+	for i := range maxPathBoundCounters {
+		if isTracked(h, "/real/"+strconv.Itoa(i)) {
+			survivors++
+		}
+	}
+	require.Equal(t, maxPathBoundCounters, survivors,
+		"a flood of one-hit URLs must not displace paths carrying real traffic")
+}
+
+// TestOverflowEntriesAreExemptFromCap: the sink untracked traffic lands in must
+// not compete for the slots it exists to protect.
+func TestOverflowEntriesAreExemptFromCap(t *testing.T) {
+	h := newCappedMetrics()
+
+	for i := range 100 {
+		hit(h, "/scan/"+strconv.Itoa(i))
+	}
+	require.Equal(t, maxPathBoundCounters, h.pathBound)
+
+	h.overflowCounter(counterKey("app", overflowLabel, overflowLabel))
+	h.overflowCounter(counterKey("other-app", overflowLabel, overflowLabel))
+
+	require.Equal(t, maxPathBoundCounters, h.pathBound, "overflow entries must not count against the cap")
+	require.Greater(t, len(h.counters), maxPathBoundCounters, "they do still live in the same map")
+}
+
+// TestBusyPathDisplacesQuietOne is the "re-evaluated" half. First-seen-wins
+// would let a crawler squat every slot at startup and never give them back.
+func TestBusyPathDisplacesQuietOne(t *testing.T) {
+	h := newCappedMetrics()
+
+	for i := range maxPathBoundCounters {
+		hit(h, "/quiet/"+strconv.Itoa(i))
+	}
+	require.Equal(t, maxPathBoundCounters, h.pathBound)
+	require.False(t, isTracked(h, "/busy"), "the cap is full, so /busy starts out untracked")
+
+	for range 2 * promotionWindow {
+		hit(h, "/busy")
+	}
+
+	require.True(t, isTracked(h, "/busy"), "a path this busy must earn a slot from a quiet one")
+	require.Equal(t, maxPathBoundCounters, h.pathBound, "promotion swaps a slot, it does not add one")
+}
+
+// TestPromotedCounterStartsAtZero guards the reported values: a promoted path's
+// candidacy traffic was already counted under the overflow entry, so carrying it
+// over would report those requests twice. The incumbents are given real counts
+// first, so an implementation that recycled an evicted entry's struct gets
+// caught rather than passing on a field that happens to be zero anyway.
+func TestPromotedCounterStartsAtZero(t *testing.T) {
+	now := time.Now()
+	h := newCappedMetrics()
+
+	for i := range maxPathBoundCounters {
+		path := "/quiet/" + strconv.Itoa(i)
+		hit(h, path)
+		h.counters[counterKey("app", "GET", path)].observe("200", 200, 5, now)
+	}
+	for i := range maxPathBoundCounters {
+		require.NotEmpty(t, h.counters[counterKey("app", "GET", "/quiet/"+strconv.Itoa(i))].requests,
+			"incumbents must carry real counts, or this test cannot fail")
+	}
+
+	for range 2 * promotionWindow {
+		hit(h, "/busy")
+	}
+
+	c := h.counters[counterKey("app", "GET", "/busy")]
+	require.NotNil(t, c)
+	require.Empty(t, c.requests, "a promoted counter reports from zero, not from its candidacy")
+	require.Zero(t, c.durationCount)
+}
+
+// TestOverflowLabelsReachExportedPoints pins the half of the fix that bounds
+// VictoriaMetrics rather than the heap. Without it, a regression putting
+// req.Path back into the label maps keeps every other test green while series
+// cardinality goes unbounded again.
+func TestOverflowLabelsReachExportedPoints(t *testing.T) {
+	now := time.Now()
+	h := newRecordingMetrics(func() time.Time { return now })
+
+	last := "/scan/" + strconv.Itoa(maxPathBoundCounters+4)
+	for i := range maxPathBoundCounters + 5 {
+		record(t, h, "/scan/"+strconv.Itoa(i), 200, 3)
+	}
+
+	var sawOverflow bool
+	for _, p := range h.Writer.buffer {
+		require.NotEqual(t, last, p.Labels["path"], "a path past the cap must never reach an exported label")
+		if p.Labels["path"] == overflowLabel {
+			sawOverflow = true
+			require.Equal(t, overflowLabel, p.Labels["method"], "method collapses along with the path")
+		}
+	}
+	require.True(t, sawOverflow, "traffic past the cap still has to be exported, under the overflow label")
+}
+
+// TestTopPathsReportsErrorsForTrackedPath is the corruption this change exists
+// to remove. Statuses used to be separate map entries admitted and evicted
+// independently, so a path could keep its 200 counter while its 500 counter fell
+// into the overflow bucket, and the per-path error rate read zero. Error
+// statuses are rarer than successes, so they were the weakest entries and the
+// first evicted: the paths that had errors were the ones that lost them.
+func TestTopPathsReportsErrorsForTrackedPath(t *testing.T) {
+	now := time.Now()
+	h := newRecordingMetrics(func() time.Time { return now })
+
+	for range 9 {
+		record(t, h, "/api", 200, 10)
+	}
+	record(t, h, "/api", 500, 30)
+	for range 4 {
+		record(t, h, "/health", 200, 1)
+	}
+
+	paths, err := h.TopPaths("app", 5)
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+
+	require.Equal(t, "/api", paths[0].Path, "busiest path first")
+	require.EqualValues(t, 10, paths[0].Count)
+	require.InDelta(t, 0.1, paths[0].ErrorRate, 0.0001, "one 500 in ten requests")
+	require.InDelta(t, 12.0, paths[0].AvgDurationMs, 0.0001, "(9*10 + 30) / 10")
+
+	require.Equal(t, "/health", paths[1].Path)
+	require.Zero(t, paths[1].ErrorRate)
+}
+
+// TestTopPathsExcludesOverflow: "other" is not a path anyone can act on, and it
+// would outrank every real one on a busy app.
+func TestTopPathsExcludesOverflow(t *testing.T) {
+	now := time.Now()
+	h := newRecordingMetrics(func() time.Time { return now })
+
+	record(t, h, "/real", 200, 1)
+	for i := range 200 {
+		for range 3 {
+			record(t, h, "/scan/"+strconv.Itoa(i), 404, 1)
+		}
+	}
+
+	paths, err := h.TopPaths("app", 10)
+	require.NoError(t, err)
+	for _, p := range paths {
+		require.NotEqual(t, overflowLabel, p.Path, "the overflow bucket is not a path")
+	}
+}
+
+// TestTopPathsWindowExpires: the numbers are a rolling hour, matching the [1h]
+// range of the query this replaced. Cumulative-since-start would let a path that
+// was busy yesterday outrank one busy now.
+func TestTopPathsWindowExpires(t *testing.T) {
+	now := time.Now()
+	h := newRecordingMetrics(func() time.Time { return now })
+
+	for range 5 {
+		record(t, h, "/api", 200, 10)
+	}
+
+	paths, err := h.TopPaths("app", 5)
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+
+	now = now.Add(2 * time.Hour)
+	paths, err = h.TopPaths("app", 5)
+	require.NoError(t, err)
+	require.Empty(t, paths, "traffic older than the window must age out")
+}
+
+// TestLongPathIsTruncated: the cap counts entries, so an entry has to have a
+// bounded size. The ingress allows a ~1MB request line, and the path went into
+// both the key and the exported label verbatim.
+func TestLongPathIsTruncated(t *testing.T) {
+	now := time.Now()
+	h := newRecordingMetrics(func() time.Time { return now })
+
+	record(t, h, "/"+strings.Repeat("a", 10_000), 200, 1)
+
+	for key, c := range h.counters {
+		require.LessOrEqual(t, len(c.path), maxKeyPathBytes+3, "stored path must be truncated")
+		require.LessOrEqual(t, len(key), maxKeyPathBytes+64, "the map key must be truncated too")
+	}
+	for _, p := range h.Writer.buffer {
+		require.LessOrEqual(t, len(p.Labels["path"]), maxKeyPathBytes+3, "exported label must be truncated")
+	}
+}

--- a/metrics/integration_test.go
+++ b/metrics/integration_test.go
@@ -238,16 +238,39 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("TopPaths returns most frequent paths", func(t *testing.T) {
+	t.Run("TopPaths reports the busiest paths from local counters", func(t *testing.T) {
+		// TopPaths no longer queries VictoriaMetrics. It reads the counters this
+		// process keeps, so the cardinality cap and this view cannot disagree
+		// about which paths exist -- and a path's statuses can no longer be
+		// tracked separately from each other, which is what used to report the
+		// error rate of a path whose error counter had been evicted as zero.
+		//
+		// The "RecordRequest writes all metrics" subtest above already recorded
+		// one /api/users request, so that path ends on five.
+		for range 4 {
+			require.NoError(t, httpMetrics.RecordRequest(context.Background(), HTTPRequest{
+				Timestamp: time.Now(), App: "testapp", Method: "GET",
+				Path: "/api/users", StatusCode: 200, DurationMs: 100,
+			}))
+		}
+		for range 2 {
+			require.NoError(t, httpMetrics.RecordRequest(context.Background(), HTTPRequest{
+				Timestamp: time.Now(), App: "testapp", Method: "GET",
+				Path: "/api/posts", StatusCode: 500, DurationMs: 50,
+			}))
+		}
+
 		paths, err := httpMetrics.TopPaths("testapp", 5)
 		require.NoError(t, err)
 		require.Len(t, paths, 2)
 
 		assert.Equal(t, "/api/users", paths[0].Path)
-		assert.Equal(t, int64(150), paths[0].Count)
+		assert.Equal(t, int64(5), paths[0].Count)
+		assert.Zero(t, paths[0].ErrorRate)
 
 		assert.Equal(t, "/api/posts", paths[1].Path)
-		assert.Equal(t, int64(100), paths[1].Count)
+		assert.Equal(t, int64(2), paths[1].Count)
+		assert.InDelta(t, 1.0, paths[1].ErrorRate, 0.0001, "every /api/posts request was a 500")
 	})
 
 	t.Run("ErrorsLastHour returns error breakdown", func(t *testing.T) {


### PR DESCRIPTION
Fixes MIR-1802.

`RecordRequest` kept a map keyed on the raw client-supplied URL path with no eviction. The 0.14.0 heap profile has it holding ~780k keys and 83MB — **70.7% of live heap and 89% of live objects**. It is a retention problem, not a churn one: across 766GB of cumulative allocation in the same profile, `RecordRequest` does not reach the top ten allocators.

The same path also went into the exported labels, so every unique URL became a permanent VictoriaMetrics series. Any app with IDs in its routes grew both without bound, and a client walking random URLs could do it deliberately.

## The bound

The counter table is capped at 100 path-bound entries — **one budget shared by every app on the node**, not a per-app allowance. Traffic past the cap is still counted, under `path="other"` and `method="other"`. Those overflow entries are exempt from the cap because their remaining labels, app and status, are not client-chosen.

Metric labels follow whichever counter the request landed in, so the collapsed path reaches VictoriaMetrics too. Series cardinality is bounded along with the memory, which was the larger of the two problems.

Which paths hold the slots is re-evaluated rather than first-come-first-served: untracked keys are counted in a bounded candidate table, and every `promotionWindow` of traffic the busiest candidate takes the slot of the least busy tracked entry, provided it clears `minPromotionHits` and out-scores it. Tracked scores halve each window, so a path that was busy once cannot hold a slot forever.

### Why the window is measured in traffic

An earlier revision of this branch closed the promotion window when the candidate table filled — after 100 distinct untracked keys. That is a quantity the client controls completely. A scan closed windows continuously, the per-window decay drove every real path's score to zero with no traffic in between to re-earn it, and a one-hit URL then outranked everything. Measured at the time: **25 real paths at 100 hits each, all 25 evicted by 10,000 one-hit junk paths.**

So the window counts traffic, and `minPromotionHits` is a floor that stops a URL seen once from displacing anything however quiet the incumbent. `TestFloodDoesNotEvictBusyPaths` pins both, and its flood is deliberately long enough that a shorter one would pass with the floor removed.

## Why TopPaths changed too

Capping the `path` label and serving `TopPaths` from that label could not both be right.

Counters are now **per path rather than per key**. Statuses and durations used to be separate map entries, admitted and evicted independently, so a path could keep its `200` counter while its `500` counter fell into the overflow bucket. Error statuses are rarer than successes, which made them the weakest entries and the first evicted — so the paths that had errors were exactly the ones whose errors disappeared, and the per-path error rate read as zero. A path could also hold its request counter but not its duration counter, and the CLI would print `0ms avg`.

With one entry per path holding its statuses and durations together, that is unrepresentable. It also means 100 entries is 100 real paths.

`TopPaths` then reads those counters directly instead of querying VictoriaMetrics. The old implementation issued a `topk` plus **two more queries per returned path** — an average and an error rate each — all reading the label the cap collapses. Reading locally removes the conflict and removes 1+2N round trips per `miren app status`. A ring of per-minute buckets preserves the rolling hour the `[1h]` range provided, so the view still means "busiest in the last hour" rather than "busiest since this process booted".

Only this node's ingress traffic is counted. That is the whole cluster today, since the ingress runs on the coordinator alone; it stops being true the day runners serve ingress, and this will have to aggregate across them then.

## Two smaller fixes the same code needed

**Paths are truncated to 256 bytes** before entering a key or a label. Counting entries only bounds memory if an entry has a bounded size, and the ingress leaves `MaxHeaderBytes` at Go's 1MB default — 100 candidate entries holding megabyte paths is ~100MB, the same order as the leak being fixed.

**The key separator is NUL.** With `":"`, the request key for `("/x", status 200)` and the duration key for path `"/x:200"` were the same string.

## Verification

`go build ./...` clean. `metrics` 114 tests, `servers/httpingress` 154, `servers/app` 109. `make lint` 0 issues.

Every new claim was mutation-checked rather than trusted on a green run — each of these deliberate breakages fails the test named:

| mutation | caught by |
| --- | --- |
| remove the promotion floor | `TestFloodDoesNotEvictBusyPaths` |
| stop collapsing exported labels | `TestOverflowLabelsReachExportedPoints` |
| stop truncating long paths | `TestLongPathIsTruncated` |
| stop counting errors | `TestTopPathsReportsErrorsForTrackedPath` |
| ignore the rolling window | `TestTopPathsWindowExpires` |
| remove the cap | `TestCounterMapStaysBounded` |
| never promote | `TestBusyPathDisplacesQuietOne` |

`TestCounterMapStaysBoundedAcrossWindows` runs 500k unique paths over 100 promotion windows and records the running maximum, not just the end state: counters peak at the cap, candidates at theirs.

The existing `TestHTTPMetrics_Integration/TopPaths` subtest was asserting against canned VictoriaMetrics query responses, so it was testing a path that no longer exists. It now records real requests and checks the counters, including that an all-500 path reports a 100% error rate.

## Known limits, not addressed here

- **A scanner still influences window length** by contributing traffic. With each URL repeated k times at S req/s, paths under roughly `S/625` req/s can be evicted and cannot return. A wall-clock window would decouple it entirely.
- **The candidate table is first-come-first-served** within a window, so a scan can occupy all 100 slots and a quiet legitimate path is never counted. Space-Saving admission is the standard fix.

Both are narrower than what this bounds, and both are follow-up sized.
