### PR TITLE
Close the server side of a QUIC dial cancelled mid-handshake

### DIFF
--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -145,12 +145,7 @@ func (c *NetworkClient) setupTransport() {
 
 		setTLSConfigServerName(tlsCfg, uaddr, addr)
 
-		var conn *quic.Conn
-		if early {
-			conn, err = c.transport.DialEarly(ctx, uaddr, tlsCfg, cfg)
-		} else {
-			conn, err = c.transport.Dial(ctx, uaddr, tlsCfg, cfg)
-		}
+		conn, err := dialQUIC(ctx, c.transport, uaddr, tlsCfg, cfg, early)
 		if err != nil {
 			return nil, err
 		}
@@ -180,6 +175,52 @@ func (c *NetworkClient) setupTransport() {
 		return conn, err
 	}
 	c.httpDrain = &drainingHTTP{base: &c.htr, ctx: c.State.top, prepare: c.prepareRequest}
+}
+
+// dialQUIC dials through t and closes the connection properly if ctx is
+// cancelled while the handshake is still in flight.
+//
+// quic-go's own cancellation path destroys the half-built connection without
+// sending a CONNECTION_CLOSE. The server has usually already accepted it by
+// then (an EarlyListener hands connections over before the handshake finishes)
+// and is left with a peer that has silently vanished, which it only notices at
+// the idle timeout. That is long enough to hold a graceful shutdown past its
+// deadline, and a coordinator dialing itself, as its controllers do for entity
+// watches, stalls its own drain that way when a watch is cancelled mid-dial.
+//
+// So the dial runs against a context the caller cannot cancel and only the
+// wait is abandoned on cancellation. HandshakeIdleTimeout still bounds the
+// detached dial, and whatever it produces is closed with a proper
+// CONNECTION_CLOSE so the peer can let go too. quic-go already derives the
+// connection's own context with WithoutCancel, so this changes nothing about a
+// connection that does get established.
+func dialQUIC(ctx context.Context, t *quic.Transport, addr net.Addr, tlsCfg *tls.Config, cfg *quic.Config, early bool) (*quic.Conn, error) {
+	type result struct {
+		conn *quic.Conn
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		var r result
+		if early {
+			r.conn, r.err = t.DialEarly(context.WithoutCancel(ctx), addr, tlsCfg, cfg)
+		} else {
+			r.conn, r.err = t.Dial(context.WithoutCancel(ctx), addr, tlsCfg, cfg)
+		}
+		done <- r
+	}()
+
+	select {
+	case r := <-done:
+		return r.conn, r.err
+	case <-ctx.Done():
+		go func() {
+			if r := <-done; r.conn != nil {
+				_ = r.conn.CloseWithError(0, "dial cancelled")
+			}
+		}()
+		return nil, context.Cause(ctx)
+	}
 }
 
 func setTLSConfigServerName(tlsConf *tls.Config, addr net.Addr, host string) {

--- a/pkg/rpc/client_internal_test.go
+++ b/pkg/rpc/client_internal_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"io"
 	"log/slog"
 	"net"
@@ -459,4 +460,87 @@ func quietQUICServer(t *testing.T, parent context.Context, run func(context.Cont
 	}()
 
 	return packetConn.LocalAddr().String()
+}
+
+// Cancelling a dial while its handshake is still in flight has to tell the
+// server. quic-go's own cancellation destroys the client side without a
+// CONNECTION_CLOSE, leaving a server that accepted the connection early to
+// discover the peer is gone only at the idle timeout, which is how a
+// coordinator's own entity watches held its drain past the deadline.
+func TestQUICDialCancelledMidHandshakeClosesServerSide(t *testing.T) {
+	r := require.New(t)
+
+	packetConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	r.NoError(err)
+	t.Cleanup(func() { _ = packetConn.Close() })
+	ln, err := quic.ListenEarly(packetConn, testServerTLSConfig(t), &quic.Config{
+		EnableDatagrams:                  true,
+		EnableStreamResetPartialDelivery: true,
+		// Longer than the assertion window, so the server can only let go
+		// because the client told it to.
+		HandshakeIdleTimeout: 30 * time.Second,
+		MaxIdleTimeout:       30 * time.Second,
+	})
+	r.NoError(err)
+	t.Cleanup(func() { _ = ln.Close() })
+	accepted := make(chan *quic.Conn, 1)
+	go func() {
+		conn, err := ln.Accept(t.Context())
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	// Hold the client in certificate verification. By then the server has
+	// handed the connection to Accept and is waiting on the client's Finished.
+	verifying := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseClient := func() { releaseOnce.Do(func() { close(release) }) }
+	client := newTestWebTransportClient(t, packetConn.LocalAddr().String())
+	// Registered after the client so it runs before the client's transport
+	// is closed; a failing run must not leave that close waiting on a
+	// handshake nobody will finish.
+	t.Cleanup(releaseClient)
+	client.tlsCfg.VerifyPeerCertificate = func([][]byte, [][]*x509.Certificate) error {
+		close(verifying)
+		<-release
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := client.ws.Dial(ctx, "https://"+client.remote+"/", nil)
+		done <- err
+	}()
+
+	select {
+	case <-verifying:
+	case <-time.After(3 * time.Second):
+		t.Fatal("client never reached certificate verification")
+	}
+	var serverConn *quic.Conn
+	select {
+	case serverConn = <-accepted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not accept the connection before the handshake finished")
+	}
+
+	cancel()
+	r.NoError(serverConn.Context().Err(), "server side closed before the client could have told it anything")
+	releaseClient()
+	select {
+	case err := <-done:
+		r.ErrorIs(err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("dial did not return after cancellation")
+	}
+
+	select {
+	case <-serverConn.Context().Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("server side of a cancelled dial stayed open")
+	}
 }


### PR DESCRIPTION
`TestControlPlaneParse` has been failing most CI runs since the coordinator started dialing itself over WebTransport for its entity watches (#1184): the HTTP/3 drain times out with a few connections still open, and thanks to the census #1177 added we can see they're idle server-side sessions whose client half is already gone.

The client half is gone because quic-go answers a cancelled `Dial` with `destroy`, which drops the connection without sending a CONNECTION_CLOSE. The server has already handed that connection to `Accept` by then, so it keeps it until the 30s idle timeout, which is longer than the 10s a graceful shutdown waits. Stopping a coordinator right after starting it cancels its controllers' watches while their dials are still in the handshake, and the coordinator then waits on its own ghosts. It reproduces locally about one run in four at `GOMAXPROCS=2`.

The fix runs the dial against a context the caller can't cancel and abandons only the wait; whatever the detached dial produces gets closed properly so the peer can let go. `HandshakeIdleTimeout` still bounds it, and an established connection behaves exactly as before. The new test holds a client mid-handshake so the cancellation lands after the server's `Accept`, and fails on the old path with the server side still open.

This supersedes #1198, which closes the test's own RPC client in cleanup. That client's connection was already being closed by `rs.Close()`; the survivors are the coordinator's connections to itself, so the test-side change can't reach them.

Related to MIR-1792
