### PR TITLE
Release an attached run's terminal when its container exits

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -2379,6 +2379,23 @@ func (c *SandboxController) monitorTaskExit(
 			// this input and nothing to contend with.
 			c.reportRunExit(ctx, sb, exitStatus.ExitCode(), exitAt)
 
+			// Release this container's stdio now that its process is gone.
+			//
+			// StopSandbox does this too, but it runs from reconciliation, and
+			// nothing schedules a reconcile at this moment -- so it lands on
+			// the controller's next resync, anywhere from zero to a full period
+			// away. An attached client blocks on the Hub closing, so waiting
+			// for that pass put a uniform 0-60s tail on every `miren app run`:
+			// the command's output arrived at once and the terminal then sat
+			// there, long after the container had exited (MIR-1769).
+			//
+			// Closing a Hub also closes the container's stdin, which is why
+			// only teardown may normally do it. It is safe here for the same
+			// reason it is safe there: the process this stdin belonged to has
+			// already exited. The Hub lingers after closing, so a client that
+			// arrives late still gets the replayed output.
+			c.hubs.Remove(sb.ID, containerName)
+
 			c.Log.Info("marked sandbox as STOPPED due to process exit, cleanup will be triggered by reconciliation", "sandbox", sb.ID)
 			return
 


### PR DESCRIPTION
`miren app run -- echo hi` against prod took 40 to 50 seconds, while garden took about 10. The obvious readings all turned out to be wrong. It wasn't image pull, since the lighter of the two prod apps was the slower one. It wasn't distance to the cluster, and it wasn't cluster size.

It isn't startup at all. Run the same thing with `--detach` and the run reaches `succeeded` and has its sandbox reaped in about two seconds, on either cluster. The command finishes fast and prints its output fast, and then the terminal just sits there. Every bit of the delay lands after the container has already exited.

The cause is a gap in the teardown handoff. When a task's process exits, the runner marks the sandbox STOPPED and leaves the rest to reconciliation. But the code that closes the stdio Hub lives in StopSandbox, which only ever runs from a reconcile, and nothing enqueues one at that moment. So the Hub survived until the sandbox controller's next periodic resync, a minute apart, and an exit can land anywhere in that cycle. Every attached run picked up a uniform zero to sixty second tail.

That uniform spread is also why this read as a property of the cluster. The numbers in the original report were just different points in the same cycle. Instrumented, I measured 7s, 14s, 25s, 41s, 45s, 59s and a couple of dead-on 60s runs across both clusters, and reproduced it at 25s on a single-node local cluster with no network latency at all. The server log makes it plain: the container exits at `00:55:21.094`, and `stopping sandbox` lands at `00:55:46.211`.

The fix retires the container's Hub as soon as its process exits instead of waiting for a reconcile. Closing a Hub also closes the container's stdin, which is normally teardown's privilege, but it's safe here for exactly the reason it's safe there: the process that owned that stdin is already gone. The Hub still lingers after closing, so a client that arrives late gets the replayed output, which is what makes `echo hi` print anything at all.

Locally this takes `app run -- echo hi` from 25s to 0.32s. Exit codes still propagate and a long-running command still streams over its full duration, so the Hub is closing at real process exit rather than early.

Closes MIR-1769
