### PR TITLE
Hold deploys until addons are active

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -1939,11 +1939,13 @@ func (v *DiskConfig) UnmarshalJSON(data []byte) error {
 }
 
 type addonInstanceData struct {
-	Id      *string `cbor:"0,keyasint,omitempty" json:"id,omitempty"`
-	Name    *string `cbor:"1,keyasint,omitempty" json:"name,omitempty"`
-	Addon   *string `cbor:"2,keyasint,omitempty" json:"addon,omitempty"`
-	Variant *string `cbor:"3,keyasint,omitempty" json:"variant,omitempty"`
-	Version *string `cbor:"4,keyasint,omitempty" json:"version,omitempty"`
+	Id           *string `cbor:"0,keyasint,omitempty" json:"id,omitempty"`
+	Name         *string `cbor:"1,keyasint,omitempty" json:"name,omitempty"`
+	Addon        *string `cbor:"2,keyasint,omitempty" json:"addon,omitempty"`
+	Variant      *string `cbor:"3,keyasint,omitempty" json:"variant,omitempty"`
+	Version      *string `cbor:"4,keyasint,omitempty" json:"version,omitempty"`
+	Status       *string `cbor:"5,keyasint,omitempty" json:"status,omitempty"`
+	ErrorMessage *string `cbor:"6,keyasint,omitempty" json:"error_message,omitempty"`
 }
 
 type AddonInstance struct {
@@ -2023,6 +2025,36 @@ func (v *AddonInstance) Version() string {
 
 func (v *AddonInstance) SetVersion(version string) {
 	v.data.Version = &version
+}
+
+func (v *AddonInstance) HasStatus() bool {
+	return v.data.Status != nil
+}
+
+func (v *AddonInstance) Status() string {
+	if v.data.Status == nil {
+		return ""
+	}
+	return *v.data.Status
+}
+
+func (v *AddonInstance) SetStatus(status string) {
+	v.data.Status = &status
+}
+
+func (v *AddonInstance) HasErrorMessage() bool {
+	return v.data.ErrorMessage != nil
+}
+
+func (v *AddonInstance) ErrorMessage() string {
+	if v.data.ErrorMessage == nil {
+		return ""
+	}
+	return *v.data.ErrorMessage
+}
+
+func (v *AddonInstance) SetErrorMessage(error_message string) {
+	v.data.ErrorMessage = &error_message
 }
 
 func (v *AddonInstance) MarshalCBOR() ([]byte, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -421,6 +421,14 @@ types:
       - name: version
         type: string
         index: 4
+      - name: status
+        doc: Association lifecycle state (pending, provisioning, active, error, deprovisioning)
+        type: string
+        index: 5
+      - name: error_message
+        doc: Why provisioning failed; set only when status is error
+        type: string
+        index: 6
 
   - type: RunInfo
     doc: One execution of an app task

--- a/blackbox/addon_memcache_test.go
+++ b/blackbox/addon_memcache_test.go
@@ -22,7 +22,7 @@ func TestMemcacheAddonCreateListDestroy(t *testing.T) {
 	m.MustRun("addon", "create", "miren-memcache:small", "-a", name)
 
 	// Wait for addon to appear and provisioning to complete.
-	harness.WaitForAddonReady(t, m, name, "miren-memcache", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-memcache", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "MEMCACHE_URL", 5*time.Minute)
 
 	// Verify Memcache-specific env vars are injected
@@ -54,7 +54,7 @@ func TestMemcacheAddonDeployWithAppToml(t *testing.T) {
 	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
 
 	// Wait for addon provisioning to complete.
-	harness.WaitForAddonReady(t, m, name, "miren-memcache", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-memcache", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "MEMCACHE_HOST", 5*time.Minute)
 
 	// Now wait for the app to become healthy

--- a/blackbox/addon_rabbitmq_test.go
+++ b/blackbox/addon_rabbitmq_test.go
@@ -22,7 +22,7 @@ func TestRabbitmqAddonCreateListDestroy(t *testing.T) {
 	m.MustRun("addon", "create", "miren-rabbitmq:small", "-a", name)
 
 	// Wait for addon to appear and provisioning to complete.
-	harness.WaitForAddonReady(t, m, name, "miren-rabbitmq", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-rabbitmq", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "RABBITMQ_URL", 5*time.Minute)
 
 	// Verify RabbitMQ-specific env vars are injected
@@ -57,7 +57,7 @@ func TestRabbitmqAddonDeployWithAppToml(t *testing.T) {
 	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
 
 	// Wait for addon provisioning to complete.
-	harness.WaitForAddonReady(t, m, name, "miren-rabbitmq", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-rabbitmq", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "RABBITMQ_HOST", 5*time.Minute)
 
 	// Now wait for the app to become healthy

--- a/blackbox/addon_rotate_test.go
+++ b/blackbox/addon_rotate_test.go
@@ -127,7 +127,7 @@ func TestAddonRotateValkey(t *testing.T) {
 	name := harness.DeployApp(t, m, harness.AppOptions{Testdata: "go-server"})
 
 	m.MustRun("addon", "create", "miren-valkey:small", "-a", name)
-	harness.WaitForAddonReady(t, m, name, "miren-valkey", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-valkey", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "VALKEY_PASSWORD", 5*time.Minute)
 
 	// Scope to this app's dedicated server (named vk-<app>-s<id>).
@@ -164,7 +164,7 @@ func TestAddonRotateSharedPostgresSuperuser(t *testing.T) {
 	name := harness.DeployApp(t, m, harness.AppOptions{Testdata: "go-server"})
 
 	m.MustRun("addon", "create", "miren-postgresql:shared", "-a", name)
-	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
 	// The shared server is the singleton named "pg-shared"; scope to it so
@@ -199,7 +199,7 @@ func TestAddonRotateSharedPostgresUser(t *testing.T) {
 	name := harness.DeployApp(t, m, harness.AppOptions{Testdata: "go-server"})
 
 	m.MustRun("addon", "create", "miren-postgresql:shared", "-a", name)
-	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
 	r := m.MustRun("addon", "rotate", "miren-postgresql", "-a", name, "--force")

--- a/blackbox/addon_test.go
+++ b/blackbox/addon_test.go
@@ -4,6 +4,7 @@ package blackbox
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -60,7 +61,7 @@ func TestAddonCreateListDestroy(t *testing.T) {
 	// Wait for addon to appear in the list, then for provisioning to complete.
 	// The addon shows up in "addon list" immediately (status=pending), but env
 	// vars aren't injected until the provisioning saga finishes.
-	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
 	// Destroy the addon and verify full async cleanup completes.
@@ -83,25 +84,23 @@ func TestAddonDeployWithAppToml(t *testing.T) {
 		m.Run("app", "delete", name, "-f")
 	})
 
-	// Deploy without waiting for healthy — the app depends on DATABASE_URL
-	// which is only injected after addon provisioning completes. The launcher
-	// defers pool creation until addons are ready, but we don't want
-	// WaitForAppReady to fatal on transient "crashed" health during provisioning.
-	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
+	// The deploy holds until the addon is active, and says so on the way. The
+	// app depends on DATABASE_URL, which only exists once the association is
+	// active, so this is what keeps the first boot from racing the database
+	// (MIR-1804).
+	r := m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
+	r.RequireContains(t, "Addon miren-postgresql ready")
 
-	// Wait for addon to appear in the list, then for provisioning to complete.
-	// Env vars are the true readiness signal — they're injected only after the
-	// full provisioning saga finishes (which may include creating the shared
-	// PG server from scratch if a previous run's cleanup is still settling).
-	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
 	// Now wait for the app to become healthy
 	harness.WaitForAppReady(t, m, name, 3*time.Minute)
 
-	// Verify addon is listed
-	r := m.MustRun("addon", "list", "-a", name, "--format", "json")
+	// Verify addon is listed as active
+	r = m.MustRun("addon", "list", "-a", name, "--format", "json")
 	r.RequireContains(t, "miren-postgresql")
+	r.RequireContains(t, `"status": "active"`)
 
 	// Set a route and verify the app responds with DB connectivity
 	host := name + ".test.local"
@@ -128,6 +127,87 @@ func TestAddonDeployWithAppToml(t *testing.T) {
 	}
 }
 
+// TestAddonRedeployReachesSteadyState covers both halves of MIR-1804. The first
+// deploy of an app that declares an addon has to hold until the addon is
+// active, and say so. Every deploy after that has to find the addon already
+// active: no provisioning progress, no wait, and the version comes up healthy
+// inside the deploy itself rather than needing the test to wait for it.
+func TestAddonRedeployReachesSteadyState(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.UniqueAppName(t, "bun-postgres")
+
+	hostDir := filepath.Join(c.TestdataDir, "bun-postgres")
+	containerDir := m.ContainerPath(hostDir)
+
+	t.Cleanup(func() {
+		t.Logf("cleaning up app %s", name)
+		m.Run("app", "delete", name, "-f")
+	})
+
+	host := name + ".test.local"
+
+	// serving asserts the app answers over its route with a working database:
+	// / reads and writes the visits table, so it fails if DATABASE_URL is
+	// missing or points at nothing.
+	serving := func(stage string) {
+		t.Helper()
+		harness.Poll(t, stage+": app responds via route", 30*time.Second, 2*time.Second, func() (bool, string) {
+			code, body, err := harness.HTTPGet(m, host, "/")
+			if err != nil {
+				return false, err.Error()
+			}
+			if code != 200 {
+				return false, "status " + body
+			}
+			return true, ""
+		})
+	}
+
+	// First deploy: the association does not exist yet, so the deploy must
+	// create it, wait for it, and only then activate. The health verdict is
+	// the point: it is printed inside the deploy's own 90 second window, which
+	// used to expire while Postgres was still coming up.
+	first := m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
+	first.RequireContains(t, "Provisioning addon miren-postgresql")
+	first.RequireContains(t, "Addon miren-postgresql ready")
+	first.RequireContains(t, "is live and serving")
+
+	m.MustRun("route", "set", host, name)
+	serving("first deploy")
+
+	previous := extractVersion(t, m.MustRun("app", "list", "--format", "json").Stdout, name)
+
+	// Steady state. Two more deploys, because the second is the one that
+	// first sees an already-active addon and the third proves that was not a
+	// one-off.
+	for i := 2; i <= 3; i++ {
+		stage := fmt.Sprintf("deploy %d", i)
+
+		r := m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
+		if r.OutputContains("Provisioning addon") {
+			t.Fatalf("%s: addon was already active, yet the deploy waited on it:\n%s%s", stage, r.Stdout, r.Stderr)
+		}
+		r.RequireContains(t, "is live and serving")
+
+		current := extractVersion(t, m.MustRun("app", "list", "--format", "json").Stdout, name)
+		if current == previous {
+			t.Fatalf("%s: expected a new version, still on %s", stage, previous)
+		}
+		previous = current
+
+		// The binding must carry forward to the new version without the
+		// addon being re-provisioned.
+		harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 30*time.Second)
+		serving(stage)
+	}
+
+	// And the addon itself never left active.
+	list := m.MustRun("addon", "list", "-a", name, "--format", "json")
+	list.RequireContains(t, `"status": "active"`)
+}
+
 func TestMysqlAddonDeployWithAppToml(t *testing.T) {
 	c := harness.NewCluster(t)
 	m := harness.NewMiren(t, c)
@@ -147,7 +227,7 @@ func TestMysqlAddonDeployWithAppToml(t *testing.T) {
 	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
 
 	// Wait for addon provisioning to complete.
-	harness.WaitForAddonReady(t, m, name, "miren-mysql", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-mysql", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
 	// Now wait for the app to become healthy
@@ -194,7 +274,7 @@ func TestMysqlAddonCreateListDestroy(t *testing.T) {
 	m.MustRun("addon", "create", "miren-mysql:small", "-a", name)
 
 	// Wait for addon to appear and provisioning to complete.
-	harness.WaitForAddonReady(t, m, name, "miren-mysql", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-mysql", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
 	// Verify MySQL-specific env vars are injected
@@ -219,7 +299,7 @@ func TestValkeyAddonCreateListDestroy(t *testing.T) {
 	m.MustRun("addon", "create", "miren-valkey:small", "-a", name)
 
 	// Wait for addon to appear and provisioning to complete.
-	harness.WaitForAddonReady(t, m, name, "miren-valkey", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-valkey", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "VALKEY_URL", 5*time.Minute)
 
 	// Verify Valkey-specific env vars are injected
@@ -251,7 +331,7 @@ func TestAddonDeployWithVersionInAppToml(t *testing.T) {
 
 	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
 
-	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
 	harness.WaitForAppReady(t, m, name, 3*time.Minute)
@@ -326,7 +406,7 @@ func TestAddonEnvSurvivesDeployVersion(t *testing.T) {
 	t.Logf("pre-addon version: %s", preAddonVersion)
 
 	m.MustRun("addon", "create", "miren-postgresql:small", "-a", name)
-	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
 	// Captured now, asserted at the end: attaching an addon contributes a binding

--- a/blackbox/addon_valkey_test.go
+++ b/blackbox/addon_valkey_test.go
@@ -29,7 +29,7 @@ func TestValkeyAddonDeployWithAppToml(t *testing.T) {
 	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
 
 	// Wait for addon provisioning to complete.
-	harness.WaitForAddonReady(t, m, name, "miren-valkey", 30*time.Second)
+	harness.WaitForAddonReady(t, m, name, "miren-valkey", 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "VALKEY_URL", 5*time.Minute)
 
 	// Now wait for the app to become healthy

--- a/blackbox/harness/addon.go
+++ b/blackbox/harness/addon.go
@@ -9,12 +9,16 @@ import (
 
 // addonListEntry matches the JSON output of `miren addon list -a <app> --format json`.
 type addonListEntry struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Variant string `json:"variant"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Variant      string `json:"variant"`
+	Status       string `json:"status"`
+	ErrorMessage string `json:"error_message"`
 }
 
-// WaitForAddonReady polls `addon list` until the named addon appears for the app.
+// WaitForAddonReady polls `addon list` until the named addon is active on the
+// app. An addon in error will never become active, so that fails the test at
+// once with the controller's reason instead of running out the timeout.
 func WaitForAddonReady(t *testing.T, m *Miren, appName, addonName string, timeout time.Duration) {
 	t.Helper()
 
@@ -30,9 +34,16 @@ func WaitForAddonReady(t *testing.T, m *Miren, appName, addonName string, timeou
 		}
 
 		for _, a := range addons {
-			if a.Name == addonName {
-				return true, ""
+			if a.Name != addonName {
+				continue
 			}
+			switch a.Status {
+			case "active":
+				return true, ""
+			case "error":
+				t.Fatalf("addon %s on %s failed to provision: %s", addonName, appName, a.ErrorMessage)
+			}
+			return false, fmt.Sprintf("addon %s is %s", addonName, a.Status)
 		}
 
 		return false, fmt.Sprintf("addon %s not found in list (%d addons)", addonName, len(addons))

--- a/blackbox/sqlite_disk_test.go
+++ b/blackbox/sqlite_disk_test.go
@@ -142,7 +142,7 @@ func deploySqliteApp(t *testing.T, m *harness.Miren, c *harness.Cluster, tc sqli
 	containerDir := m.ContainerPath(filepath.Join(c.TestdataDir, tc.testdata))
 	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
 
-	harness.WaitForAddonReady(t, m, name, tc.addon, 60*time.Second)
+	harness.WaitForAddonReady(t, m, name, tc.addon, 5*time.Minute)
 	harness.WaitForEnvVar(t, m, name, "SQLITE_PATH", 2*time.Minute)
 	harness.WaitForAppReady(t, m, name, 3*time.Minute)
 

--- a/cli/commands/addon.go
+++ b/cli/commands/addon.go
@@ -227,26 +227,30 @@ func AddonList(ctx *Context, opts struct {
 
 	if opts.IsJSON() {
 		type addonInfo struct {
-			ID      string `json:"id"`
-			Name    string `json:"name"`
-			Variant string `json:"variant"`
-			Version string `json:"version,omitempty"`
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			Variant      string `json:"variant"`
+			Version      string `json:"version,omitempty"`
+			Status       string `json:"status"`
+			ErrorMessage string `json:"error_message,omitempty"`
 		}
 
 		var infos []addonInfo
 		for _, a := range addons {
 			infos = append(infos, addonInfo{
-				ID:      a.Id(),
-				Name:    a.Name(),
-				Variant: a.Variant(),
-				Version: a.Version(),
+				ID:           a.Id(),
+				Name:         a.Name(),
+				Variant:      a.Variant(),
+				Version:      a.Version(),
+				Status:       a.Status(),
+				ErrorMessage: a.ErrorMessage(),
 			})
 		}
 		return PrintJSON(infos)
 	}
 
 	var rows []ui.Row
-	headers := []string{"ADDON", "VARIANT", "VERSION"}
+	headers := []string{"ADDON", "VARIANT", "VERSION", "STATUS"}
 
 	for _, a := range addons {
 		version := a.Version()
@@ -257,6 +261,7 @@ func AddonList(ctx *Context, opts struct {
 			a.Name(),
 			a.Variant(),
 			version,
+			addonStatusCell(a.Status(), a.ErrorMessage()),
 		})
 	}
 
@@ -273,6 +278,26 @@ func AddonList(ctx *Context, opts struct {
 
 	ctx.Printf("%s\n", table.Render())
 	return nil
+}
+
+// addonStatusCell renders an association's status for the table. An older
+// server sends no status at all; show that as unknown rather than an empty
+// cell. An error carries its reason inline, since that is the one state where
+// the user has to act.
+func addonStatusCell(status, errorMessage string) string {
+	switch status {
+	case "":
+		return "-"
+	case "active":
+		return infoGreen.Render(status)
+	case "error":
+		if errorMessage != "" {
+			return infoRed.Render(fmt.Sprintf("error: %s", errorMessage))
+		}
+		return infoRed.Render(status)
+	default:
+		return status
+	}
 }
 
 func AddonDestroy(ctx *Context, opts struct {

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -844,6 +844,51 @@ func Deploy(ctx *Context, opts struct {
 		safeStatus := newSafeStatusCh(pw.Status())
 		defer safeStatus.Close()
 
+		// Server progress messages (addon provisioning, deploy tasks) only
+		// had the TUI to land in. Without one, print each as its own line on
+		// stderr alongside the build output, clearing any in-place upload
+		// line first. The callback's send is non-blocking, so this drains
+		// promptly and flushes what is queued when the build call returns.
+		//
+		// Not for rawjson: there stderr is a stream of JSON build events for
+		// a machine to parse, and a line of prose in it would break the
+		// consumer. A nil channel makes the callback drop messages as before.
+		var (
+			updateCh     chan string
+			stopMessages = func() {}
+		)
+		if opts.ExplainFormat != "rawjson" {
+			updateCh = make(chan string, 16)
+			msgDone := make(chan struct{})
+			var msgWG sync.WaitGroup
+			printMsg := func(msg string) { fmt.Fprintf(os.Stderr, "\r\033[K%s\n", msg) }
+			msgWG.Go(func() {
+				for {
+					select {
+					case msg := <-updateCh:
+						printMsg(msg)
+					case <-msgDone:
+						for {
+							select {
+							case msg := <-updateCh:
+								printMsg(msg)
+							default:
+								return
+							}
+						}
+					}
+				}
+			})
+			var stopMsgOnce sync.Once
+			stopMessages = func() {
+				stopMsgOnce.Do(func() {
+					close(msgDone)
+					msgWG.Wait()
+				})
+			}
+		}
+		defer stopMessages()
+
 		// Add upload progress tracking in explain mode
 		uploadStartTime := time.Now()
 		var uploadBytes int64
@@ -894,9 +939,10 @@ func Deploy(ctx *Context, opts struct {
 			return safeStatus.Send(buildCtx, status)
 		}
 
-		cb = createBuildStatusCallback(buildCtx, nil, nil, &buildStateMu, &buildErrors, nil, &deployWarnings, progressHandler, onDeployment, onImage)
+		cb = createBuildStatusCallback(buildCtx, updateCh, nil, &buildStateMu, &buildErrors, nil, &deployWarnings, progressHandler, onDeployment, onImage)
 
 		results, err = buildCall(buildCtx, r, cb)
+		stopMessages()
 		if err != nil {
 			uploadSpan.RecordError(err)
 			uploadSpan.SetStatus(codes.Error, err.Error())

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -94,6 +94,19 @@ func (l *Launcher) CreatePoolForVersion(ctx context.Context, ver *core_v1alpha.A
 	app.Decode(appResp.Entity().Entity())
 	app.ID = ver.App
 
+	// Same gate as Reconcile. A pool built now would resolve a config with no
+	// addon variables in it, and every instance would boot without its
+	// database. The activator treats this as a failed on-demand creation and
+	// tries again on the next request; the normal reconcile creates the pool
+	// once the association flips to active.
+	ready, err := l.addonsReady(ctx, ver.App)
+	if err != nil {
+		return "", fmt.Errorf("checking addon readiness for app %s: %w", ver.App, err)
+	}
+	if !ready {
+		return "", fmt.Errorf("addons for app %s are still provisioning", ver.App)
+	}
+
 	// Resolve config
 	spec, err := coreutil.ResolveRuntimeConfig(ctx, l.EAC, ver)
 	if err != nil {
@@ -168,6 +181,11 @@ func (l *Launcher) Reconcile(ctx context.Context, app *core_v1alpha.App, meta *e
 
 // addonsReady returns true if the app has no pending or provisioning addon associations.
 // Apps without any addons are always considered ready.
+//
+// An association in error does not hold the app. Error is terminal in the
+// addon controller, so blocking on it would turn every later env change or
+// rollback on that app into a silent no-op. The deploy path fails loudly on
+// error before the version is ever activated; here it is only worth a warning.
 func (l *Launcher) addonsReady(ctx context.Context, appID entity.Id) (bool, error) {
 	results, err := l.EAC.List(ctx, entity.Ref(addon_v1alpha.AddonAssociationAppId, appID))
 	if err != nil {
@@ -178,9 +196,13 @@ func (l *Launcher) addonsReady(ctx context.Context, appID entity.Id) (bool, erro
 		var assoc addon_v1alpha.AddonAssociation
 		assoc.Decode(ent.Entity())
 
-		if assoc.Status == "pending" || assoc.Status == "provisioning" {
+		switch assoc.Status {
+		case "pending", "provisioning":
 			l.Log.Info("addon not ready", "association", assoc.ID, "status", assoc.Status)
 			return false, nil
+		case "error":
+			l.Log.Warn("addon failed to provision; app will launch without its variables",
+				"association", assoc.ID, "app", appID, "error", assoc.ErrorMessage)
 		}
 	}
 

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -3878,6 +3878,60 @@ func TestCreatePoolForVersionEphemeral(t *testing.T) {
 	assert.Contains(t, pool.ReferencedByVersions, version.ID)
 }
 
+// TestCreatePoolForVersionDefersWhileAddonsPending guards the on-demand path
+// with the same gate Reconcile has. An ephemeral version shares the app's
+// addons and skips provisioning, so a request arriving while the addon is
+// still coming up used to build a pool whose config had no DATABASE_URL.
+func TestCreatePoolForVersionDefersWhileAddonsPending(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:            app.ID,
+		Version:        "v1",
+		ImageUrl:       "test:latest",
+		EphemeralLabel: "feat-x",
+		EphemeralTtl:   "48h",
+		Config: core_v1alpha.Config{
+			Port:     3000,
+			Services: []core_v1alpha.Services{{Name: "web"}},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	assocID, err := server.Client.Create(ctx, "assoc-pg", &addon_v1alpha.AddonAssociation{
+		App:    app.ID,
+		Addon:  entity.Id("addon/miren-postgresql"),
+		Status: "provisioning",
+	})
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+
+	_, err = launcher.CreatePoolForVersion(ctx, version, "web")
+	require.Error(t, err, "a pool built now would have no addon variables")
+	assert.Contains(t, err.Error(), "still provisioning")
+	assert.Empty(t, listAllPools(t, ctx, server), "no pool may exist while the addon is provisioning")
+
+	require.NoError(t, server.Client.Patch(ctx, assocID, 0,
+		entity.String(addon_v1alpha.AddonAssociationStatusId, "active")))
+
+	poolID, err := launcher.CreatePoolForVersion(ctx, version, "web")
+	require.NoError(t, err)
+	assert.NotEmpty(t, poolID)
+	assert.Len(t, listAllPools(t, ctx, server), 1)
+}
+
 // TestNonEphemeralPoolUnaffected guards against the ephemeral changes leaking
 // into normal deploys: a non-ephemeral fixed-mode version must still get the
 // configured instance count.

--- a/docs/docs/addons.md
+++ b/docs/docs/addons.md
@@ -289,8 +289,17 @@ When you deploy an app with addons or run `addon create`, Miren:
 
 Provisioning typically takes 1–2 minutes for a new dedicated server (longer if the PostgreSQL image needs to be pulled for the first time).
 
-:::note[Provisioning blocks startup]
-Your app won't start until addon provisioning completes — Miren holds off launching your app's processes until all addons reach active status.
+:::note[Deploys wait for addons]
+`miren deploy` does not activate a new version until every addon declared in app.toml is **active**. While it waits, the deploy output shows each addon's progress:
+
+```
+Provisioning addon miren-postgresql (small)...
+Addon miren-postgresql ready
+```
+
+Deploy-triggered tasks (such as migrations) run only after this point, so they always see the addon's connection variables. If an addon fails to provision, the deploy fails and prints the reason; fix the cause, run `miren addon destroy` for that addon, and redeploy.
+
+An addon attached with `addon create` to an app that is already running follows the same rule: Miren holds off launching the app's processes until the addon reaches active status.
 :::
 
 ### Checking Status
@@ -302,6 +311,16 @@ List addons attached to your app:
 miren addon list -a myapp
 ```
 </CliCommand>
+
+The `STATUS` column shows where each addon is in its lifecycle:
+
+| Status | Meaning |
+|---|---|
+| `pending` | Requested, provisioning has not started |
+| `provisioning` | The backing service is being created |
+| `active` | Ready; connection variables are injected into the app |
+| `error` | Provisioning failed. The reason is shown next to the status. Destroy the addon and recreate it once the cause is fixed. |
+| `deprovisioning` | Being removed |
 
 ### Removing an Addon
 

--- a/servers/app/addons.go
+++ b/servers/app/addons.go
@@ -161,6 +161,8 @@ func (s *AddonsServer) ListInstances(ctx context.Context, state *app_v1alpha.Add
 		instance.SetAddon(string(assoc.Addon))
 		instance.SetVariant(assoc.Variant)
 		instance.SetVersion(assoc.Version)
+		instance.SetStatus(assoc.Status)
+		instance.SetErrorMessage(assoc.ErrorMessage)
 		addons = append(addons, instance)
 	}
 

--- a/servers/app/runtime.go
+++ b/servers/app/runtime.go
@@ -267,6 +267,9 @@ func (a *AppInfo) AppInfo(ctx context.Context, state *app_v1alpha.AppStatusAppIn
 			instance.SetName(addon.NameFromRef(assoc.Addon))
 			instance.SetAddon(string(assoc.Addon))
 			instance.SetVariant(assoc.Variant)
+			instance.SetVersion(assoc.Version)
+			instance.SetStatus(assoc.Status)
+			instance.SetErrorMessage(assoc.ErrorMessage)
 			addons = append(addons, instance)
 		}
 		if len(addons) > 0 {

--- a/servers/build/addon_wait.go
+++ b/servers/build/addon_wait.go
@@ -1,0 +1,268 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/indexwatch"
+)
+
+// addonWaitCeiling bounds the wait as a whole. It sits above the providers'
+// own pool-ready timeouts (5 minutes) so a provisioning failure surfaces as
+// the association's error, with its message, before this deadline turns it
+// into a bare timeout. It must stay well under the deploy lock TTL (30
+// minutes). A variable rather than a constant so tests can shrink it.
+var addonWaitCeiling = 10 * time.Minute
+
+// expectedAddon is one addon the deploy declared and therefore requires to
+// be active before the version can serve.
+type expectedAddon struct {
+	Name    string
+	Variant string
+}
+
+// expectedAddons lists the addons app.toml declares, sorted by name so the
+// deploy's messages come out in a stable order. The key in app.toml is the
+// addon name, optionally with a ":variant" suffix that CreateInstance
+// splits the same way.
+func expectedAddons(ac *appconfig.AppConfig) []expectedAddon {
+	if ac == nil {
+		return nil
+	}
+	out := make([]expectedAddon, 0, len(ac.Addons))
+	for key, cfg := range ac.Addons {
+		name, suffix, _ := strings.Cut(key, ":")
+		variant := suffix
+		if cfg != nil && cfg.Variant != "" {
+			variant = cfg.Variant
+		}
+		out = append(out, expectedAddon{Name: name, Variant: variant})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// awaitAddons blocks until each expected addon has an active association on
+// the app. With nothing expected it returns at once without touching the
+// store.
+//
+// Creating an association only records the request; the addon controller
+// provisions the backing service on its own clock and flips the association
+// to active once the database is listening and reachable. Nothing downstream
+// of the deploy can use the addon before that: ResolveRuntimeConfig injects
+// variables only from active associations, so a deploy task run earlier
+// would have no DATABASE_URL, and a version activated earlier would sit at
+// 0/0 instances until the launcher's gate released it, long after the CLI
+// gave up waiting for health.
+//
+// The wait is driven by what the deploy declared, not by whatever records
+// happen to exist. An expected addon whose association is not visible yet is
+// simply not active yet, so a slow index never lets the deploy through
+// early. It watches the app's association index rather than polling it, so
+// the deploy moves on the moment the controller flips the status.
+//
+// An expected addon in error fails the deploy: error is terminal in the
+// controller and nothing in a redeploy heals it, so the user has to act, and
+// the message says how. One being deprovisioned fails too: it was destroyed
+// out from under this deploy and will not come back on its own.
+func (b *Builder) awaitAddons(
+	ctx context.Context,
+	appName string,
+	appID entity.Id,
+	expected []expectedAddon,
+	status StatusSender,
+) error {
+	if len(expected) == 0 {
+		return nil
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	w := indexwatch.New(b.EAS, entity.Ref(addon_v1alpha.AddonAssociationAppId, appID), indexwatch.Options{
+		Logger:     b.Log.With("component", "addon-wait", "app", appName),
+		BufferSize: 16,
+	})
+	if err := w.Start(watchCtx); err != nil {
+		return fmt.Errorf("watching addon associations for app %q: %w", appName, err)
+	}
+	defer w.Stop()
+
+	deadline := time.NewTimer(addonWaitCeiling)
+	defer deadline.Stop()
+
+	state := newAddonWaitState(appName, expected, status)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-deadline.C:
+			return fmt.Errorf("addons did not become ready within %s: %s",
+				addonWaitCeiling, strings.Join(state.waiting(), ", "))
+
+		case ev, ok := <-w.Updates():
+			if !ok {
+				// The watcher only closes Updates when its context ends,
+				// which is our context.
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return fmt.Errorf("addon association watch for app %q ended unexpectedly", appName)
+			}
+
+			state.apply(ev)
+
+			if err := state.failed(); err != nil {
+				return err
+			}
+			if len(state.waiting()) == 0 {
+				return nil
+			}
+		}
+	}
+}
+
+// addonWaitState is the deploy's view of the expected addons, kept current
+// from watch events. Associations for addons the deploy did not declare are
+// ignored.
+type addonWaitState struct {
+	appName  string
+	status   StatusSender
+	expected []expectedAddon
+
+	// current is the latest association seen per expected addon name. An
+	// expected addon absent from this map has no visible record yet.
+	current map[string]*addon_v1alpha.AddonAssociation
+
+	// announced tracks which addons have had a "provisioning" line sent, so
+	// each one gets that line once and a "ready" line once.
+	announced map[string]bool
+	// ready tracks which addons have had their "ready" line sent.
+	ready map[string]bool
+}
+
+func newAddonWaitState(appName string, expected []expectedAddon, status StatusSender) *addonWaitState {
+	return &addonWaitState{
+		appName:   appName,
+		status:    status,
+		expected:  expected,
+		current:   make(map[string]*addon_v1alpha.AddonAssociation, len(expected)),
+		announced: make(map[string]bool, len(expected)),
+		ready:     make(map[string]bool, len(expected)),
+	}
+}
+
+// apply folds one watch event into the state and then emits progress for
+// any expected addon whose situation changed.
+func (s *addonWaitState) apply(ev indexwatch.Event) {
+	switch ev.Type {
+	case indexwatch.EventSync:
+		// A snapshot is the complete current set: anything not in it is gone.
+		s.current = make(map[string]*addon_v1alpha.AddonAssociation, len(s.expected))
+		for _, en := range ev.Entities {
+			s.observe(en)
+		}
+	case indexwatch.EventAdded, indexwatch.EventUpdated:
+		s.observe(ev.Entity)
+	case indexwatch.EventDeleted:
+		for name, assoc := range s.current {
+			if assoc.ID == ev.Id {
+				delete(s.current, name)
+			}
+		}
+	}
+	s.announce()
+}
+
+func (s *addonWaitState) observe(en *entity.Entity) {
+	if en == nil {
+		return
+	}
+	var assoc addon_v1alpha.AddonAssociation
+	assoc.Decode(en)
+	name := addon.NameFromRef(assoc.Addon)
+	if !s.expects(name) {
+		return
+	}
+	s.current[name] = &assoc
+}
+
+func (s *addonWaitState) expects(name string) bool {
+	for _, e := range s.expected {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// announce sends one "provisioning" line per expected addon the first time
+// it is seen not yet active, and one "ready" line when it gets there. An
+// addon that was active from the first snapshot is not news and gets neither.
+func (s *addonWaitState) announce() {
+	for _, e := range s.expected {
+		assoc := s.current[e.Name]
+		active := assoc != nil && assoc.Status == "active"
+
+		switch {
+		case !active && !s.announced[e.Name]:
+			s.announced[e.Name] = true
+			variant := e.Variant
+			if assoc != nil && assoc.Variant != "" {
+				variant = assoc.Variant
+			}
+			if variant != "" {
+				s.status.SendMessage(fmt.Sprintf("Provisioning addon %s (%s)...", e.Name, variant))
+			} else {
+				s.status.SendMessage(fmt.Sprintf("Provisioning addon %s...", e.Name))
+			}
+		case active && s.announced[e.Name] && !s.ready[e.Name]:
+			s.ready[e.Name] = true
+			s.status.SendMessage(fmt.Sprintf("Addon %s ready", e.Name))
+		}
+	}
+}
+
+// waiting returns the names of expected addons that do not yet have an
+// active association, in declaration order.
+func (s *addonWaitState) waiting() []string {
+	var names []string
+	for _, e := range s.expected {
+		assoc := s.current[e.Name]
+		if assoc == nil || assoc.Status != "active" {
+			names = append(names, e.Name)
+		}
+	}
+	return names
+}
+
+// failed returns the deploy-ending error for the first expected addon that
+// can no longer become active, or nil.
+func (s *addonWaitState) failed() error {
+	for _, e := range s.expected {
+		assoc := s.current[e.Name]
+		if assoc == nil {
+			continue
+		}
+		switch assoc.Status {
+		case "error":
+			const format = "addon %q failed to provision: %s. Run 'miren addon destroy %s -a %s' and redeploy"
+			s.status.SendError(format, e.Name, assoc.ErrorMessage, e.Name, s.appName)
+			return fmt.Errorf(format, e.Name, assoc.ErrorMessage, e.Name, s.appName)
+		case "deprovisioning":
+			const format = "addon %q is being removed from app %q; redeploy once it is gone"
+			s.status.SendError(format, e.Name, s.appName)
+			return fmt.Errorf(format, e.Name, s.appName)
+		}
+	}
+	return nil
+}

--- a/servers/build/addon_wait_test.go
+++ b/servers/build/addon_wait_test.go
@@ -1,0 +1,227 @@
+package build
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+const testAddonRef = entity.Id("addon/miren-postgresql")
+
+var expectPostgres = []expectedAddon{{Name: "miren-postgresql", Variant: "small"}}
+
+// addonWaitFixture is a Builder against an in-memory store, whose mock store
+// delivers live index events so the watch path is exercised for real. The
+// ceiling is shrunk so the timeout test runs in milliseconds.
+type addonWaitFixture struct {
+	b     *Builder
+	inmem *testutils.InMemEntityServer
+	appID entity.Id
+}
+
+func newAddonWaitFixture(t *testing.T, ceiling time.Duration) *addonWaitFixture {
+	t.Helper()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	origCeiling := addonWaitCeiling
+	addonWaitCeiling = ceiling
+	t.Cleanup(func() { addonWaitCeiling = origCeiling })
+
+	return &addonWaitFixture{
+		b:     &Builder{Log: testutils.TestLogger(t), EAS: inmem.EAC},
+		inmem: inmem,
+		appID: entity.Id("app/demo"),
+	}
+}
+
+func (f *addonWaitFixture) association(t *testing.T, name string, assoc *addon_v1alpha.AddonAssociation) entity.Id {
+	t.Helper()
+	assoc.App = f.appID
+	if assoc.Addon == "" {
+		assoc.Addon = testAddonRef
+	}
+	id, err := f.inmem.Client.Create(context.Background(), name, assoc)
+	require.NoError(t, err)
+	return id
+}
+
+func (f *addonWaitFixture) setStatus(t *testing.T, id entity.Id, status string) {
+	t.Helper()
+	err := f.inmem.Client.Patch(context.Background(), id, 0,
+		entity.String(addon_v1alpha.AddonAssociationStatusId, status))
+	require.NoError(t, err)
+}
+
+func (f *addonWaitFixture) await(expected []expectedAddon, sender StatusSender) error {
+	return f.b.awaitAddons(context.Background(), "demo", f.appID, expected, sender)
+}
+
+// The wait has to release once the addon controller flips the association,
+// and the user watching the deploy has to see both ends of it.
+func TestAwaitAddonsReturnsWhenAssociationGoesActive(t *testing.T) {
+	f := newAddonWaitFixture(t, 5*time.Second)
+	id := f.association(t, "assoc-pending", &addon_v1alpha.AddonAssociation{
+		Variant: "small",
+		Status:  "pending",
+	})
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		f.setStatus(t, id, "active")
+	}()
+
+	sender := &recordingSender{}
+	require.NoError(t, f.await(expectPostgres, sender))
+
+	assert.Equal(t, []string{
+		"Provisioning addon miren-postgresql (small)...",
+		"Addon miren-postgresql ready",
+	}, sender.Messages)
+}
+
+// The deploy declared the addon, so the wait must hold even before the
+// association record is visible: a slow index must not let the deploy
+// through as though there were nothing to wait for.
+func TestAwaitAddonsWaitsForAnAssociationThatDoesNotExistYet(t *testing.T) {
+	f := newAddonWaitFixture(t, 5*time.Second)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		f.association(t, "assoc-late", &addon_v1alpha.AddonAssociation{
+			Variant: "small",
+			Status:  "active",
+		})
+	}()
+
+	sender := &recordingSender{}
+	require.NoError(t, f.await(expectPostgres, sender))
+
+	assert.Equal(t, []string{
+		"Provisioning addon miren-postgresql (small)...",
+		"Addon miren-postgresql ready",
+	}, sender.Messages)
+}
+
+// An addon that was already active is not news; a redeploy of an app whose
+// addons are all up must return at once and say nothing.
+func TestAwaitAddonsIsSilentWhenAlreadyActive(t *testing.T) {
+	f := newAddonWaitFixture(t, time.Second)
+	f.association(t, "assoc-active", &addon_v1alpha.AddonAssociation{Status: "active"})
+
+	sender := &recordingSender{}
+	require.NoError(t, f.await(expectPostgres, sender))
+	assert.Empty(t, sender.Messages)
+}
+
+// Error is terminal in the addon controller and a redeploy cannot heal it, so
+// the deploy must fail here, carrying the controller's reason and the fix,
+// rather than 90 seconds later in the CLI's health wait with "0 of 0 ready".
+func TestAwaitAddonsFailsOnErrorWithMessageAndGuidance(t *testing.T) {
+	f := newAddonWaitFixture(t, time.Second)
+	f.association(t, "assoc-error", &addon_v1alpha.AddonAssociation{
+		Status:       "error",
+		ErrorMessage: "pool never became ready",
+	})
+
+	sender := &recordingSender{}
+	err := f.await(expectPostgres, sender)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "miren-postgresql")
+	assert.Contains(t, err.Error(), "pool never became ready")
+	assert.Contains(t, err.Error(), "miren addon destroy miren-postgresql -a demo")
+	require.Len(t, sender.Errors, 1, "the reason must reach the deploy stream too")
+	assert.Contains(t, sender.Errors[0], "failed to provision")
+}
+
+// A declared addon that is being removed was destroyed out from under this
+// deploy and will not come back on its own; say so instead of waiting out
+// the ceiling.
+func TestAwaitAddonsFailsWhenExpectedAddonIsDeprovisioning(t *testing.T) {
+	f := newAddonWaitFixture(t, time.Second)
+	f.association(t, "assoc-leaving", &addon_v1alpha.AddonAssociation{Status: "deprovisioning"})
+
+	err := f.await(expectPostgres, &recordingSender{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "being removed")
+}
+
+func TestAwaitAddonsFailsAtCeiling(t *testing.T) {
+	f := newAddonWaitFixture(t, 30*time.Millisecond)
+	f.association(t, "assoc-stuck", &addon_v1alpha.AddonAssociation{Status: "provisioning"})
+
+	err := f.await(expectPostgres, &recordingSender{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not become ready")
+	assert.Contains(t, err.Error(), "miren-postgresql")
+}
+
+// Only the declared addons matter. One the deploy did not ask for, whatever
+// its state, must neither hold the deploy nor fail it.
+func TestAwaitAddonsIgnoresUndeclaredAssociations(t *testing.T) {
+	f := newAddonWaitFixture(t, time.Second)
+	f.association(t, "assoc-other", &addon_v1alpha.AddonAssociation{
+		Addon:  entity.Id("addon/miren-valkey"),
+		Status: "error",
+	})
+	f.association(t, "assoc-pg", &addon_v1alpha.AddonAssociation{Status: "active"})
+
+	sender := &recordingSender{}
+	require.NoError(t, f.await(expectPostgres, sender))
+	assert.Empty(t, sender.Messages)
+}
+
+// With nothing declared there is nothing to wait for, and the store must not
+// even be consulted: this is every deploy of an app without addons.
+func TestAwaitAddonsReturnsImmediatelyWhenNothingExpected(t *testing.T) {
+	f := newAddonWaitFixture(t, time.Second)
+	f.b.EAS = nil // any touch of the store would panic
+
+	sender := &recordingSender{}
+	require.NoError(t, f.await(nil, sender))
+	assert.Empty(t, sender.Messages)
+}
+
+// A cancelled deploy must stop waiting rather than run out the ceiling.
+func TestAwaitAddonsHonorsCancellation(t *testing.T) {
+	f := newAddonWaitFixture(t, time.Minute)
+	f.association(t, "assoc-slow", &addon_v1alpha.AddonAssociation{Status: "pending"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	err := f.b.awaitAddons(ctx, "demo", f.appID, expectPostgres, &recordingSender{})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// The expected set comes from app.toml. The key is the addon name, a
+// ":variant" suffix on the key is honored the way CreateInstance honors it,
+// and an explicit variant field wins over the suffix.
+func TestExpectedAddonsFromConfig(t *testing.T) {
+	assert.Nil(t, expectedAddons(nil))
+	assert.Empty(t, expectedAddons(&appconfig.AppConfig{}))
+
+	got := expectedAddons(&appconfig.AppConfig{Addons: map[string]*appconfig.AddonConfig{
+		"miren-valkey":           nil,
+		"miren-postgresql":       {Variant: "shared"},
+		"miren-mysql:small":      {},
+		"miren-rabbitmq:default": {Variant: "small"},
+	}})
+	assert.Equal(t, []expectedAddon{
+		{Name: "miren-mysql", Variant: "small"},
+		{Name: "miren-postgresql", Variant: "shared"},
+		{Name: "miren-rabbitmq", Variant: "small"},
+		{Name: "miren-valkey", Variant: ""},
+	}, got)
+}

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1921,11 +1921,26 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 		deploy.setPhase(ctx, deploylifecycle.PhaseActivating)
 
 		// Provision addons before activating the version so that AddonAssociation
-		// entities exist when the launcher runs. The addon controller will create
-		// a new AppVersion with addon vars once provisioning completes.
+		// entities exist when the launcher runs.
 		if ac != nil && b.addonsClient != nil {
 			if err := b.provisionAddons(ctx, name, ac); err != nil {
 				return nil, fmt.Errorf("addon provisioning failed: %w", err)
+			}
+		}
+
+		var expected []expectedAddon
+		if b.addonsClient != nil {
+			expected = expectedAddons(ac)
+		}
+
+		// Hold the deploy until every declared addon is active. Creating an
+		// association only records the request; deploy tasks and the version
+		// flip both need the backing service to actually exist. Mirrors the
+		// saga's waitAddons action.
+		if len(expected) > 0 {
+			if addonErr := b.awaitAddons(ctx, name, appRec.ID, expected, NewRPCStatusSender(status, b.Log)); addonErr != nil {
+				b.sendErrorStatus(ctx, status, "%s", addonErr)
+				return nil, addonErr
 			}
 		}
 
@@ -1933,11 +1948,6 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 		// runDeployTasks action and has to exist here too: the saga builder is
 		// behind a labs flag, so this is the path that actually runs today.
 		if len(deployTriggeredTasks(&configSpec)) > 0 {
-			appRec, appErr := b.appClient.GetByName(ctx, name)
-			if appErr != nil {
-				return nil, fmt.Errorf("reading app for deploy tasks: %w", appErr)
-			}
-
 			if taskErr := b.runDeployTasks(ctx, name, appRec.ID, id, &configSpec,
 				NewRPCStatusSender(status, b.Log)); taskErr != nil {
 				b.sendErrorStatus(ctx, status, "%s", taskErr)

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -38,6 +38,7 @@ const (
 	actionCreateConfigVer = "create-config-version"
 	actionCreateVersion   = "create-version"
 	actionProvisionAddons = "provision-addons"
+	actionWaitAddons      = "wait-addons"
 	actionRunDeployTasks  = "run-deploy-tasks"
 	actionSetActiveVer    = "set-active-version"
 	actionFinalize        = "finalize"
@@ -561,14 +562,70 @@ func undoProvisionAddons(_ context.Context, _ provisionAddonsIn, _ provisionAddo
 	return nil
 }
 
+// waitAddons blocks the deploy until every addon app.toml declares has an
+// active association on the app. provisionAddons only records the request;
+// this is the step that makes addons_ready mean what it says, so deploy tasks
+// and the version flip both see a database that exists.
+//
+// It is its own action rather than a tail on provisionAddons so a coordinator
+// restart mid-wait resumes only the wait: the create/remove reconciliation is
+// never re-run. It is a pure read, so re-entry is safe. It takes the expected
+// set from the same app config provisionAddons acted on, so it never depends
+// on the association records already being visible.
+
+type waitAddonsIn struct {
+	AppName        string               `json:"app_name" saga:"app_name"`
+	StreamID       string               `json:"stream_id" saga:"stream_id"`
+	AppConfig      *appconfig.AppConfig `json:"app_config,omitempty" saga:"app_config,optional"`
+	EphemeralLabel string               `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
+	Provisioned    saga.Edge            `saga:"addons_provisioned"`
+}
+
+type waitAddonsOut struct {
+	Done saga.Edge `saga:"addons_ready"`
+}
+
+func waitAddons(ctx context.Context, in waitAddonsIn) (waitAddonsOut, error) {
+	// An ephemeral preview shares the app's addons and is not gated on them;
+	// the launcher holds its pools back the same way it does the app's.
+	if in.EphemeralLabel != "" {
+		return waitAddonsOut{}, nil
+	}
+	expected := expectedAddons(in.AppConfig)
+	if len(expected) == 0 {
+		return waitAddonsOut{}, nil
+	}
+
+	deps := saga.Get[*buildSagaDeps](ctx)
+	b := deps.builder
+	if b.addonsClient == nil {
+		return waitAddonsOut{}, nil
+	}
+
+	appRec, err := b.appClient.GetByName(ctx, in.AppName)
+	if err != nil {
+		return waitAddonsOut{}, fmt.Errorf("reading app: %w", err)
+	}
+
+	if err := b.awaitAddons(ctx, in.AppName, appRec.ID, expected, deps.statuses.SenderFor(in.StreamID)); err != nil {
+		return waitAddonsOut{}, err
+	}
+	return waitAddonsOut{}, nil
+}
+
+func undoWaitAddons(_ context.Context, _ waitAddonsIn, _ waitAddonsOut) error {
+	return nil
+}
+
 // setActiveVersion keeps the persisted saga action name, but no longer writes
 // either app pointer. It runs the last promotion checks; activateDeployment
 // performs the paired active_version and active_deployment update later.
 
 // runDeployTasksIn gates the version flip on every deploy-triggered task.
 //
-// It consumes addons_provisioned so it runs only once the app's backing
-// services exist -- a migration needs its database -- and produces an edge
+// It consumes addons_ready so it runs only once the app's backing services
+// are active -- a migration needs its database, and its DATABASE_URL only
+// exists once the association is active -- and produces an edge
 // setActiveVersion consumes, which is what puts it strictly before any traffic
 // moves.
 type runDeployTasksIn struct {
@@ -577,7 +634,7 @@ type runDeployTasksIn struct {
 	AppVersionID   string    `json:"app_version_id" saga:"app_version_id"`
 	ConfigSpec     string    `json:"config_spec_json" saga:"config_spec_json"`
 	EphemeralLabel string    `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
-	AddonsReady    saga.Edge `saga:"addons_provisioned"`
+	AddonsReady    saga.Edge `saga:"addons_ready"`
 }
 
 type runDeployTasksOut struct {
@@ -633,7 +690,7 @@ type setActiveVersionIn struct {
 	AppVersionID   string               `json:"app_version_id" saga:"app_version_id"`
 	EphemeralLabel string               `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
 	AppConfig      *appconfig.AppConfig `json:"app_config,omitempty" saga:"app_config,optional"`
-	AddonsReady    saga.Edge            `saga:"addons_provisioned"`
+	AddonsReady    saga.Edge            `saga:"addons_ready"`
 	// DeployTasksRan puts the promotion gate strictly after every
 	// deploy-triggered task has succeeded, so a failed task means a failed
 	// deploy rather than a half-promoted one.
@@ -1045,6 +1102,7 @@ func registerBuildSaga(
 		Action(actionCreateConfigVer, createConfigVersion).Undo(undoCreateConfigVersion).
 		Action(actionCreateVersion, createVersion).Undo(undoCreateVersion).
 		Action(actionProvisionAddons, provisionAddons).Undo(undoProvisionAddons).
+		Action(actionWaitAddons, waitAddons).Undo(undoWaitAddons).
 		Action(actionRunDeployTasks, runDeployTasks).Undo(undoRunDeployTasks).
 		Action(actionSetActiveVer, setActiveVersion).Undo(undoSetActiveVersion).
 		Action(actionFinalize, finalize).Undo(undoFinalize).

--- a/servers/build/build_saga_deploy_test.go
+++ b/servers/build/build_saga_deploy_test.go
@@ -68,6 +68,7 @@ func newDeploySagaHarnessWith(t *testing.T, setActive any) *sagaTestHarness {
 		Action(actionCreateConfigVer, createConfigVersion).Undo(undoCreateConfigVersion).
 		Action(actionCreateVersion, createVersion).Undo(undoCreateVersion).
 		Action(actionProvisionAddons, provisionAddons).Undo(undoProvisionAddons).
+		Action(actionWaitAddons, waitAddons).Undo(undoWaitAddons).
 		Action(actionSetActiveVer, setActive).Undo(undoSetActiveVersion).
 		Action(actionFinalize, finalize).Undo(undoFinalize).
 		Action(actionBeginDeploy, beginDeployment).Undo(undoBeginDeployment).

--- a/servers/build/build_saga_test.go
+++ b/servers/build/build_saga_test.go
@@ -87,6 +87,7 @@ func newSagaTestHarness(t *testing.T) *sagaTestHarness {
 		Action(actionCreateConfigVer, createConfigVersion).Undo(undoCreateConfigVersion).
 		Action(actionCreateVersion, createVersion).Undo(undoCreateVersion).
 		Action(actionProvisionAddons, provisionAddons).Undo(undoProvisionAddons).
+		Action(actionWaitAddons, waitAddons).Undo(undoWaitAddons).
 		Action(actionSetActiveVer, setActiveVersion).Undo(undoSetActiveVersion).
 		Action(actionFinalize, finalize).Undo(undoFinalize).
 		Action(actionBeginDeploy, beginDeployment).Undo(undoBeginDeployment).
@@ -629,6 +630,7 @@ func TestBuildSaga_FailedActivate_CompensatesEntities(t *testing.T) {
 		Action(actionCreateConfigVer, createConfigVersion).Undo(undoCreateConfigVersion).
 		Action(actionCreateVersion, createVersion).Undo(undoCreateVersion).
 		Action(actionProvisionAddons, provisionAddons).Undo(undoProvisionAddons).
+		Action(actionWaitAddons, waitAddons).Undo(undoWaitAddons).
 		Action(actionSetActiveVer, failingSetActive).Undo(undoSetActiveVersion).
 		Action(actionFinalize, finalize).Undo(undoFinalize).
 		RegisterTo(registry); err != nil {
@@ -753,11 +755,15 @@ func TestBuildSaga_DeployTasksGateSitsBetweenAddonsAndActivation(t *testing.T) {
 	}
 
 	addons := pos(actionProvisionAddons)
+	wait := pos(actionWaitAddons)
 	tasks := pos(actionRunDeployTasks)
 	activate := pos(actionSetActiveVer)
 
-	if addons >= tasks {
-		t.Errorf("deploy tasks must run after addons are provisioned (a migration needs its database); order: %v", order)
+	if addons >= wait {
+		t.Errorf("the addon wait must follow provisioning, or there is nothing to wait on; order: %v", order)
+	}
+	if wait >= tasks {
+		t.Errorf("deploy tasks must run after addons are active (a migration needs its database); order: %v", order)
 	}
 	if tasks >= activate {
 		t.Errorf("deploy tasks must gate the version flip, or a failed task leaves a half-promoted deploy; order: %v", order)

--- a/servers/build/deploy_tasks.go
+++ b/servers/build/deploy_tasks.go
@@ -28,8 +28,8 @@ const (
 // runDeployTasks creates a Run for every task triggered by deploy and waits for
 // all of them.
 //
-// It sits between addons being ready and ActiveVersion flipping, which is the
-// only hook point in the deploy and deliberately so. Gating here means the runs
+// It sits between addons being active (awaitAddons) and ActiveVersion
+// flipping, which is the only hook point in the deploy and deliberately so. Gating here means the runs
 // complete or fail while the previous version is still the only thing serving:
 // there is no partial rollout to unwind, no traffic to shift back, and no
 // compensation step. A failed deploy task is a failed deploy, not a


### PR DESCRIPTION
Deploying an app with an addon in app.toml had a race baked into it. The deploy created the addon association and moved straight on, but the association starts out pending and the addon controller brings it to active on its own clock. Everything downstream assumed the addon was already usable. Deploy-triggered migrations ran with no `DATABASE_URL` (the runtime config only injects variables from active associations). The version activated with nothing able to serve. And the CLI's 90 second health wait timed out with "0 of 0 instances ready" and no hint that Postgres was still booting. The launcher did have a gate holding pools back while the addon provisioned, but it was silent, and it didn't cover the on-demand pool path that ephemeral versions use.

The fix is to make the deploy itself wait. The build saga gets a `wait-addons` action between provisioning and deploy tasks. It takes the set of addons app.toml declares and watches the app's association index until each one has an active association. Driving it from the declared set rather than from whatever records exist means it never depends on the association being visible yet, and it does nothing at all for an app without addons. Progress goes out on the deploy stream ("Provisioning addon miren-postgresql (small)..." then "Addon miren-postgresql ready"), and an association in error fails the deploy with the controller's reason and the fix. The legacy non-saga path does the same, and the `addons_ready` edge now means what the deploy-tasks comment always claimed it did.

Running the new blackbox test turned up a second gap: those progress lines, and the existing deploy-task ones, only ever reached the interactive build TUI. Non-interactive deploys (CI, the blackbox harness) dropped every server message on the floor. The CLI now prints them as lines on stderr in that mode too.

A few smaller things came along for the ride. `CreatePoolForVersion` now checks the same addon gate `Reconcile` does, so an ephemeral version can't build a pool without its addon variables. The `AddonInstance` RPC type carries `status` and `error_message`, and `miren addon list` shows a STATUS column, so a stuck or errored addon is visible instead of indistinguishable from a healthy one. The blackbox harness's `WaitForAddonReady` now requires active rather than mere presence. And there's a new blackbox test that deploys an app with an addon and then redeploys it twice, checking that the first deploy waits and the later ones find the addon already active and come up immediately.

Closes MIR-1804
