### PR TITLE
Stamp released binaries with their version again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,13 +203,26 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: 'go.mod'
-        # Same as the package job: `make bin/miren` runs the tag's Makefile, so
-        # a dispatched rebuild starts from a cold module cache.
+        # Same as the package job: the build below runs the tag's own build
+        # script, so a dispatched rebuild starts from a cold module cache.
         cache: ${{ needs.init.outputs.cache }}
 
     - name: Build binary for ${{ matrix.os }}-${{ matrix.arch }}
+      # build-ci.sh rather than `make bin/miren`, and the same two variables the
+      # package job passes. hack/build.sh, which is what make runs, derives the
+      # version from the checkout: `git describe --exact-match --tags`, then the
+      # current branch name. Neither survives `ref: <sha>` above — a commit
+      # checkout is detached and fetches no tags, so describe finds nothing and
+      # the branch name is the literal string "HEAD". Every binary this job
+      # produced from v0.14.0 through v0.15.1 was stamped "HEAD:<short sha>"
+      # instead of its version. build-ci.sh takes the ref from the environment
+      # and recognizes a version tag, which is why the bundle the package job
+      # builds was stamped correctly across the same releases.
+      env:
+        GIT_BRANCH: ${{ needs.init.outputs.ref }}
+        GIT_COMMIT: ${{ needs.init.outputs.sha }}
       run: |
-        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make bin/miren
+        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} bash hack/build-ci.sh
 
     - name: Import certificate and sign macOS binary
       if: matrix.os == 'darwin'


### PR DESCRIPTION
The standalone CLI binaries have shipped stamped `HEAD:<short sha>` instead of their version since v0.14.0. Read straight out of the published artifacts:

| Artifact | v0.15.0 | v0.15.1 |
| --- | --- | --- |
| `miren-base-linux-*` (server bundle) | `v0.15.0` ✅ | `v0.15.1` ✅ |
| `miren-{linux,darwin}-*`, `.zip`, `.pkg` (CLI) | `HEAD:f8055a3` ❌ | `HEAD:175b811` ❌ |

v0.13.0 was the last release whose CLI was stamped correctly. v0.14.0, v0.15.0 and v0.15.1 are all affected. The server bundle was never affected, which is why a running server has always reported its version correctly and why this went unnoticed.

## Cause

Two build scripts, and only one of them knows about tags.

`hack/build.sh`, which `make bin/miren` runs, derives the version from the checkout — `git describe --exact-match --tags HEAD`, then the current branch name. `hack/build-ci.sh`, which the `package` job runs, takes the ref from the environment and recognizes a version tag by name:

```bash
if [[ $current_branch =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
  version="$current_branch"
```

Between v0.13.0 and v0.14.0 the `build-binaries` checkout changed from `ref: needs.init.outputs.ref` (the tag name) to `ref: needs.init.outputs.sha`, in f2ebfb89 / bac05caa. A commit checkout is detached and fetches no tags, so `git describe` finds nothing and `git rev-parse --abbrev-ref HEAD` returns the literal string `HEAD`. Hence `HEAD:175b811`.

## Fix

Point `build-binaries` at `build-ci.sh` with the two variables the `package` job already passes.

Resolving a single sha in `init` is worth keeping — it's what stops a release straddling two commits if a tag moves mid-run — so this takes the ref names out of the build rather than putting the tag checkout back. Both release artifacts now come from one build script instead of two that disagree.

Branch builds improve as a side effect, from `HEAD:<sha>` to `main:<sha>`.

The step carries a comment explaining why `build.sh` cannot work under a sha checkout, so the next person to touch the checkout ref sees the trap. The `setup-go` comment above it referred to `make bin/miren` running "the tag's Makefile" and is updated to match.

## Verification

Ran the exact command the workflow will run, with v0.15.1's environment:

```
$ GIT_BRANCH=v0.15.1 GIT_COMMIT=175b811c... bash hack/build-ci.sh
Building version v0.15.1

$ go version -m bin/miren | grep version.Version
version.Version=v0.15.1
```

`make lint` passes.

## Follow-ups, not in this PR

- **Republishing the affected tags.** This only fixes builds from here on. Once it lands, a `workflow_dispatch` on `v0.15.1` with `update_latest: true` republishes correctly stamped CLIs — at the cost of new checksums and a rewritten `version.json` for that version, which matters to anyone pinning a sha256. Whether to do the same for v0.15.0 is a separate call, since it is no longer `latest`.
- **A guard.** Nothing checks the stamp, which is why this shipped three times. Asserting after the build that a tag build's stamped version equals the tag would catch it the first time.
- **`hack/build.sh` keeps the same blind spot** for anyone building locally from a detached checkout. Not release-affecting once nothing in CI uses it, but it is the underlying divergence.
