### PR TITLE
Stop streaming RPC leaks on v0.15

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -13,6 +13,14 @@ All notable changes to Miren Runtime will be documented in this file.
 
 ---
 
+## v0.15.1
+*2026-09-11*
+
+**Bug Fixes**
+- **Stop control-plane memory growth during watch resyncs** - Periodic controller watches left streaming connections alive after each resync, accumulating goroutines and memory until the host could run out. Streaming calls now close their connections when they finish, and closed connections and sessions are released from bookkeeping. This patch keeps v0.15's transport protocol and QUIC version. ([#1202](https://github.com/mirendev/runtime/pull/1202))
+
+---
+
 ## v0.15.0
 *2026-09-09*
 

--- a/go.mod
+++ b/go.mod
@@ -420,3 +420,7 @@ require (
 // v0.28.6. Drop this replace once we move to a flannel release carrying both.
 // Tracking: MIR-1274.
 replace github.com/flannel-io/flannel => github.com/mirendev/flannel v0.26.8-0.20260805213236-ce737c30f40c
+
+// MIR-1820: v0.9 session-registry cleanup for the v0.15 hotfix.
+// Keeps the released protocol and QUIC dependencies; main uses the newer transport.
+replace github.com/quic-go/webtransport-go => github.com/mirendev/webtransport-go v0.9.1-0.20260911143147-180830f79577

--- a/go.sum
+++ b/go.sum
@@ -896,6 +896,8 @@ github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLT
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/mirendev/flannel v0.26.8-0.20260805213236-ce737c30f40c h1:JA+DVw1mVm48VLK/U0zI991j2feFzikW/fU9tO5Eq+s=
 github.com/mirendev/flannel v0.26.8-0.20260805213236-ce737c30f40c/go.mod h1:/oz+EbTC6NGJTxk2VsqBigFAqaIEYBuS7Bf9/MDJ2DI=
+github.com/mirendev/webtransport-go v0.9.1-0.20260911143147-180830f79577 h1:kdHkzuUBWFAULAHUAAA8I7MswjFhldA6QT/lQ7JeOzo=
+github.com/mirendev/webtransport-go v0.9.1-0.20260911143147-180830f79577/go.mod h1:4FUYIiUc75XSsF6HShcLeXXYZJ9AGwo/xh3L8M/P1ao=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -1124,8 +1126,6 @@ github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
 github.com/quic-go/quic-go v0.57.1 h1:25KAAR9QR8KZrCZRThWMKVAwGoiHIrNbT72ULHTuI10=
 github.com/quic-go/quic-go v0.57.1/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
-github.com/quic-go/webtransport-go v0.9.0 h1:jgys+7/wm6JarGDrW+lD/r9BGqBAmqY/ssklE09bA70=
-github.com/quic-go/webtransport-go v0.9.0/go.mod h1:4FUYIiUc75XSsF6HShcLeXXYZJ9AGwo/xh3L8M/P1ao=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/regfish/regfish-dnsapi-go v0.1.1 h1:TJFtbePHkd47q5GZwYl1h3DIYXmoxdLjW/SBsPtB5IE=

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -103,15 +103,18 @@ type NetworkClient struct {
 
 	//cachedConn *cachedConn
 
-	// conns records every QUIC connection this client has dialed, so a failed
+	// conns records live QUIC connections this client has dialed, so a failed
 	// request can be classified by whether a handshake ever completed. That
 	// distinction is not recoverable from the error value: quic-go raises the
 	// same IdleTimeoutError ("timeout: no recent network activity") both for a
 	// connection that never got a packet back and for one that completed its
 	// handshake and later went quiet. Those are different problems with
 	// different fixes, and we own the Dial hook, so we track it ourselves.
-	connMu sync.Mutex
-	conns  []*quic.Conn
+	// Preserve the handshake result after closure without retaining the
+	// connection and its buffers for the lifetime of a controller's client.
+	connMu           sync.Mutex
+	conns            map[*quic.Conn]struct{}
+	handshakeReached bool
 
 	inlineClient *inlineClient
 	localClient  *localClient
@@ -191,11 +194,20 @@ func setTLSConfigServerName(tlsConf *tls.Config, addr net.Addr, host string) {
 
 func (c *NetworkClient) trackConn(conn *quic.Conn) {
 	c.connMu.Lock()
-	c.conns = append(c.conns, conn)
+	if c.conns == nil {
+		c.conns = make(map[*quic.Conn]struct{})
+	}
+	c.conns[conn] = struct{}{}
 	c.connMu.Unlock()
 	if c.State != nil {
 		c.State.trackOutboundConn(conn)
 	}
+	context.AfterFunc(conn.Context(), func() {
+		c.connMu.Lock()
+		defer c.connMu.Unlock()
+		c.recordHandshake(conn)
+		delete(c.conns, conn)
+	})
 }
 
 // reachedServer reports whether any connection this client dialed finished its
@@ -208,17 +220,26 @@ func (c *NetworkClient) trackConn(conn *quic.Conn) {
 // non-blocking receive is an accurate "did we ever get this far" test.
 func (c *NetworkClient) reachedServer() bool {
 	c.connMu.Lock()
-	conns := slices.Clone(c.conns)
-	c.connMu.Unlock()
+	defer c.connMu.Unlock()
 
-	for _, conn := range conns {
-		select {
-		case <-conn.HandshakeComplete():
-			return true
-		default:
+	if !c.handshakeReached {
+		for conn := range c.conns {
+			c.recordHandshake(conn)
+			if c.handshakeReached {
+				break
+			}
 		}
 	}
-	return false
+	return c.handshakeReached
+}
+
+// Caller holds connMu. DialEarly can return before the handshake succeeds.
+func (c *NetworkClient) recordHandshake(conn *quic.Conn) {
+	select {
+	case <-conn.HandshakeComplete():
+		c.handshakeReached = true
+	default:
+	}
 }
 
 // classifyTransportError turns a transport failure during capability
@@ -909,6 +930,13 @@ func (c *NetworkClient) dialWebTransport(ctx context.Context, url string, header
 	ch := make(chan dialResult, 1)
 	go func() {
 		hr, s, err := ws.Dial(ctx, url, header)
+		if err != nil {
+			abandonDial()
+		} else {
+			// v0.9 closes session streams without closing the dedicated QUIC
+			// connection. Keepalives prevent that connection from timing out.
+			context.AfterFunc(s.Context(), abandonDial)
+		}
 		ch <- dialResult{hr, s, err}
 	}()
 

--- a/pkg/rpc/client_lifecycle_test.go
+++ b/pkg/rpc/client_lifecycle_test.go
@@ -1,0 +1,111 @@
+package rpc
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamingRPCReleasesConnections(t *testing.T) {
+	for _, outcome := range []string{"success", "handler error", "canceled", "rejected"} {
+		t.Run(outcome, func(t *testing.T) {
+			state, err := NewState(t.Context(), WithSkipVerify)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = state.Close() })
+			started := make(chan struct{}, 1)
+			state.Server().ExposeValue("lifecycle", &Interface{
+				name: "Lifecycle",
+				methods: map[string]Method{
+					"call": {Name: "call", InterfaceName: "Lifecycle", Handler: func(ctx context.Context, call Call) error {
+						var args map[string]any
+						call.Args(&args)
+						if outcome == "canceled" {
+							started <- struct{}{}
+							<-ctx.Done()
+							return ctx.Err()
+						}
+						if outcome == "handler error" {
+							return errors.New("handler failed")
+						}
+						call.Results(map[string]any{})
+						return nil
+					}},
+				},
+			})
+			client, err := state.Connect(state.LoopbackAddr(), "lifecycle")
+			require.NoError(t, err)
+			method := "call"
+			if outcome == "rejected" {
+				method = "missing"
+			}
+			for range 20 {
+				ctx, cancel := context.WithCancel(t.Context())
+				done := make(chan error, 1)
+				go func() {
+					var result map[string]any
+					done <- client.CallWithCaps(ctx, method, map[string]any{}, &result, nil)
+				}()
+				if outcome == "canceled" {
+					select {
+					case <-started:
+					case <-time.After(5 * time.Second):
+						cancel()
+						t.Fatal("streaming handler did not start")
+					}
+					cancel()
+				}
+				select {
+				case err := <-done:
+					cancel()
+					if outcome == "success" {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+					}
+				case <-time.After(5 * time.Second):
+					cancel()
+					t.Fatal("streaming RPC did not finish")
+				}
+			}
+
+			// Only the original unary connection should remain. The State tracks
+			// live connections; the client must also release its diagnostic refs.
+			require.Eventually(t, func() bool {
+				state.outboundMu.Lock()
+				defer state.outboundMu.Unlock()
+				return len(state.outboundConns) == 1
+			}, 5*time.Second, 10*time.Millisecond, "completed streaming RPCs left live QUIC connections")
+			require.Eventually(t, func() bool {
+				client.connMu.Lock()
+				defer client.connMu.Unlock()
+				return len(client.conns) == 1
+			}, time.Second, 10*time.Millisecond, "client retained closed QUIC connections")
+		})
+	}
+}
+
+func TestClientRemembersHandshakeAfterConnectionCloses(t *testing.T) {
+	addr := quietQUICServer(t, t.Context(), func(_ context.Context, conn *quic.Conn) {
+		<-conn.Context().Done()
+	})
+	conn, err := quic.DialAddr(t.Context(), addr, &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h3"},
+	}, &quic.Config{})
+	require.NoError(t, err)
+	client := new(NetworkClient)
+	client.trackConn(conn)
+	require.NoError(t, conn.CloseWithError(0, "test"))
+	require.Eventually(t, func() bool {
+		client.connMu.Lock()
+		defer client.connMu.Unlock()
+		return len(client.conns) == 0
+	}, time.Second, time.Millisecond)
+	// No diagnostic lookup happened before the connection was removed.
+	require.True(t, client.reachedServer())
+}


### PR DESCRIPTION
Periodic controller watch resyncs in v0.15.0 left streaming connections alive, accumulating goroutines and memory even without app traffic. Close each call's dedicated connection when its session ends or its dial fails, and backport #1202 to release closed connections from diagnostics.

A minimal patch to the v0.9 WebTransport fork also releases closed sessions from its registry. The transport protocol and QUIC version stay at their v0.15.0 versions. The fork is pinned to an exact commit, and the v0.15.1 changelog is included.

Repeated-call and watch-resync probes stay flat in goroutines, with retained heap bounded in the repeated-call probe. RPC/watch tests, focused race checks, mixed-version watch/exec tests with packet loss, and lint pass.

Part of MIR-1820
