### PR TITLE
Retire the distributedrunners labs flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -481,7 +481,7 @@ jobs:
     # result, so the condition lives here in one place.
     #
     # The distributed suite exercises the multi-node topology (a coordinator plus
-    # a separate runner peer) with distributedrunners enabled. Setup is heavy
+    # a separate runner peer). Setup is heavy
     # (iso peers, a binary build, the join dance) and it's the only place a
     # second node exists, so a bug there is invisible until it's already on main
     # blocking a release (exactly how MIR-1469 got in). It therefore runs on

--- a/.iso/peers.yml
+++ b/.iso/peers.yml
@@ -12,7 +12,6 @@ peers:
     hostname: coordinator
     environment:
       ROLE: coordinator
-      MIREN_LABS: distributedrunners
     ports:
       - "8443:8443"
 
@@ -20,4 +19,3 @@ peers:
     hostname: runner1
     environment:
       ROLE: runner
-      MIREN_LABS: distributedrunners

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ make test-blackbox-distributed
 make dev-distributed-down
 ```
 
-The distributed environment uses `.iso/peers.yml` to define two peers (coordinator and runner1) and connects them to the existing services (etcd, VictoriaMetrics, VictoriaLogs). The `MIREN_LABS=distributedrunners` feature flag is set on both peers.
+The distributed environment uses `.iso/peers.yml` to define two peers (coordinator and runner1) and connects them to the existing services (etcd, VictoriaMetrics, VictoriaLogs).
 
 Blackbox tests that are specific to distributed topologies (runner list, metrics pipeline, log pipeline) live in `blackbox/distributed_runner_test.go` and self-skip when not running in peers mode.
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"miren.dev/mflags"
-	"miren.dev/runtime/pkg/labs"
 )
 
 func RegisterAll(d *mflags.Dispatcher) {
@@ -895,175 +894,156 @@ miren deploy --analyze
 		}),
 	))
 
-	// Runner commands (distributed runners) - behind feature flag
-	if labs.DistributedRunners() {
-		d.Dispatch("runner", Section("runner", "Runner management commands", "", WithSectionGroup(GroupServer)))
-		d.Dispatch("runner token", Section("runner token", "Manage join tokens", ""))
-		d.Dispatch("runner token create", Infer("runner token create", "Create a join token for a runner", RunnerTokenCreate,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Create a one-time join token",
-				Body: "miren runner token create",
-			}),
-			WithExample(mflags.Example{
-				Name: "Create a reusable token for automation",
-				Body: "miren runner token create --reusable --name infra-terraform --ttl 0",
-			}),
-			WithExample(mflags.Example{
-				Name: "Create a token with a specific coordinator address",
-				Body: "miren runner token create --addr 10.0.0.5:8443",
-			}),
-		))
-		d.Dispatch("runner join", Infer("runner join", "Join this machine to a coordinator as a runner", RunnerJoin,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Join using a token",
-				Body: "miren runner join mren_...",
-			}),
-			WithExample(mflags.Example{
-				Name: "Join with coordinator address override",
-				Body: "miren runner join mren_... --coordinator 10.0.0.5:8443",
-			}),
-		))
-		d.Dispatch("runner reissue", Infer("runner reissue", "Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity", RunnerReissue,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Rotate this runner's certificate",
-				Body: "miren runner reissue",
-			}),
-		))
-		d.Dispatch("runner start", Infer("runner start", "Start this machine as a distributed runner", RunnerStart,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithDaemon(),
-			WithExample(mflags.Example{
-				Name: "Start the runner",
-				Body: "miren runner start",
-			}),
-		))
-		d.Dispatch("runner list", Infer("runner list", "List all registered runners", RunnerList,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "List runners",
-				Body: "miren runner list",
-			}),
-		))
-		d.Dispatch("runner status", Infer("runner status", "Show runner health and configuration", RunnerStatus,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Check runner status",
-				Body: "miren runner status",
-			}),
-		))
-		d.Dispatch("runner token revoke", Infer("runner token revoke", "Revoke a join token", RunnerTokenRevoke,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Revoke a token",
-				Body: "miren runner token revoke inv_abc123",
-			}),
-		))
-		d.Dispatch("runner token list", Infer("runner token list", "List all join tokens", RunnerTokenList,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "List tokens",
-				Body: "miren runner token list",
-			}),
-		))
-		d.Dispatch("runner remove", Infer("runner remove", "Remove a registered runner and clean up resources", RunnerRemove,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Remove a runner by name",
-				Body: "miren runner remove my-runner",
-			}),
-			WithExample(mflags.Example{
-				Name: "Force remove a runner with active sandboxes",
-				Body: "miren runner remove my-runner --force",
-			}),
-		))
-		d.Dispatch("runner cordon", Infer("runner cordon", "Mark a runner unschedulable without stopping its sandboxes", RunnerCordon,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Cordon a runner",
-				Body: "miren runner cordon my-runner",
-			}),
-			WithExample(mflags.Example{
-				Name: "Cordon with a reason",
-				Body: "miren runner cordon my-runner --reason \"cert rotation\"",
-			}),
-		))
-		d.Dispatch("runner uncordon", Infer("runner uncordon", "Make a cordoned runner eligible for scheduling again", RunnerUncordon,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Uncordon a runner",
-				Body: "miren runner uncordon my-runner",
-			}),
-		))
-		d.Dispatch("runner drain", Infer("runner drain", "Cordon a runner and evict its sandboxes onto other nodes", RunnerDrain,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Drain a runner before maintenance",
-				Body: "miren runner drain my-runner",
-			}),
-			WithExample(mflags.Example{
-				Name: "Drain with a timeout",
-				Body: "miren runner drain my-runner --timeout 300",
-			}),
-		))
-		d.Dispatch("runner install", Infer("runner install", "Install systemd service for miren runner", RunnerInstall,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Install interactively",
-				Body: "miren runner install",
-			}),
-			WithExample(mflags.Example{
-				Name: "Install with token (for automation)",
-				Body: "miren runner install --token mren_...",
-			}),
-		))
-		d.Dispatch("runner uninstall", Infer("runner uninstall", "Remove systemd service for miren runner", RunnerUninstall,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Uninstall the runner service",
-				Body: "miren runner uninstall",
-			}),
-			WithExample(mflags.Example{
-				Name: "Uninstall and remove all runner data",
-				Body: "miren runner uninstall --remove-data",
-			}),
-		))
-		d.Dispatch("runner service-status", Infer("runner service-status", "Show miren-runner systemd service status", RunnerServiceStatus,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Show service status",
-				Body: "miren runner service-status",
-			}),
-			WithExample(mflags.Example{
-				Name: "Follow service logs",
-				Body: "miren runner service-status --follow",
-			}),
-		))
-		d.Dispatch("runner upgrade", Infer("runner upgrade", "Upgrade miren runner to the latest or specified version", RunnerUpgrade,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Upgrade to the latest version",
-				Body: "miren runner upgrade",
-			}),
-			WithExample(mflags.Example{
-				Name: "Check for available updates",
-				Body: "miren runner upgrade --check",
-			}),
-			WithExample(mflags.Example{
-				Name: "Upgrade to a specific version",
-				Body: "miren runner upgrade --version v0.2.0",
-			}),
-		))
-		d.Dispatch("runner upgrade rollback", Infer("runner upgrade rollback", "Rollback runner to previous version", RunnerUpgradeRollback,
-			WithLabsFeature(labs.FeatureDistributedRunners),
-			WithExample(mflags.Example{
-				Name: "Rollback to the previous version",
-				Body: "miren runner upgrade rollback",
-			}),
-		))
-	}
+	// Runner commands
+	d.Dispatch("runner", Section("runner", "Runner management commands", "", WithSectionGroup(GroupServer)))
+	d.Dispatch("runner token", Section("runner token", "Manage join tokens", ""))
+	d.Dispatch("runner token create", Infer("runner token create", "Create a join token for a runner", RunnerTokenCreate,
+		WithExample(mflags.Example{
+			Name: "Create a one-time join token",
+			Body: "miren runner token create",
+		}),
+		WithExample(mflags.Example{
+			Name: "Create a reusable token for automation",
+			Body: "miren runner token create --reusable --name infra-terraform --ttl 0",
+		}),
+		WithExample(mflags.Example{
+			Name: "Create a token with a specific coordinator address",
+			Body: "miren runner token create --addr 10.0.0.5:8443",
+		}),
+	))
+	d.Dispatch("runner join", Infer("runner join", "Join this machine to a coordinator as a runner", RunnerJoin,
+		WithExample(mflags.Example{
+			Name: "Join using a token",
+			Body: "miren runner join mren_...",
+		}),
+		WithExample(mflags.Example{
+			Name: "Join with coordinator address override",
+			Body: "miren runner join mren_... --coordinator 10.0.0.5:8443",
+		}),
+	))
+	d.Dispatch("runner reissue", Infer("runner reissue", "Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity", RunnerReissue,
+		WithExample(mflags.Example{
+			Name: "Rotate this runner's certificate",
+			Body: "miren runner reissue",
+		}),
+	))
+	d.Dispatch("runner start", Infer("runner start", "Start this machine as a distributed runner", RunnerStart,
+		WithDaemon(),
+		WithExample(mflags.Example{
+			Name: "Start the runner",
+			Body: "miren runner start",
+		}),
+	))
+	d.Dispatch("runner list", Infer("runner list", "List all registered runners", RunnerList,
+		WithExample(mflags.Example{
+			Name: "List runners",
+			Body: "miren runner list",
+		}),
+	))
+	d.Dispatch("runner status", Infer("runner status", "Show runner health and configuration", RunnerStatus,
+		WithExample(mflags.Example{
+			Name: "Check runner status",
+			Body: "miren runner status",
+		}),
+	))
+	d.Dispatch("runner token revoke", Infer("runner token revoke", "Revoke a join token", RunnerTokenRevoke,
+		WithExample(mflags.Example{
+			Name: "Revoke a token",
+			Body: "miren runner token revoke inv_abc123",
+		}),
+	))
+	d.Dispatch("runner token list", Infer("runner token list", "List all join tokens", RunnerTokenList,
+		WithExample(mflags.Example{
+			Name: "List tokens",
+			Body: "miren runner token list",
+		}),
+	))
+	d.Dispatch("runner remove", Infer("runner remove", "Remove a registered runner and clean up resources", RunnerRemove,
+		WithExample(mflags.Example{
+			Name: "Remove a runner by name",
+			Body: "miren runner remove my-runner",
+		}),
+		WithExample(mflags.Example{
+			Name: "Force remove a runner with active sandboxes",
+			Body: "miren runner remove my-runner --force",
+		}),
+	))
+	d.Dispatch("runner cordon", Infer("runner cordon", "Mark a runner unschedulable without stopping its sandboxes", RunnerCordon,
+		WithExample(mflags.Example{
+			Name: "Cordon a runner",
+			Body: "miren runner cordon my-runner",
+		}),
+		WithExample(mflags.Example{
+			Name: "Cordon with a reason",
+			Body: "miren runner cordon my-runner --reason \"cert rotation\"",
+		}),
+	))
+	d.Dispatch("runner uncordon", Infer("runner uncordon", "Make a cordoned runner eligible for scheduling again", RunnerUncordon,
+		WithExample(mflags.Example{
+			Name: "Uncordon a runner",
+			Body: "miren runner uncordon my-runner",
+		}),
+	))
+	d.Dispatch("runner drain", Infer("runner drain", "Cordon a runner and evict its sandboxes onto other nodes", RunnerDrain,
+		WithExample(mflags.Example{
+			Name: "Drain a runner before maintenance",
+			Body: "miren runner drain my-runner",
+		}),
+		WithExample(mflags.Example{
+			Name: "Drain with a timeout",
+			Body: "miren runner drain my-runner --timeout 300",
+		}),
+	))
+	d.Dispatch("runner install", Infer("runner install", "Install systemd service for miren runner", RunnerInstall,
+		WithExample(mflags.Example{
+			Name: "Install interactively",
+			Body: "miren runner install",
+		}),
+		WithExample(mflags.Example{
+			Name: "Install with token (for automation)",
+			Body: "miren runner install --token mren_...",
+		}),
+	))
+	d.Dispatch("runner uninstall", Infer("runner uninstall", "Remove systemd service for miren runner", RunnerUninstall,
+		WithExample(mflags.Example{
+			Name: "Uninstall the runner service",
+			Body: "miren runner uninstall",
+		}),
+		WithExample(mflags.Example{
+			Name: "Uninstall and remove all runner data",
+			Body: "miren runner uninstall --remove-data",
+		}),
+	))
+	d.Dispatch("runner service-status", Infer("runner service-status", "Show miren-runner systemd service status", RunnerServiceStatus,
+		WithExample(mflags.Example{
+			Name: "Show service status",
+			Body: "miren runner service-status",
+		}),
+		WithExample(mflags.Example{
+			Name: "Follow service logs",
+			Body: "miren runner service-status --follow",
+		}),
+	))
+	d.Dispatch("runner upgrade", Infer("runner upgrade", "Upgrade miren runner to the latest or specified version", RunnerUpgrade,
+		WithExample(mflags.Example{
+			Name: "Upgrade to the latest version",
+			Body: "miren runner upgrade",
+		}),
+		WithExample(mflags.Example{
+			Name: "Check for available updates",
+			Body: "miren runner upgrade --check",
+		}),
+		WithExample(mflags.Example{
+			Name: "Upgrade to a specific version",
+			Body: "miren runner upgrade --version v0.2.0",
+		}),
+	))
+	d.Dispatch("runner upgrade rollback", Infer("runner upgrade rollback", "Rollback runner to previous version", RunnerUpgradeRollback,
+		WithExample(mflags.Example{
+			Name: "Rollback to the previous version",
+			Body: "miren runner upgrade rollback",
+		}),
+	))
 
 	// Server commands
 	d.Dispatch("server", Infer("server", "Start the miren server", Server,

--- a/cli/commands/global_test.go
+++ b/cli/commands/global_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"miren.dev/mflags"
-	"miren.dev/runtime/pkg/labs"
 )
 
 // TestVerbosityLadder pins the level each -v count resolves to for both kinds of
@@ -69,11 +68,6 @@ func TestWithDaemonMarksCommand(t *testing.T) {
 // is silent — the process just goes quiet — and the last time a runner ran
 // quieter than intended it took a fleet-wide systemd override to notice.
 func TestDaemonCommandsAreRegisteredAsDaemons(t *testing.T) {
-	// `runner start` only registers with distributed runners enabled, and labs
-	// state is process-wide, so put it back when we're done.
-	labs.Init(slog.New(slog.DiscardHandler), []string{labs.FeatureDistributedRunners})
-	t.Cleanup(func() { labs.Init(slog.New(slog.DiscardHandler), nil) })
-
 	d := mflags.NewDispatcher("miren")
 	RegisterAll(d)
 

--- a/cli/commands/runner_install.go
+++ b/cli/commands/runner_install.go
@@ -107,7 +107,7 @@ func RunnerInstall(ctx *Context, opts struct {
 		execStart := strings.Join(execStartParts, " ")
 
 		// Propagate the current MIREN_LABS value so the spawned binary
-		// also has distributed runners (and any other flags) enabled.
+		// runs with the same labs features as the process installing it.
 		labsEnv := os.Getenv("MIREN_LABS")
 
 		serviceContent := fmt.Sprintf(`[Unit]

