### PR TITLE
Stop retaining closed RPC connections

### DIFF
--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -104,15 +104,18 @@ type NetworkClient struct {
 
 	//cachedConn *cachedConn
 
-	// conns records every QUIC connection this client has dialed, so a failed
+	// conns records live QUIC connections this client has dialed, so a failed
 	// request can be classified by whether a handshake ever completed. That
 	// distinction is not recoverable from the error value: quic-go raises the
 	// same IdleTimeoutError ("timeout: no recent network activity") both for a
 	// connection that never got a packet back and for one that completed its
 	// handshake and later went quiet. Those are different problems with
 	// different fixes, and we own the Dial hook, so we track it ourselves.
-	connMu sync.Mutex
-	conns  []*quic.Conn
+	// Preserve the handshake result after closure without retaining the
+	// connection and its buffers for the lifetime of a controller's client.
+	connMu           sync.Mutex
+	conns            map[*quic.Conn]struct{}
+	handshakeReached bool
 
 	inlineClient *inlineClient
 	localClient  *localClient
@@ -203,11 +206,20 @@ func setTLSConfigServerName(tlsConf *tls.Config, addr net.Addr, host string) {
 
 func (c *NetworkClient) trackConn(conn *quic.Conn) {
 	c.connMu.Lock()
-	c.conns = append(c.conns, conn)
+	if c.conns == nil {
+		c.conns = make(map[*quic.Conn]struct{})
+	}
+	c.conns[conn] = struct{}{}
 	c.connMu.Unlock()
 	if c.State != nil {
 		c.State.trackOutboundConn(conn)
 	}
+	context.AfterFunc(conn.Context(), func() {
+		c.connMu.Lock()
+		defer c.connMu.Unlock()
+		c.recordHandshake(conn)
+		delete(c.conns, conn)
+	})
 }
 
 // reachedServer reports whether any connection this client dialed finished its
@@ -220,17 +232,26 @@ func (c *NetworkClient) trackConn(conn *quic.Conn) {
 // non-blocking receive is an accurate "did we ever get this far" test.
 func (c *NetworkClient) reachedServer() bool {
 	c.connMu.Lock()
-	conns := slices.Clone(c.conns)
-	c.connMu.Unlock()
+	defer c.connMu.Unlock()
 
-	for _, conn := range conns {
-		select {
-		case <-conn.HandshakeComplete():
-			return true
-		default:
+	if !c.handshakeReached {
+		for conn := range c.conns {
+			c.recordHandshake(conn)
+			if c.handshakeReached {
+				break
+			}
 		}
 	}
-	return false
+	return c.handshakeReached
+}
+
+// Caller holds connMu. DialEarly can return before the handshake succeeds.
+func (c *NetworkClient) recordHandshake(conn *quic.Conn) {
+	select {
+	case <-conn.HandshakeComplete():
+		c.handshakeReached = true
+	default:
+	}
 }
 
 // classifyTransportError turns a transport failure during capability

--- a/pkg/rpc/client_lifecycle_test.go
+++ b/pkg/rpc/client_lifecycle_test.go
@@ -1,0 +1,111 @@
+package rpc
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamingRPCReleasesConnections(t *testing.T) {
+	for _, outcome := range []string{"success", "handler error", "canceled", "rejected"} {
+		t.Run(outcome, func(t *testing.T) {
+			state, err := NewState(t.Context(), WithSkipVerify)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = state.Close() })
+			started := make(chan struct{}, 1)
+			state.Server().ExposeValue("lifecycle", &Interface{
+				name: "Lifecycle",
+				methods: map[string]Method{
+					"call": {Name: "call", InterfaceName: "Lifecycle", Handler: func(ctx context.Context, call Call) error {
+						var args map[string]any
+						call.Args(&args)
+						if outcome == "canceled" {
+							started <- struct{}{}
+							<-ctx.Done()
+							return ctx.Err()
+						}
+						if outcome == "handler error" {
+							return errors.New("handler failed")
+						}
+						call.Results(map[string]any{})
+						return nil
+					}},
+				},
+			})
+			client, err := state.Connect(state.LoopbackAddr(), "lifecycle")
+			require.NoError(t, err)
+			method := "call"
+			if outcome == "rejected" {
+				method = "missing"
+			}
+			for range 20 {
+				ctx, cancel := context.WithCancel(t.Context())
+				done := make(chan error, 1)
+				go func() {
+					var result map[string]any
+					done <- client.CallWithCaps(ctx, method, map[string]any{}, &result, nil)
+				}()
+				if outcome == "canceled" {
+					select {
+					case <-started:
+					case <-time.After(5 * time.Second):
+						cancel()
+						t.Fatal("streaming handler did not start")
+					}
+					cancel()
+				}
+				select {
+				case err := <-done:
+					cancel()
+					if outcome == "success" {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+					}
+				case <-time.After(5 * time.Second):
+					cancel()
+					t.Fatal("streaming RPC did not finish")
+				}
+			}
+
+			// Only the original unary connection should remain. The State tracks
+			// live connections; the client must also release its diagnostic refs.
+			require.Eventually(t, func() bool {
+				state.outboundMu.Lock()
+				defer state.outboundMu.Unlock()
+				return len(state.outboundConns) == 1
+			}, 5*time.Second, 10*time.Millisecond, "completed streaming RPCs left live QUIC connections")
+			require.Eventually(t, func() bool {
+				client.connMu.Lock()
+				defer client.connMu.Unlock()
+				return len(client.conns) == 1
+			}, time.Second, 10*time.Millisecond, "client retained closed QUIC connections")
+		})
+	}
+}
+
+func TestClientRemembersHandshakeAfterConnectionCloses(t *testing.T) {
+	addr := quietQUICServer(t, t.Context(), func(_ context.Context, conn *quic.Conn) {
+		<-conn.Context().Done()
+	})
+	conn, err := quic.DialAddr(t.Context(), addr, &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h3"},
+	}, &quic.Config{})
+	require.NoError(t, err)
+	client := new(NetworkClient)
+	client.trackConn(conn)
+	require.NoError(t, conn.CloseWithError(0, "test"))
+	require.Eventually(t, func() bool {
+		client.connMu.Lock()
+		defer client.connMu.Unlock()
+		return len(client.conns) == 0
+	}, time.Second, time.Millisecond)
+	// No diagnostic lookup happened before the connection was removed.
+	require.True(t, client.reachedServer())
+}


### PR DESCRIPTION
Periodic watch resyncs left long-lived RPC clients holding every connection they had opened. #1184 fixed the live-connection leak, but closed connections and their buffers still accumulated in timeout diagnostics. Release those references while preserving whether a handshake ever succeeded.

Regression coverage checks cleanup after successful, failed, canceled, and rejected streaming calls. RPC and indexwatch tests, focused race tests, and lint pass.

Part of MIR-1820
