### PR TITLE
Surface image pull failures in miren logs

### DIFF
--- a/controllers/sandbox/image_pull.go
+++ b/controllers/sandbox/image_pull.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/errdefs"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/components/ocireg"
@@ -25,6 +26,12 @@ func (c *SandboxController) ensureImage(ctx context.Context, sb *compute.Sandbox
 	img, err := c.CC.GetImage(ctx, ref)
 	if err == nil {
 		return c.logImageReady(ctx, img)
+	}
+	// Only a missing image justifies a pull. Anything else (a containerd RPC
+	// failure, a cancelled context) would just fail again and be misreported
+	// as a pull failure.
+	if !errdefs.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to get image %s: %w", ref, err)
 	}
 
 	_, err = c.CC.Pull(ctx, ref, containerd.WithPullUnpack, containerd.WithResolver(c.resolver()))

--- a/controllers/sandbox/image_pull.go
+++ b/controllers/sandbox/image_pull.go
@@ -29,7 +29,13 @@ func (c *SandboxController) ensureImage(ctx context.Context, sb *compute.Sandbox
 
 	_, err = c.CC.Pull(ctx, ref, containerd.WithPullUnpack, containerd.WithResolver(c.resolver()))
 	if err != nil {
-		c.EmitSandboxEvent(sb, shortID, describePullFailure(ref, err))
+		// A cancelled context means we were superseded or are shutting down,
+		// not that the pull failed. Skip the event so the app's logs don't
+		// report a failure (and, via the url.Error wrapper, a network hint)
+		// for something that never went wrong. Same guard as the port wait.
+		if ctx.Err() == nil {
+			c.EmitSandboxEvent(sb, shortID, describePullFailure(ref, err))
+		}
 		return nil, fmt.Errorf("failed to pull image %s: %w", ref, err)
 	}
 
@@ -56,8 +62,8 @@ func (c *SandboxController) logImageReady(ctx context.Context, img containerd.Im
 // error names an IP and port but not what is listening there, and the
 // distributed-runner case that motivated MIR-1541 is exactly a runner that
 // cannot open port 5000 on the coordinator.
-const registryUnreachableHint = "check that this node can reach the cluster image registry (" +
-	ocireg.Host + ", served by the coordinator on port 5000)"
+const registryUnreachableHint = "check that this node can reach the cluster image registry at " +
+	ocireg.Host + " on the coordinator"
 
 // describePullFailure builds the user-facing line for a failed image pull.
 // The containerd error is kept verbatim because its tail carries the root
@@ -67,9 +73,20 @@ func describePullFailure(ref string, err error) string {
 	msg := fmt.Sprintf("failed to pull image %s: %v", ref, err)
 
 	var netErr net.Error
-	if strings.HasPrefix(ref, ocireg.Host+"/") && errors.As(err, &netErr) {
+	if isClusterRegistryRef(ref) && errors.As(err, &netErr) {
 		msg += "; " + registryUnreachableHint
 	}
 
 	return msg
+}
+
+// isClusterRegistryRef reports whether ref is served by the cluster registry.
+// It accepts the same two host spellings SandboxController.resolver routes
+// there: with the port (what the build pipeline writes) and without it.
+func isClusterRegistryRef(ref string) bool {
+	host, _, ok := strings.Cut(ref, "/")
+	if !ok {
+		return false
+	}
+	return host == ocireg.Host || host == "cluster.local"
 }

--- a/controllers/sandbox/image_pull.go
+++ b/controllers/sandbox/image_pull.go
@@ -1,0 +1,75 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	containerd "github.com/containerd/containerd/v2/client"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/components/ocireg"
+)
+
+// ensureImage returns the image for ref, pulling it if containerd does not
+// already have it.
+//
+// A pull failure is written to the sandbox's log stream before being
+// returned. The pull runs on whichever node hosts the sandbox, so without
+// this the reason lives only in that node's journal: the sandbox is marked
+// DEAD, the pool crash-loops, and `miren logs` shows nothing because no
+// container ever produced output (MIR-1541).
+func (c *SandboxController) ensureImage(ctx context.Context, sb *compute.Sandbox, shortID, ref string) (containerd.Image, error) {
+	img, err := c.CC.GetImage(ctx, ref)
+	if err == nil {
+		return c.logImageReady(ctx, img)
+	}
+
+	_, err = c.CC.Pull(ctx, ref, containerd.WithPullUnpack, containerd.WithResolver(c.resolver()))
+	if err != nil {
+		c.EmitSandboxEvent(sb, shortID, describePullFailure(ref, err))
+		return nil, fmt.Errorf("failed to pull image %s: %w", ref, err)
+	}
+
+	img, err = c.CC.GetImage(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image %s: %w", ref, err)
+	}
+
+	return c.logImageReady(ctx, img)
+}
+
+func (c *SandboxController) logImageReady(ctx context.Context, img containerd.Image) (containerd.Image, error) {
+	sz, err := img.Size(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.Log.Info("image ready", "ref", img.Metadata().Target.Digest, "size", sz)
+	return img, nil
+}
+
+// registryUnreachableHint is appended to a pull failure when the image lives
+// on the cluster registry and the error is a network one. The raw containerd
+// error names an IP and port but not what is listening there, and the
+// distributed-runner case that motivated MIR-1541 is exactly a runner that
+// cannot open port 5000 on the coordinator.
+const registryUnreachableHint = "check that this node can reach the cluster image registry (" +
+	ocireg.Host + ", served by the coordinator on port 5000)"
+
+// describePullFailure builds the user-facing line for a failed image pull.
+// The containerd error is kept verbatim because its tail carries the root
+// cause (a dial timeout, a 404, an auth failure); the hint is only added when
+// the failure is a network error against the cluster registry.
+func describePullFailure(ref string, err error) string {
+	msg := fmt.Sprintf("failed to pull image %s: %v", ref, err)
+
+	var netErr net.Error
+	if strings.HasPrefix(ref, ocireg.Host+"/") && errors.As(err, &netErr) {
+		msg += "; " + registryUnreachableHint
+	}
+
+	return msg
+}

--- a/controllers/sandbox/image_pull_test.go
+++ b/controllers/sandbox/image_pull_test.go
@@ -44,6 +44,12 @@ func TestDescribePullFailure(t *testing.T) {
 			wantHint: true,
 		},
 		{
+			name:     "bare cluster.local spelling is also the cluster registry",
+			ref:      "cluster.local/app:v1",
+			err:      dialTimeout,
+			wantHint: true,
+		},
+		{
 			name:     "missing image on the cluster registry gets no hint",
 			ref:      ocireg.Host + "/app:v1",
 			err:      fmt.Errorf("failed to resolve reference %q: %w", "x", errdefs.ErrNotFound),
@@ -106,4 +112,13 @@ func TestEnsureImageEmitsPullFailure(t *testing.T) {
 	assert.Equal(t, "abc123", got.log.Attributes["miren.short_id"])
 	// Not a cluster-registry ref, so no reachability hint.
 	assert.NotContains(t, got.log.Body, registryUnreachableHint)
+
+	// A pull interrupted by cancellation is not a failure the app's logs
+	// should report: the error still comes back, but nothing is written.
+	cancelledCtx, cancelNow := context.WithCancel(ctx)
+	cancelNow()
+	img, err = co.ensureImage(cancelledCtx, sb, "abc123", ref)
+	r.Error(err)
+	r.Nil(img)
+	assert.Len(t, lw.entries, 1, "cancelled pull must not add a log entry")
 }

--- a/controllers/sandbox/image_pull_test.go
+++ b/controllers/sandbox/image_pull_test.go
@@ -1,0 +1,109 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/errdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/components/ocireg"
+	"miren.dev/runtime/observability"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/testutils"
+)
+
+func TestDescribePullFailure(t *testing.T) {
+	// Shaped like containerd's wrapping: resolver -> http client -> dialer.
+	dialTimeout := fmt.Errorf("failed to resolve reference %q: %w", "x",
+		fmt.Errorf("failed to do request: %w", &url.Error{
+			Op:  "Head",
+			URL: "http://10.0.0.5:5000/v2/app/manifests/v1",
+			Err: &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED},
+		}))
+
+	tests := []struct {
+		name     string
+		ref      string
+		err      error
+		wantHint bool
+	}{
+		{
+			name:     "network error against the cluster registry gets the hint",
+			ref:      ocireg.Host + "/app:v1",
+			err:      dialTimeout,
+			wantHint: true,
+		},
+		{
+			name:     "missing image on the cluster registry gets no hint",
+			ref:      ocireg.Host + "/app:v1",
+			err:      fmt.Errorf("failed to resolve reference %q: %w", "x", errdefs.ErrNotFound),
+			wantHint: false,
+		},
+		{
+			name:     "network error against a public registry gets no hint",
+			ref:      "docker.io/library/nope:latest",
+			err:      dialTimeout,
+			wantHint: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := describePullFailure(tt.ref, tt.err)
+
+			assert.True(t, strings.HasPrefix(got, "failed to pull image "+tt.ref+": "), got)
+			assert.Contains(t, got, tt.err.Error())
+			assert.Equal(t, tt.wantHint, strings.Contains(got, registryUnreachableHint), got)
+		})
+	}
+}
+
+// TestEnsureImageEmitsPullFailure drives a real containerd pull against a
+// port nothing listens on and checks that the failure lands on the sandbox's
+// log stream with the app entity, not just in the returned error.
+func TestEnsureImageEmitsPullFailure(t *testing.T) {
+	r := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	testDeps, cleanup := testutils.NewTestDeps()
+	defer cleanup()
+
+	co, err := newSandboxController(testDeps)
+	r.NoError(err)
+	defer co.Close()
+
+	lw := &mockLogWriter{}
+	co.LogWriter = lw
+
+	sb := &compute.Sandbox{ID: entity.Id("sandbox/pull-test")}
+	sb.Spec.LogEntity = "app/pull-test"
+
+	const ref = "127.0.0.1:1/nope:latest"
+	ctx = namespaces.WithNamespace(ctx, co.Namespace)
+	img, err := co.ensureImage(ctx, sb, "abc123", ref)
+	r.Error(err)
+	r.Nil(img)
+	assert.Contains(t, err.Error(), "failed to pull image "+ref)
+
+	r.Len(lw.entries, 1)
+	got := lw.entries[0]
+	assert.Equal(t, "app/pull-test", got.entity)
+	assert.Equal(t, observability.Stderr, got.log.Stream)
+	assert.True(t, strings.HasPrefix(got.log.Body, "[miren] failed to pull image "+ref), got.log.Body)
+	assert.Equal(t, "pull-test", got.log.Attributes["source"])
+	assert.Equal(t, "abc123", got.log.Attributes["miren.short_id"])
+	// Not a cluster-registry ref, so no reachability hint.
+	assert.NotContains(t, got.log.Body, registryUnreachableHint)
+}

--- a/controllers/sandbox/image_pull_test.go
+++ b/controllers/sandbox/image_pull_test.go
@@ -113,12 +113,16 @@ func TestEnsureImageEmitsPullFailure(t *testing.T) {
 	// Not a cluster-registry ref, so no reachability hint.
 	assert.NotContains(t, got.log.Body, registryUnreachableHint)
 
-	// A pull interrupted by cancellation is not a failure the app's logs
-	// should report: the error still comes back, but nothing is written.
+	// A cancelled context is not a failure the app's logs should report. The
+	// lookup fails with something other than NotFound, so no pull is even
+	// attempted (the error names the lookup, not a pull) and nothing is
+	// written.
 	cancelledCtx, cancelNow := context.WithCancel(ctx)
 	cancelNow()
 	img, err = co.ensureImage(cancelledCtx, sb, "abc123", ref)
 	r.Error(err)
 	r.Nil(img)
-	assert.Len(t, lw.entries, 1, "cancelled pull must not add a log entry")
+	assert.Contains(t, err.Error(), "failed to get image "+ref)
+	assert.NotContains(t, err.Error(), "failed to pull image")
+	assert.Len(t, lw.entries, 1, "cancelled lookup must not add a log entry")
 }

--- a/controllers/sandbox/interface.go
+++ b/controllers/sandbox/interface.go
@@ -65,6 +65,6 @@ type SandboxObservability interface {
 	// sandbox's normal log stream, so `miren logs sandbox <id>`
 	// surfaces it alongside container output. Intended for startup
 	// or teardown events where a container never produced logs of
-	// its own (e.g. volume mount failures).
+	// its own (e.g. volume mount failures, image pull failures).
 	LogSandboxEvent(sb *compute.Sandbox, shortID, line string)
 }

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1806,27 +1806,10 @@ func (c *SandboxController) BuildSpec(
 	[]containerd.NewContainerOpts,
 	error,
 ) {
-	img, err := c.CC.GetImage(ctx, sandboxImage)
-	if err != nil {
-		// If the image is not found, we can try to pull it.
-		_, err = c.CC.Pull(ctx, sandboxImage, containerd.WithPullUnpack, containerd.WithResolver(c.resolver()))
-		if err != nil {
-			return nil, fmt.Errorf("failed to pull image %s: %w", sandboxImage, err)
-		}
-
-		img, err = c.CC.GetImage(ctx, sandboxImage)
-		if err != nil {
-			// If we still can't get the image, return the error.
-			return nil, fmt.Errorf("failed to get image %s: %w", sandboxImage, err)
-		}
-	}
-
-	sz, err := img.Size(ctx)
+	img, err := c.ensureImage(ctx, sb, meta.ShortId(), sandboxImage)
 	if err != nil {
 		return nil, err
 	}
-
-	c.Log.Info("image ready", "ref", img.Metadata().Target.Digest, "size", sz)
 
 	var (
 		opts []containerd.NewContainerOpts
@@ -2521,27 +2504,10 @@ func (c *SandboxController) buildSubContainerSpec(
 	[]containerd.NewContainerOpts,
 	error,
 ) {
-	img, err := c.CC.GetImage(ctx, co.Image)
-	if err != nil {
-		// If the image is not found, we can try to pull it.
-		_, err = c.CC.Pull(ctx, co.Image, containerd.WithPullUnpack, containerd.WithResolver(c.resolver()))
-		if err != nil {
-			return nil, fmt.Errorf("failed to pull image %s: %w", co.Image, err)
-		}
-
-		img, err = c.CC.GetImage(ctx, co.Image)
-		if err != nil {
-			// If we still can't get the image, return the error.
-			return nil, fmt.Errorf("failed to get image %s: %w", co.Image, err)
-		}
-	}
-
-	sz, err := img.Size(ctx)
+	img, err := c.ensureImage(ctx, sb, meta.ShortId(), co.Image)
 	if err != nil {
 		return nil, err
 	}
-
-	c.Log.Info("image ready", "ref", img.Metadata().Target.Digest, "size", sz)
 
 	var (
 		opts []containerd.NewContainerOpts


### PR DESCRIPTION
When a node can't pull a sandbox's image, the boot fails and the sandbox gets marked DEAD, but the reason only ever reached that node's journal. The case that prompted this (MIR-1541) is a distributed runner that can't open port 5000 on the coordinator: the deploy reports "crash-looped" with no logs at all, because no container ever ran, and `miren logs` is just as empty. You'd have to ssh to the runner and read journalctl to find out why.

We already had the right mechanism for this. `EmitSandboxEvent` writes a `[miren] ...` line onto the sandbox's log stream, keyed by the app entity, and the volume and port-binding failures use it. Image pulls just never did. This change factors the duplicated GetImage/Pull/GetImage block out of `BuildSpec` and `buildSubContainerSpec` into one `ensureImage` helper that emits `[miren] failed to pull image <ref>: <err>` on failure before returning the same error as before. The line now shows up in `miren logs <app>`, `miren logs sandbox <id>`, and the "Recent logs" tail a failed deploy prints. When the ref is on the cluster registry and the error is a network one, the line also says to check that the node can reach the coordinator on port 5000, since the raw containerd error names an IP but not what should be listening there.

Verified in the dev environment by removing an app's image from containerd, blocking port 5000, and restarting the app: the full line landed in `miren logs` within a few seconds, one per boot attempt.

Fixes MIR-1541