--- a/cli/commands/server_install_container.go
+++ b/cli/commands/server_install_container.go
@@ -36,7 +36,7 @@ func ServerInstallContainer(ctx *Context, opts struct {
 	ClusterName   string            `long:"cluster-name" description:"Cluster name for cloud registration"`
 	CloudURL      string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
 	Tags          map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
-	Labs          []string          `short:"l" long:"labs" description:"Miren Labs features to enable (e.g. sagas). Prefix with - to disable."`
+	Labs          []string          `short:"l" long:"labs" description:"Miren Labs features to enable (e.g. appvisibility). Prefix with - to disable."`
 }) error {
 	if opts.ClusterName == "" {
 		opts.ClusterName = opts.Name

--- a/components/server/boot_etcd.go
+++ b/components/server/boot_etcd.go
@@ -11,15 +11,13 @@ import (
 	"miren.dev/runtime/components/coordinate"
 	"miren.dev/runtime/components/etcd"
 	"miren.dev/runtime/pkg/boot"
-	"miren.dev/runtime/pkg/labs"
 	"miren.dev/runtime/pkg/serverconfig"
 )
 
 type etcdBootInputs struct {
-	config      serverconfig.EtcdConfig
-	tls         serverconfig.TLSConfig
-	dataPath    string
-	distributed bool
+	config   serverconfig.EtcdConfig
+	tls      serverconfig.TLSConfig
+	dataPath string
 }
 
 type etcdBootOutput struct {
@@ -38,10 +36,9 @@ type etcdBoot struct {
 
 func etcdInputs(options StartOptions) etcdBootInputs {
 	return etcdBootInputs{
-		config:      options.Config.Etcd,
-		tls:         options.Config.TLS,
-		dataPath:    options.Config.Server.GetDataPath(),
-		distributed: labs.DistributedRunners(),
+		config:   options.Config.Etcd,
+		tls:      options.Config.TLS,
+		dataPath: options.Config.Server.GetDataPath(),
 	}
 }
 
@@ -91,18 +88,16 @@ func (b *etcdBoot) startEmbedded(ctx context.Context, ipDiscovery ipDiscoveryBoo
 		QuotaBackendBytes: int64(b.inputs.config.GetQuotaBackendBytes()),
 	}
 
-	if b.inputs.distributed {
-		log.Info("setting up etcd mTLS for distributed runners")
-		if _, err := coordinate.EnsureCA(log, b.inputs.dataPath); err != nil {
-			return etcdBootOutput{}, fmt.Errorf("ensuring CA for etcd TLS: %w", err)
-		}
-		var err error
-		b.result.tls, err = coordinate.SetupEtcdTLS(log, b.inputs.dataPath, b.inputs.tls.AdditionalNames, ipDiscovery.ipSet.RawIPs())
-		if err != nil {
-			return etcdBootOutput{}, fmt.Errorf("setting up etcd TLS: %w", err)
-		}
-		config.TLS = &etcd.TLSConfig{CertsDir: b.result.tls.CertsDir}
+	log.Info("setting up etcd mTLS")
+	if _, err := coordinate.EnsureCA(log, b.inputs.dataPath); err != nil {
+		return etcdBootOutput{}, fmt.Errorf("ensuring CA for etcd TLS: %w", err)
 	}
+	tls, err := coordinate.SetupEtcdTLS(log, b.inputs.dataPath, b.inputs.tls.AdditionalNames, ipDiscovery.ipSet.RawIPs())
+	if err != nil {
+		return etcdBootOutput{}, fmt.Errorf("setting up etcd TLS: %w", err)
+	}
+	b.result.tls = tls
+	config.TLS = &etcd.TLSConfig{CertsDir: tls.CertsDir}
 
 	if err := b.server.Start(ctx, config); err != nil {
 		return etcdBootOutput{}, err

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -13,6 +13,7 @@ All notable changes to Miren Runtime will be documented in this file.
 
 **Breaking Changes**
 - **The `sagas` escape hatch is gone** - Builds and sandbox startup have run on the saga engine by default since v0.14.0, and `--labs -sagas` existed to put a cluster back on the previous code path if that went badly. It shipped a full release without anyone needing it, so both the flag and the path it selected are now removed. `-sagas` is no longer a known feature, so a server still passing it logs `unknown labs feature flag` at boot and starts normally; drop it from your `--labs` or `MIREN_LABS` setting to quiet the warning. Nothing else changes, because the saga path is already what you have been running. ([#1191](https://github.com/mirendev/runtime/pull/1191))
+- **The `distributedrunners` escape hatch is gone** - Distributed runners have been on by default since v0.13.0, with `--labs -distributedrunners` there to hide the `miren runner` commands and skip etcd mTLS setup if the new topology caused trouble. Two releases went by without anyone reaching for it, so the flag and its gating are removed: the runner commands are now always registered, and an embedded etcd always comes up with mTLS. As with `-sagas`, a server still passing `-distributedrunners` logs `unknown labs feature flag` at boot and starts normally; drop it from your `--labs` or `MIREN_LABS` setting to quiet the warning. ([#1192](https://github.com/mirendev/runtime/pull/1192))
 
 ---
 

--- a/docs/docs/command/server-container-install.md
+++ b/docs/docs/command/server-container-install.md
@@ -23,7 +23,7 @@ miren server container install [flags]
 - `--http-port` — HTTP port mapping (default: `80`)
 - `--image, -i` — Container image to use (default: `oci.miren.cloud/miren:latest`)
 - `--ingress-mode` — Ingress mode: tls-autoprovision (default), behind-proxy-http (Miren serves plain HTTP behind a TLS-terminating proxy like tailscale serve / nginx), or behind-proxy-https (Miren terminates TLS on :443 behind a TCP-passthrough proxy)
-- `--labs, -l` — Miren Labs features to enable (e.g. sagas). Prefix with - to disable.
+- `--labs, -l` — Miren Labs features to enable (e.g. appvisibility). Prefix with - to disable.
 - `--name, -n` — Container name
 - `--runtime` — Container runtime to use: docker or podman (auto-detected by default, preferring docker)
 - `--url, -u` — Cloud URL for registration (default: `https://miren.cloud`)

--- a/docs/docs/labs.md
+++ b/docs/docs/labs.md
@@ -28,34 +28,31 @@ Labs features are controlled via the `--labs` flag or `MIREN_LABS` environment v
 
 <CliCommand context="server">
 ```miren
-# Enable a single labs feature
+# Enable a labs feature
 miren server --labs appvisibility
-
-# Enable multiple features
-miren server --labs appvisibility --labs distributedrunners
 
 # Via environment variable
 MIREN_LABS=appvisibility miren server
-
-# Multiple features via environment variable (comma-separated)
-MIREN_LABS=appvisibility,distributedrunners miren server
 ```
 </CliCommand>
 
+To name more than one feature, repeat `--labs` or comma-separate the
+environment variable.
+
 ## Turning a Feature Off
 
-Prefix a feature name with `-` to disable it. This is how you back out of a feature that's on by default, and it takes the same flag and environment variable as enabling.
+Prefix a feature name with `-` to disable it, using the same flag and
+environment variable as enabling. This is mainly how you back out of a feature
+that has graduated to on by default, for the one release its flag sticks around
+as an escape hatch.
 
 <CliCommand context="server">
 ```miren
-# Turn off a feature that is on by default
-miren server --labs -distributedrunners
+# Turn a feature off
+miren server --labs -appvisibility
 
 # Via environment variable
-MIREN_LABS=-distributedrunners miren server
-
-# Mix and match: app visibility on, distributed runners off
-MIREN_LABS=appvisibility,-distributedrunners miren server
+MIREN_LABS=-appvisibility miren server
 ```
 </CliCommand>
 

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -3,8 +3,3 @@ features:
     predicate: AppVisibility
     description: Negotiate app visibility protocols over the cloud uplink
     default: false
-
-  - name: distributedrunners
-    predicate: DistributedRunners
-    description: Schedule jobs across multiple runner nodes
-    default: true

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -11,23 +11,20 @@ import (
 
 // Feature name constants
 const (
-	FeatureAppVisibility      = "appvisibility"
-	FeatureDistributedRunners = "distributedrunners"
+	FeatureAppVisibility = "appvisibility"
 )
 
 // AllFeatures returns a list of all known feature names
 func AllFeatures() []string {
 	return []string{
 		FeatureAppVisibility,
-		FeatureDistributedRunners,
 	}
 }
 
 // FeatureDescriptions returns a map of feature names to their descriptions
 func FeatureDescriptions() map[string]string {
 	return map[string]string{
-		FeatureAppVisibility:      "Negotiate app visibility protocols over the cloud uplink",
-		FeatureDistributedRunners: "Schedule jobs across multiple runner nodes",
+		FeatureAppVisibility: "Negotiate app visibility protocols over the cloud uplink",
 	}
 }
 
@@ -38,8 +35,7 @@ var (
 
 // featureDefaults holds the default state for each feature
 var featureDefaults = map[string]bool{
-	FeatureAppVisibility:      false,
-	FeatureDistributedRunners: true,
+	FeatureAppVisibility: false,
 }
 
 // Init initializes the labs feature flags from the provided flag strings.
@@ -139,10 +135,4 @@ func IsEnabled(name string) bool {
 // Negotiate app visibility protocols over the cloud uplink
 func AppVisibility() bool {
 	return IsEnabled(FeatureAppVisibility)
-}
-
-// DistributedRunners returns whether the distributedrunners feature is enabled.
-// Schedule jobs across multiple runner nodes
-func DistributedRunners() bool {
-	return IsEnabled(FeatureDistributedRunners)
 }

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -3,6 +3,7 @@ package labs
 import (
 	"bytes"
 	"log/slog"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -12,43 +13,93 @@ func quiet() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
-func TestDisableFeatureWithPrefix(t *testing.T) {
-	Reset()
+// withFeatures swaps in a synthetic feature registry for one test and returns
+// its names sorted.
+//
+// Everything below is about how Init parses flags, which is independent of
+// whichever features happen to be in labs this release. Naming real features
+// here meant rewriting this file every time one graduated out, and the registry
+// eventually gets too small to say anything: with a single feature left there
+// is no way to tell "the exclusion disabled the one I named" apart from "the
+// exclusion disabled everything". Synthetic names cost nothing and never churn.
+func withFeatures(t *testing.T, defaults map[string]bool) []string {
+	t.Helper()
 
-	// Enable first, then disable
-	Init(quiet(), []string{"distributedrunners", "-distributedrunners"})
+	mu.Lock()
+	savedDefaults, savedEnabled := featureDefaults, enabledFeatures
+	featureDefaults = defaults
+	enabledFeatures = make(map[string]bool)
+	mu.Unlock()
 
-	if DistributedRunners() {
-		t.Error("DistributedRunners should be disabled after '-distributedrunners'")
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		featureDefaults, enabledFeatures = savedDefaults, savedEnabled
+	})
+
+	names := make([]string, 0, len(defaults))
+	for name := range defaults {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestDefaultsApplyWithoutFlags(t *testing.T) {
+	withFeatures(t, map[string]bool{"alpha": true, "beta": false})
+
+	Init(quiet(), nil)
+
+	if !IsEnabled("alpha") {
+		t.Error("alpha defaults to on and should be enabled with no flags")
+	}
+	if IsEnabled("beta") {
+		t.Error("beta defaults to off and should stay disabled with no flags")
 	}
 }
 
-func TestDistributedRunnersEnabledByDefault(t *testing.T) {
-	Reset()
+func TestDisableFeatureWithPrefix(t *testing.T) {
+	withFeatures(t, map[string]bool{"alpha": false})
 
-	// GA: distributed runners are on by default with no flags set.
-	Init(quiet(), nil)
+	// Enable first, then disable
+	Init(quiet(), []string{"alpha", "-alpha"})
 
-	if !DistributedRunners() {
-		t.Error("DistributedRunners should be enabled by default")
+	if IsEnabled("alpha") {
+		t.Error("alpha should be disabled after '-alpha'")
+	}
+}
+
+// A feature that ships on by default keeps its flag for a release purely so an
+// operator can put the old behavior back. That escape hatch has to work from a
+// cold start, with nothing else named.
+func TestNegativePrefixAloneDisablesDefaultOnFeature(t *testing.T) {
+	withFeatures(t, map[string]bool{"alpha": true, "beta": true})
+
+	Init(quiet(), []string{"-alpha"})
+
+	if IsEnabled("alpha") {
+		t.Error("alpha should be disabled by '-alpha' alone")
+	}
+	if !IsEnabled("beta") {
+		t.Error("beta should stay enabled when only alpha is named")
 	}
 }
 
 func TestCaseInsensitiveFeatureNames(t *testing.T) {
-	Reset()
+	withFeatures(t, map[string]bool{"alpha": false, "beta": false})
 
-	Init(quiet(), []string{"AppVisibility", "DISTRIBUTEDRUNNERS"})
+	Init(quiet(), []string{"Alpha", "BETA"})
 
-	if !AppVisibility() {
-		t.Error("AppVisibility should be enabled (case-insensitive)")
+	if !IsEnabled("alpha") {
+		t.Error("alpha should be enabled (case-insensitive)")
 	}
-	if !DistributedRunners() {
-		t.Error("DistributedRunners should be enabled (case-insensitive)")
+	if !IsEnabled("beta") {
+		t.Error("beta should be enabled (case-insensitive)")
 	}
 }
 
 func TestUnknownFeatureLogsWarning(t *testing.T) {
-	Reset()
+	withFeatures(t, map[string]bool{"alpha": false})
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -65,21 +116,21 @@ func TestUnknownFeatureLogsWarning(t *testing.T) {
 }
 
 func TestEmptyAndWhitespaceFlags(t *testing.T) {
-	Reset()
+	withFeatures(t, map[string]bool{"alpha": false})
 
-	Init(quiet(), []string{"", "  ", "appvisibility", "  ", ""})
+	Init(quiet(), []string{"", "  ", "alpha", "  ", ""})
 
-	if !AppVisibility() {
-		t.Error("AppVisibility should be enabled despite empty/whitespace flags")
+	if !IsEnabled("alpha") {
+		t.Error("alpha should be enabled despite empty/whitespace flags")
 	}
 }
 
 func TestAllKeywordEnablesAllFeatures(t *testing.T) {
-	Reset()
+	names := withFeatures(t, map[string]bool{"alpha": false, "beta": false})
 
 	Init(quiet(), []string{"all"})
 
-	for _, name := range AllFeatures() {
+	for _, name := range names {
 		if !IsEnabled(name) {
 			t.Errorf("Feature %q should be enabled after Init with 'all'", name)
 		}
@@ -87,31 +138,43 @@ func TestAllKeywordEnablesAllFeatures(t *testing.T) {
 }
 
 func TestAllKeywordWithExclusion(t *testing.T) {
-	Reset()
+	names := withFeatures(t, map[string]bool{"alpha": false, "beta": false})
 
-	Init(quiet(), []string{"all", "-distributedrunners"})
+	Init(quiet(), []string{"all", "-beta"})
 
-	for _, name := range AllFeatures() {
-		if name == FeatureDistributedRunners {
+	for _, name := range names {
+		if name == "beta" {
 			if IsEnabled(name) {
-				t.Error("DistributedRunners should be disabled after 'all,-distributedrunners'")
+				t.Error("beta should be disabled after 'all,-beta'")
 			}
-		} else {
-			if !IsEnabled(name) {
-				t.Errorf("Feature %q should be enabled after 'all,-distributedrunners'", name)
-			}
+		} else if !IsEnabled(name) {
+			t.Errorf("Feature %q should be enabled after 'all,-beta'", name)
 		}
 	}
 }
 
 func TestNegativeAllDisablesAll(t *testing.T) {
-	Reset()
+	names := withFeatures(t, map[string]bool{"alpha": true, "beta": true})
 
-	Init(quiet(), []string{"appvisibility", "distributedrunners", "-all"})
+	Init(quiet(), []string{"alpha", "beta", "-all"})
 
-	for _, name := range AllFeatures() {
+	for _, name := range names {
 		if IsEnabled(name) {
 			t.Errorf("Feature %q should be disabled after '-all'", name)
 		}
+	}
+}
+
+func TestResetRestoresDefaults(t *testing.T) {
+	withFeatures(t, map[string]bool{"alpha": true, "beta": false})
+
+	Init(quiet(), []string{"-alpha", "beta"})
+	Reset()
+
+	if !IsEnabled("alpha") {
+		t.Error("Reset should restore alpha to its default of on")
+	}
+	if IsEnabled("beta") {
+		t.Error("Reset should restore beta to its default of off")
 	}
 }


### PR DESCRIPTION
Distributed runners have been on by default since v0.13.0, and `--labs -distributedrunners` was there so an operator could back out if the new topology caused trouble. Two releases went by without anyone reaching for it, so the escape hatch has done its job. The two gates it fed, `miren runner` command registration and etcd mTLS setup at boot, are unconditional now. A server still passing the flag logs `unknown labs feature flag` and starts normally, the same landing as `-sagas` below.

The labs tests come along for a different reason. They were always about how `Init` parses flags, but they named whichever real features happened to exist, so every graduation churned them. They use synthetic names now, which also recovers a case that was about to go vacuous: with `appvisibility` the only real feature left, nothing distinguishes "the exclusion disabled the one I named" from "the exclusion disabled everything."

One docs consequence worth a look. `appvisibility` defaults to off, so labs.md has no honest "turn off a feature that's on by default" example anymore. I reworded that section to describe the case rather than fake a snippet for it.

Stacked on #1191, which retires the `sagas` flag.

Closes MIR-1461
