### PR TITLE
Report a broken app.toml once per CLI invocation

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -335,8 +335,10 @@ func LoadAppConfig() (*AppConfig, error) {
 	return ac, err
 }
 
-// LoadAppConfigWithPath loads the app config and returns the file path it was loaded from.
-// Returns (nil, "", nil) if no config file is found.
+// LoadAppConfigWithPath loads the app config and returns the file path it was
+// loaded from. The path is also returned alongside a parse error, so a caller
+// can tell which file was at fault. Returns (nil, "", nil) if no config file
+// is found.
 func LoadAppConfigWithPath() (*AppConfig, string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -355,7 +357,7 @@ func LoadAppConfigWithPath() (*AppConfig, string, error) {
 		}
 		ac, parseErr := decodeAndValidate(data, path)
 		if parseErr != nil {
-			return nil, "", parseErr
+			return nil, path, parseErr
 		}
 		return ac, path, nil
 	}

--- a/appconfig/configerror.go
+++ b/appconfig/configerror.go
@@ -128,11 +128,15 @@ func enrichStrictMissingError(filePath string, sme *toml.StrictMissingError) *Co
 			Line:    row,
 			Column:  col,
 			Message: fmt.Sprintf("unknown field %q", unknown),
-			Context: indentContext(de.String()),
+			// go-toml labels the key "missing field" from the struct's point of
+			// view; keep the annotation consistent with the message above it.
+			Context: indentContext(strings.Replace(de.String(), "missing field", "unknown field", 1)),
 		}
 
 		if unknown != "" {
-			if candidates, ok := validFieldsForPath(parentPath); ok {
+			if hint, ok := removedFields[fieldPath(parentPath, unknown)]; ok {
+				d.Hint = hint
+			} else if candidates, ok := validFieldsForPath(parentPath); ok {
 				if suggestion := suggestField(unknown, candidates); suggestion != "" {
 					d.Hint = fmt.Sprintf("did you mean %q?", suggestion)
 				}
@@ -337,6 +341,23 @@ func isMapSection(path []string) bool {
 	}
 	last := path[len(path)-1]
 	return last == "services" || last == "addons" || last == "tasks"
+}
+
+// fieldPath joins a section path and a field name the way validFields and
+// removedFields key them: "services.*" + "comand" → "services.*.comand", and
+// "" + "name" → "name".
+func fieldPath(parentPath, field string) string {
+	if parentPath == "" {
+		return field
+	}
+	return parentPath + "." + field
+}
+
+// removedFields maps fields that app.toml once accepted to the hint shown
+// when one turns up, so the advice is "here's what replaced it" rather than a
+// fuzzy match against something unrelated.
+var removedFields = map[string]string{
+	"post_import": "post_import was removed and never ran; use a deploy task instead (see https://miren.md/tasks)",
 }
 
 // validFieldsForPath returns the valid field names for a given section path.

--- a/appconfig/configerror_test.go
+++ b/appconfig/configerror_test.go
@@ -98,6 +98,28 @@ comand = "server"
 	assert.Greater(t, ce.Diagnostics[0].Line, 0)
 }
 
+func TestEnrichDecodeError_ContextAgreesWithMessage(t *testing.T) {
+	_, err := Parse([]byte("name = \"test-app\"\ncomand = \"x\"\n"))
+	require.Error(t, err)
+
+	ce, ok := errors.AsType[*ConfigError](err)
+	require.True(t, ok, "expected *ConfigError, got %T", err)
+	require.Len(t, ce.Diagnostics, 1)
+	assert.Contains(t, ce.Diagnostics[0].Context, "unknown field")
+	assert.NotContains(t, ce.Diagnostics[0].Context, "missing field")
+}
+
+func TestEnrichDecodeError_RemovedField(t *testing.T) {
+	_, err := Parse([]byte("name = \"test-app\"\npost_import = \"\"\n"))
+	require.Error(t, err)
+
+	ce, ok := errors.AsType[*ConfigError](err)
+	require.True(t, ok, "expected *ConfigError, got %T", err)
+	require.Len(t, ce.Diagnostics, 1)
+	assert.Equal(t, `unknown field "post_import"`, ce.Diagnostics[0].Message)
+	assert.Contains(t, ce.Diagnostics[0].Hint, "deploy task")
+}
+
 func TestEnrichDecodeError_SyntaxError(t *testing.T) {
 	config := `name = "unterminated`
 	_, err := Parse([]byte(config))

--- a/cli/alias.go
+++ b/cli/alias.go
@@ -1,38 +1,23 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"miren.dev/mflags"
 	"miren.dev/runtime/appconfig"
-	"miren.dev/runtime/pkg/ui"
 )
 
-// expandAlias checks if the given args match a configured alias and expands it.
-// It tries progressively longer prefixes (longest match wins).
+// expandAlias checks if the given args match an alias configured in ac and
+// expands it. It tries progressively longer prefixes (longest match wins).
 // Returns an error if an alias name conflicts with a built-in command.
-func expandAlias(d *mflags.Dispatcher, args []string) ([]string, error) {
+//
+// ac may be nil, meaning no aliases are configured.
+func expandAlias(d *mflags.Dispatcher, ac *appconfig.AppConfig, args []string) ([]string, error) {
 	if len(args) == 0 {
 		return args, nil
 	}
 
-	ac, err := appconfig.LoadAppConfig()
-	if err != nil {
-		// errors.AsType, not a type assertion: a wrapped rich error would
-		// otherwise silently degrade to the plain path below.
-		if se, ok := errors.AsType[ui.SeverityTerminalError](err); ok {
-			se.WriteWithSeverity(os.Stderr, ui.SeverityWarning)
-		} else if te, ok := errors.AsType[ui.TerminalError](err); ok {
-			fmt.Fprint(os.Stderr, "warning: ")
-			te.WriteForTerminal(os.Stderr)
-		} else {
-			fmt.Fprintf(os.Stderr, "warning: could not load %s: %v\n", appconfig.AppConfigPath, err)
-		}
-		return args, nil
-	}
 	if ac == nil || len(ac.Aliases) == 0 {
 		return args, nil
 	}

--- a/cli/alias_test.go
+++ b/cli/alias_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/mflags"
+	"miren.dev/runtime/appconfig"
 )
 
 func TestTokenizeCommand(t *testing.T) {
@@ -96,7 +97,7 @@ func TestExpandAlias(t *testing.T) {
 
 	t.Run("no args returns unchanged", func(t *testing.T) {
 		d := newDispatcher()
-		got, err := expandAlias(d, nil)
+		got, err := expandAlias(d, nil, nil)
 		require.NoError(t, err)
 		assert.Nil(t, got)
 	})
@@ -104,13 +105,51 @@ func TestExpandAlias(t *testing.T) {
 	t.Run("no config returns unchanged", func(t *testing.T) {
 		d := newDispatcher()
 		args := []string{"foo", "bar"}
-		got, err := expandAlias(d, args)
+		got, err := expandAlias(d, nil, args)
 		require.NoError(t, err)
 		assert.Equal(t, args, got)
 	})
 
-	// Note: testing actual alias expansion with config files requires
-	// integration tests since expandAlias calls LoadAppConfig which reads
-	// from the filesystem. The "no config" case above covers the early-return
-	// path. The shadow check and expansion logic are exercised in blackbox tests.
+	ac := &appconfig.AppConfig{Aliases: map[string]string{
+		"ls":      "app list",
+		"ls all":  "app list --all",
+		"console": `app exec -i "bin/rails console"`,
+		"version": "app list",
+		"bad":     `app exec "unclosed`,
+	}}
+
+	t.Run("expands and keeps trailing args", func(t *testing.T) {
+		got, err := expandAlias(newDispatcher(), ac, []string{"ls", "-f", "json"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"app", "list", "-f", "json"}, got)
+	})
+
+	t.Run("longest prefix wins", func(t *testing.T) {
+		got, err := expandAlias(newDispatcher(), ac, []string{"ls", "all"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"app", "list", "--all"}, got)
+	})
+
+	t.Run("quoted target tokens survive", func(t *testing.T) {
+		got, err := expandAlias(newDispatcher(), ac, []string{"console"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"app", "exec", "-i", "bin/rails console"}, got)
+	})
+
+	t.Run("no match returns unchanged", func(t *testing.T) {
+		args := []string{"app", "list"}
+		got, err := expandAlias(newDispatcher(), ac, args)
+		require.NoError(t, err)
+		assert.Equal(t, args, got)
+	})
+
+	t.Run("alias shadowing a built-in is an error", func(t *testing.T) {
+		_, err := expandAlias(newDispatcher(), ac, []string{"version"})
+		require.ErrorContains(t, err, "shadows built-in command")
+	})
+
+	t.Run("untokenizable target is an error", func(t *testing.T) {
+		_, err := expandAlias(newDispatcher(), ac, []string{"bad"})
+		require.ErrorContains(t, err, `invalid alias "bad"`)
+	})
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,7 +45,11 @@ func Run(args []string) int {
 		return 0
 	}
 
-	execArgs, err := expandAlias(d, args[1:])
+	// A load error is left for the command to report; `miren version` has
+	// no reason to mention app.toml at all.
+	ac, _ := commands.LoadLocalAppConfig()
+
+	execArgs, err := expandAlias(d, ac, args[1:])
 	if err != nil {
 		printError(err)
 		return 1
@@ -67,6 +71,9 @@ func Run(args []string) int {
 			return int(exitErr)
 		}
 
+		// An alias that didn't expand because app.toml wouldn't parse
+		// otherwise surfaces as a bare "unknown command".
+		commands.WarnLocalAppConfig()
 		printError(err)
 		return 1
 	}

--- a/cli/commands/alias_list.go
+++ b/cli/commands/alias_list.go
@@ -11,8 +11,9 @@ import (
 func AliasList(ctx *Context, opts struct {
 	FormatOptions
 }) error {
-	ac, configPath, err := appconfig.LoadAppConfigWithPath()
+	ac, configPath, err := local.load()
 	if err != nil {
+		local.fatal("")
 		return err
 	}
 

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -55,9 +55,15 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 
 	if a.Dir != "." {
 		ac, err = appconfig.LoadAppConfigUnder(a.Dir)
+		if err != nil {
+			local.fatal(filepath.Join(a.Dir, appconfig.AppConfigPath))
+		}
 	} else {
 		var configPath string
-		ac, configPath, err = appconfig.LoadAppConfigWithPath()
+		ac, configPath, err = local.load()
+		if err != nil {
+			local.fatal("")
+		}
 		if err == nil && ac != nil && configPath != "" {
 			// Config was found — always record the resolved directory.
 			configDir := filepath.Dir(filepath.Dir(configPath)) // strip .miren/app.toml

--- a/cli/commands/app_delete.go
+++ b/cli/commands/app_delete.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
-	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -15,10 +14,7 @@ func AppDelete(ctx *Context, opts struct {
 }) error {
 	appName := opts.AppName
 	if appName == "" {
-		ac, err := appconfig.LoadAppConfig()
-		if err != nil {
-			printConfigWarning(err)
-		} else if ac != nil && ac.Name != "" {
+		if ac := loadLocalAppConfigOrWarn(); ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}

--- a/cli/commands/app_test.go
+++ b/cli/commands/app_test.go
@@ -43,17 +43,13 @@ func TestInferAppName(t *testing.T) {
 	}
 }
 
-// chdir changes the working directory for the duration of the test and restores it on cleanup.
+// chdir changes the working directory for the duration of the test and
+// forgets any app config memoized from the previous one.
 func chdir(t *testing.T, dir string) {
 	t.Helper()
-	orig, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get working directory: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("failed to chdir to %s: %v", dir, err)
-	}
-	t.Cleanup(func() { os.Chdir(orig) })
+	t.Chdir(dir)
+	resetLocalAppConfig()
+	t.Cleanup(resetLocalAppConfig)
 }
 
 func TestAppCentricValidate(t *testing.T) {

--- a/cli/commands/cluster_switch.go
+++ b/cli/commands/cluster_switch.go
@@ -99,9 +99,7 @@ func ClusterSwitch(ctx *Context, opts struct {
 	ctx.Printf("Switched to cluster: %s\n", clusterName)
 
 	// Also update per-app state if we're in an app directory.
-	if ac, err := appconfig.LoadAppConfig(); err != nil {
-		printConfigWarning(err)
-	} else if ac != nil && ac.Name != "" {
+	if ac := loadLocalAppConfigOrWarn(); ac != nil && ac.Name != "" {
 		_ = appconfig.SaveAppState(ac.Name, &appconfig.AppState{Cluster: clusterName})
 	}
 

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -104,9 +104,7 @@ func (c *ConfigCentric) LoadCluster() (*clientconfig.ClusterConfig, string, erro
 	}
 
 	// Check per-app state if we're in an app directory.
-	if ac, err := appconfig.LoadAppConfig(); err != nil {
-		printConfigWarning(err)
-	} else if ac != nil && ac.Name != "" {
+	if ac := loadLocalAppConfigOrWarn(); ac != nil && ac.Name != "" {
 		state, err := appconfig.LoadAppState(ac.Name)
 		if err == nil && state != nil && state.Cluster != "" {
 			cc, err := cfg.GetCluster(state.Cluster)

--- a/cli/commands/config_test.go
+++ b/cli/commands/config_test.go
@@ -123,11 +123,7 @@ func setupAppDir(t *testing.T, appName string) string {
 	// Set HOME so app state goes to our temp dir
 	t.Setenv("HOME", dir)
 
-	// Change into the app directory
-	origDir, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { os.Chdir(origDir) })
+	chdir(t, dir)
 
 	return dir
 }
@@ -157,11 +153,7 @@ func TestConfigCentricPerAppState(t *testing.T) {
 		r := require.New(t)
 
 		// Use a temp dir without .miren/app.toml
-		dir := t.TempDir()
-		origDir, err := os.Getwd()
-		r.NoError(err)
-		r.NoError(os.Chdir(dir))
-		t.Cleanup(func() { os.Chdir(origDir) })
+		chdir(t, t.TempDir())
 
 		cfg := clientconfig.NewConfig()
 		cfg.SetCluster("global-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.2:8443"})

--- a/cli/commands/localconfig.go
+++ b/cli/commands/localconfig.go
@@ -1,0 +1,94 @@
+package commands
+
+import (
+	"path/filepath"
+	"sync"
+
+	"miren.dev/runtime/appconfig"
+)
+
+// localAppConfig is the .miren/app.toml found by walking up from the working
+// directory, loaded at most once per CLI invocation. Alias expansion, per-app
+// cluster pinning, and app-name defaulting all want it, so the load is
+// memoized and a broken file is reported by whichever caller hits it first.
+// Package state rather than a Context field because alias expansion runs
+// before any Context exists. reported is a plain bool: flag validation and
+// the command body run on one goroutine, and only load is reached from
+// anywhere else.
+type localAppConfig struct {
+	once     sync.Once
+	config   *appconfig.AppConfig
+	path     string
+	err      error
+	reported bool
+}
+
+var local localAppConfig
+
+func (l *localAppConfig) load() (*appconfig.AppConfig, string, error) {
+	l.once.Do(func() {
+		l.config, l.path, l.err = appconfig.LoadAppConfigWithPath()
+	})
+	return l.config, l.path, l.err
+}
+
+// warn prints the load error as a warning unless it has already been
+// reported, either as a warning or as a command's own error. A successful
+// load is a no-op.
+func (l *localAppConfig) warn() {
+	if _, _, err := l.load(); err == nil || l.reported {
+		return
+	}
+	l.reported = true
+	printConfigWarning(l.err)
+}
+
+// fatal records that a command is failing with the load error itself, so
+// the file is not warned about again. When path is given it must name the
+// same file; an error from some other app.toml leaves a pending warning for
+// this one in place.
+func (l *localAppConfig) fatal(path string) {
+	_, own, err := l.load()
+	if err == nil {
+		return
+	}
+	if path != "" {
+		abs, err := filepath.Abs(path)
+		if err != nil || abs != own {
+			return
+		}
+	}
+	l.reported = true
+}
+
+// LoadLocalAppConfig returns the app config from the working directory, or
+// (nil, nil) when there isn't one. A load error is returned without being
+// printed; callers that carry on regardless should call WarnLocalAppConfig.
+func LoadLocalAppConfig() (*appconfig.AppConfig, error) {
+	ac, _, err := local.load()
+	return ac, err
+}
+
+// WarnLocalAppConfig prints a warning for a broken local app config, once per
+// invocation. Safe to call whether or not the load failed.
+func WarnLocalAppConfig() {
+	local.warn()
+}
+
+// loadLocalAppConfigOrWarn is the common shape for commands that would like
+// the local config but can do without it: a broken file is reported once and
+// treated as absent.
+func loadLocalAppConfigOrWarn() *appconfig.AppConfig {
+	ac, err := LoadLocalAppConfig()
+	if err != nil {
+		WarnLocalAppConfig()
+		return nil
+	}
+	return ac
+}
+
+// resetLocalAppConfig forgets the memoized load so a test can point the
+// working directory somewhere else.
+func resetLocalAppConfig() {
+	local = localAppConfig{}
+}

--- a/cli/commands/localconfig_test.go
+++ b/cli/commands/localconfig_test.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureStderr runs fn with os.Stderr redirected and returns what it wrote.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func writeLocalAppConfig(t *testing.T, contents string) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".miren"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".miren", "app.toml"), []byte(contents), 0o644))
+	chdir(t, dir)
+}
+
+func TestLocalAppConfig(t *testing.T) {
+	t.Run("broken config warns once across callers", func(t *testing.T) {
+		writeLocalAppConfig(t, "name = 'demo'\npost_import = ''\n")
+
+		out := captureStderr(t, func() {
+			// Alias expansion, setup's LoadCluster, and the command body all
+			// ask; the file is read once and reported once.
+			_, err := LoadLocalAppConfig()
+			require.Error(t, err)
+			require.Nil(t, loadLocalAppConfigOrWarn())
+			require.Nil(t, loadLocalAppConfigOrWarn())
+			WarnLocalAppConfig()
+		})
+		require.Equal(t, 1, strings.Count(out, "warning:"), "stderr:\n%s", out)
+		require.Contains(t, out, `unknown field "post_import"`)
+	})
+
+	t.Run("fatal report suppresses the warning", func(t *testing.T) {
+		writeLocalAppConfig(t, "name = 'demo'\npost_import = ''\n")
+
+		out := captureStderr(t, func() {
+			var a AppCentric
+			a.Dir = "."
+			require.Error(t, a.Validate(nil))
+			WarnLocalAppConfig()
+		})
+		require.Empty(t, out)
+	})
+
+	t.Run("fatal report through -d suppresses the warning", func(t *testing.T) {
+		writeLocalAppConfig(t, "name = 'demo'\npost_import = ''\n")
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+
+		out := captureStderr(t, func() {
+			_, err := LoadLocalAppConfig()
+			require.Error(t, err)
+			var a AppCentric
+			a.Dir = cwd
+			require.Error(t, a.Validate(nil))
+			WarnLocalAppConfig()
+		})
+		require.Empty(t, out)
+	})
+
+	t.Run("fatal report for another file leaves the warning pending", func(t *testing.T) {
+		writeLocalAppConfig(t, "name = 'demo'\npost_import = ''\n")
+		other := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(other, ".miren"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(other, ".miren", "app.toml"), []byte("name = 'other'\nbogus = 1\n"), 0o644))
+
+		out := captureStderr(t, func() {
+			_, err := LoadLocalAppConfig()
+			require.Error(t, err)
+			var a AppCentric
+			a.Dir = other
+			require.ErrorContains(t, a.Validate(nil), "bogus")
+			WarnLocalAppConfig()
+		})
+		require.Equal(t, 1, strings.Count(out, "warning:"), "stderr:\n%s", out)
+		require.Contains(t, out, "post_import")
+	})
+
+	t.Run("valid config is shared", func(t *testing.T) {
+		writeLocalAppConfig(t, "name = 'demo'\n")
+
+		out := captureStderr(t, func() {
+			ac := loadLocalAppConfigOrWarn()
+			require.NotNil(t, ac)
+			require.Equal(t, "demo", ac.Name)
+			again, err := LoadLocalAppConfig()
+			require.NoError(t, err)
+			require.Same(t, ac, again)
+			WarnLocalAppConfig()
+		})
+		require.Empty(t, out)
+	})
+
+	t.Run("no config is silent", func(t *testing.T) {
+		chdir(t, t.TempDir())
+
+		out := captureStderr(t, func() {
+			require.Nil(t, loadLocalAppConfigOrWarn())
+			WarnLocalAppConfig()
+		})
+		require.Empty(t, out)
+	})
+}

--- a/cli/commands/route_set.go
+++ b/cli/commands/route_set.go
@@ -5,7 +5,6 @@ import (
 
 	"miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/ingress"
-	"miren.dev/runtime/appconfig"
 )
 
 func RouteSet(ctx *Context, opts struct {
@@ -24,10 +23,7 @@ func RouteSet(ctx *Context, opts struct {
 
 	appName := opts.AppName
 	if appName == "" {
-		ac, err := appconfig.LoadAppConfig()
-		if err != nil {
-			printConfigWarning(err)
-		} else if ac != nil && ac.Name != "" {
+		if ac := loadLocalAppConfigOrWarn(); ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}

--- a/cli/commands/route_set_default.go
+++ b/cli/commands/route_set_default.go
@@ -5,7 +5,6 @@ import (
 
 	apppkg "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/ingress"
-	"miren.dev/runtime/appconfig"
 )
 
 func RouteSetDefault(ctx *Context, opts struct {
@@ -14,10 +13,7 @@ func RouteSetDefault(ctx *Context, opts struct {
 }) error {
 	appName := opts.AppName
 	if appName == "" {
-		ac, err := appconfig.LoadAppConfig()
-		if err != nil {
-			printConfigWarning(err)
-		} else if ac != nil && ac.Name != "" {
+		if ac := loadLocalAppConfigOrWarn(); ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}


### PR DESCRIPTION
One unknown field in `.miren/app.toml` got you the same warning three times on `miren app list`, and on `deploy` you got it as a warning and then again as the error. Three different parts of the CLI (alias expansion, cluster resolution during setup, and the command body) each read the file on their own and each complained on their own.

The local app config is now loaded once per invocation and remembers whether its failure has been reported, so it's mentioned exactly once by whichever caller gets there first. `miren version` no longer mentions a file it doesn't use, and an alias that didn't expand because the file wouldn't parse now says so instead of a bare "unknown command". As a side effect `expandAlias` takes the config as an argument, so the alias tests finally cover expansion and shadowing instead of a note saying they can't.

While in there, the diagnostic itself got two touch-ups: the squiggle said `missing field` under a headline of `unknown field`, and `post_import` now gets a hint pointing at deploy tasks instead of no hint at all.

```
warning: .miren/app.toml:2: unknown field "post_import"
  1| name = 'multipass'
  2| post_import = ''
   | ~~~~~~~~~~~ unknown field
  3| env = []
  hint: post_import was removed and never ran; use a deploy task instead (see https://miren.md/tasks)
```

Closes MIR-1818
