### PR TITLE
Pin container install image to the build version instead of :latest

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -1132,6 +1132,10 @@ miren deploy --format jsonl | jq -c 'select(.event == "build_step")'
 			Name: "Force a specific runtime",
 			Body: "miren server container install --runtime podman",
 		}),
+		WithExample(mflags.Example{
+			Name: "Install a specific release",
+			Body: "miren server container install --version v0.15.0",
+		}),
 	))
 	d.Dispatch("server container uninstall", Infer("server container uninstall", "Uninstall miren server container", ServerUninstallContainer,
 		WithExample(mflags.Example{

--- a/cli/commands/server_install_container.go
+++ b/cli/commands/server_install_container.go
@@ -17,14 +17,61 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"gopkg.in/yaml.v3"
 	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/release"
 	"miren.dev/runtime/pkg/serverconfig"
 	"miren.dev/runtime/pkg/ui"
+	"miren.dev/runtime/version"
 )
+
+// defaultContainerImageRepo is where the release workflow publishes the server
+// image, tagged with the release version (v0.15.0) or "main".
+const defaultContainerImageRepo = "oci.miren.cloud/miren"
+
+// resolveContainerImage picks the image reference to install. An explicit
+// --image wins outright; --version selects a tag in the default repository;
+// otherwise the tag follows the CLI's own build so a release installs itself
+// rather than whatever :latest points at today. Only tags the release
+// workflow actually publishes (release tags and main) are inferred; any other
+// dev build has to say what it wants.
+func resolveContainerImage(imageFlag, versionFlag, buildVersion string) (string, error) {
+	switch {
+	case imageFlag != "" && versionFlag != "":
+		return "", fmt.Errorf("--image and --version are mutually exclusive")
+	case imageFlag != "":
+		return imageFlag, nil
+	case versionFlag != "":
+		return defaultContainerImageRepo + ":" + versionFlag, nil
+	}
+
+	// The channel, not the raw version: a branch build is "main:abc123" but
+	// publishes under "main". Match the release grammar rather than just a
+	// leading "v", so a branch named v2 or vnext falls through to the error
+	// below instead of resolving to an image tag that was never pushed.
+	if tag := version.BranchOf(buildVersion); tag == "main" || isPublishedReleaseTag(tag) {
+		return defaultContainerImageRepo + ":" + tag, nil
+	}
+
+	return "", fmt.Errorf("this is a development build (%s) with no published container image; "+
+		"pass --version vX.Y.Z (or --version main) to choose what to install, or --image for a custom image",
+		buildVersion)
+}
+
+// isPublishedReleaseTag reports whether tag is a release tag the release
+// workflow publishes an image for. That workflow triggers on "v*" tags, so the
+// leading v is required on top of the semver grammar pkg/release already owns.
+func isPublishedReleaseTag(tag string) bool {
+	if !strings.HasPrefix(tag, "v") {
+		return false
+	}
+	_, err := release.ParseSemVer(tag)
+	return err == nil
+}
 
 // ServerInstallContainer sets up a container (via Docker or Podman) to run the
 // miren server.
 func ServerInstallContainer(ctx *Context, opts struct {
-	Image         string            `short:"i" long:"image" description:"Container image to use" default:"oci.miren.cloud/miren:latest"`
+	Image         string            `short:"i" long:"image" description:"Container image to use (full reference; mutually exclusive with --version)"`
+	Version       string            `short:"V" long:"version" description:"Image tag to install (e.g. v0.15.0 or main). Defaults to this CLI's release version, or main for main/HEAD builds; required for other dev builds"`
 	Name          string            `short:"n" long:"name" description:"Container name"`
 	Runtime       string            `long:"runtime" description:"Container runtime to use: docker or podman (auto-detected by default, preferring docker)"`
 	Force         bool              `short:"f" long:"force" description:"Remove existing container if present"`
@@ -51,6 +98,14 @@ func ServerInstallContainer(ctx *Context, opts struct {
 	if err := validateIngressMode(opts.IngressMode); err != nil {
 		return err
 	}
+
+	// Resolve the image before touching the runtime so a dev build with no
+	// published image stops here with the fix, not after volume setup.
+	image, err := resolveContainerImage(opts.Image, opts.Version, version.Version)
+	if err != nil {
+		return err
+	}
+	ctx.Completed("Using image %s", image)
 
 	// Pick the container runtime (docker or podman) before any work so we fail
 	// fast with clear guidance when neither is installed.
@@ -123,7 +178,7 @@ func ServerInstallContainer(ctx *Context, opts struct {
 
 	// Register with cloud unless --without-cloud is specified
 	if !opts.WithoutCloud {
-		if err := performRegistrationPreStart(ctx, rt, opts.Image, volumeName, containerRegistrationOptions{
+		if err := performRegistrationPreStart(ctx, rt, image, volumeName, containerRegistrationOptions{
 			ClusterName: opts.ClusterName,
 			CloudURL:    opts.CloudURL,
 			Tags:        opts.Tags,
@@ -140,7 +195,7 @@ func ServerInstallContainer(ctx *Context, opts struct {
 
 	// Create and optionally start the container
 	ctx.Info("Creating miren server container...")
-	containerID, err := rt.createContainer(opts.Name, opts.Image, config)
+	containerID, err := rt.createContainer(opts.Name, image, config)
 	if err != nil {
 		// The pre-flight check above catches the common case, but a port can
 		// still be grabbed in the race between check and create, or be

--- a/cli/commands/server_install_container_test.go
+++ b/cli/commands/server_install_container_test.go
@@ -227,3 +227,50 @@ func TestEnginePortConflictError(t *testing.T) {
 		r.Empty(msg)
 	})
 }
+
+func TestResolveContainerImage(t *testing.T) {
+	cases := []struct {
+		name    string
+		image   string
+		version string
+		build   string
+		want    string
+		wantErr string
+	}{
+		{name: "image and version conflict", image: "x/y:z", version: "v1.0.0", build: "v0.15.0", wantErr: "mutually exclusive"},
+		{name: "image passes through", image: "registry.example/miren:custom", build: "feature:abc1234", want: "registry.example/miren:custom"},
+		{name: "image without a tag is not touched", image: "registry.example/miren", build: "v0.15.0", want: "registry.example/miren"},
+		{name: "version picks a tag in the default repo", version: "v0.14.0", build: "v0.15.0", want: "oci.miren.cloud/miren:v0.14.0"},
+		{name: "version latest is allowed when explicit", version: "latest", build: "dev", want: "oci.miren.cloud/miren:latest"},
+		{name: "release build pins its own tag", build: "v0.15.0", want: "oci.miren.cloud/miren:v0.15.0"},
+		{name: "prerelease build pins its own tag", build: "v0.16.0-rc.1", want: "oci.miren.cloud/miren:v0.16.0-rc.1"},
+		{name: "main build uses main", build: "main:abc1234", want: "oci.miren.cloud/miren:main"},
+		{name: "detached HEAD build uses main", build: "HEAD:abc1234", want: "oci.miren.cloud/miren:main"},
+		{name: "feature branch build must choose", build: "feature:abc1234", wantErr: "--version"},
+		{name: "dev build must choose", build: "dev", wantErr: "--version"},
+		// A branch whose name merely starts with "v" is not a release. The
+		// channel has its commit suffix stripped before the check, so these
+		// only fail the grammar, not the "contains a colon" shape.
+		{name: "branch named v1 is not a release", build: "v1:abc1234", wantErr: "--version"},
+		{name: "branch named vnext is not a release", build: "vnext:abc1234", wantErr: "--version"},
+		{name: "branch named v2-rewrite is not a release", build: "v2-rewrite:abc1234", wantErr: "--version"},
+		{name: "branch named v-feature is not a release", build: "v-feature:abc1234", wantErr: "--version"},
+		{name: "version without a v prefix is not a release", build: "0.15.0", wantErr: "--version"},
+		{name: "unknown build must choose", build: "unknown", wantErr: "--version"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+
+			got, err := resolveContainerImage(tc.image, tc.version, tc.build)
+			if tc.wantErr != "" {
+				r.Error(err)
+				r.Contains(err.Error(), tc.wantErr)
+				return
+			}
+			r.NoError(err)
+			r.Equal(tc.want, got)
+		})
+	}
+}

--- a/docs/docs/command/server-container-install.md
+++ b/docs/docs/command/server-container-install.md
@@ -21,12 +21,13 @@ miren server container install [flags]
 - `--force, -f` — Remove existing container if present
 - `--host-network` — Use host networking (ignores port mappings)
 - `--http-port` — HTTP port mapping (default: `80`)
-- `--image, -i` — Container image to use (default: `oci.miren.cloud/miren:latest`)
+- `--image, -i` — Container image to use (full reference; mutually exclusive with --version)
 - `--ingress-mode` — Ingress mode: tls-autoprovision (default), behind-proxy-http (Miren serves plain HTTP behind a TLS-terminating proxy like tailscale serve / nginx), or behind-proxy-https (Miren terminates TLS on :443 behind a TCP-passthrough proxy)
 - `--labs, -l` — Miren Labs features to enable (e.g. appvisibility). Prefix with - to disable.
 - `--name, -n` — Container name
 - `--runtime` — Container runtime to use: docker or podman (auto-detected by default, preferring docker)
 - `--url, -u` — Cloud URL for registration (default: `https://miren.cloud`)
+- `--version, -V` — Image tag to install (e.g. v0.15.0 or main). Defaults to this CLI's release version, or main for main/HEAD builds; required for other dev builds
 - `--without-cloud` — Skip cloud registration setup
 
 ## Global Options
@@ -65,6 +66,12 @@ miren server container install --ingress-mode behind-proxy-http
 
 ```bash
 miren server container install --runtime podman
+```
+
+**Install a specific release:**
+
+```bash
+miren server container install --version v0.15.0
 ```
 
 ## See also

--- a/version/version.go
+++ b/version/version.go
@@ -38,16 +38,30 @@ func GetInfo() Info {
 	return info
 }
 
-// Branch returns the branch name if the binary was built from a branch (e.g. "main:abc123").
-// Returns the tag name for tagged releases (e.g. "v0.2.0"), and empty for unknown versions.
+// Branch returns the release channel this binary was built from: the tag name
+// for tagged releases (e.g. "v0.2.0"), the branch name for branch builds
+// (e.g. "main" for "main:abc123"), and empty for unknown versions. See BranchOf.
 func Branch() string {
-	if branch, _, ok := strings.Cut(Version, ":"); ok {
-		return branch
+	return BranchOf(Version)
+}
+
+// BranchOf derives the release channel from a version string as produced by
+// hack/build.sh. A detached checkout reports its branch as "HEAD", which is not
+// a channel anything publishes under; it is treated as "main" so installers
+// pick the main image and release bundle rather than failing on a channel
+// named HEAD.
+func BranchOf(v string) string {
+	branch, _, ok := strings.Cut(v, ":")
+	if !ok {
+		if v == "unknown" {
+			return ""
+		}
+		branch = v
 	}
-	if Version != "unknown" {
-		return Version
+	if branch == "HEAD" {
+		return "main"
 	}
-	return ""
+	return branch
 }
 
 // String returns the version info as a formatted string

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBranchOf(t *testing.T) {
+	cases := map[string]string{
+		"v0.15.0":          "v0.15.0",
+		"v0.16.0-rc.1":     "v0.16.0-rc.1",
+		"main:abc1234":     "main",
+		"HEAD:abc1234":     "main",
+		"feature:abc1234":  "feature",
+		"release/x:abc123": "release/x",
+		"dev":              "dev",
+		"unknown":          "",
+		"":                 "",
+	}
+
+	for in, want := range cases {
+		require.Equal(t, want, BranchOf(in), "BranchOf(%q)", in)
+	}
+}
+
+func TestBranch(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "HEAD:abc1234"
+	require.Equal(t, "main", Branch())
+
+	Version = "v0.15.0"
+	require.Equal(t, "v0.15.0", Branch())
+}


### PR DESCRIPTION
`miren server container install` has been defaulting `--image` to `oci.miren.cloud/miren:latest`. That meant a v0.14.0 CLI would happily install whatever `latest` pointed at that day, and running the same command a month later could land you on a different server. The systemd installer never had this problem: it defaults `--branch` from the version baked into the binary, so a release CLI installs its own release.

This brings the container path in line. The image tag now follows the build. A tagged release pins its own tag, a `main` or detached-HEAD build uses `main` (the release workflow publishes both), and any other dev build stops with an error telling you to pick with the new `--version` flag (or `--image` for a fully custom reference). Nothing quietly falls back to `latest` anymore, though `--version latest` still works if you actually want it.

One small extra: detached checkouts report their branch as `HEAD`, which nothing publishes under. `version.Branch()` now maps that to `main`, which also fixes the systemd, runner, prepare, and download-release paths that would otherwise try to fetch a release bundle for a channel named HEAD.

Closes MIR-1090
