### PR TITLE
Stamp released binaries with their version again (v0.15 backport)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,13 +203,26 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: 'go.mod'
-        # Same as the package job: `make bin/miren` runs the tag's Makefile, so
-        # a dispatched rebuild starts from a cold module cache.
+        # Same as the package job: the build below runs the tag's own build
+        # script, so a dispatched rebuild starts from a cold module cache.
         cache: ${{ needs.init.outputs.cache }}
 
     - name: Build binary for ${{ matrix.os }}-${{ matrix.arch }}
+      # build-ci.sh rather than `make bin/miren`, and the same two variables the
+      # package job passes. hack/build.sh, which is what make runs, derives the
+      # version from the checkout: `git describe --exact-match --tags`, then the
+      # current branch name. Neither survives `ref: <sha>` above — a commit
+      # checkout is detached and fetches no tags, so describe finds nothing and
+      # the branch name is the literal string "HEAD". Every binary this job
+      # produced from v0.14.0 through v0.15.1 was stamped "HEAD:<short sha>"
+      # instead of its version. build-ci.sh takes the ref from the environment
+      # and recognizes a version tag, which is why the bundle the package job
+      # builds was stamped correctly across the same releases.
+      env:
+        GIT_BRANCH: ${{ needs.init.outputs.ref }}
+        GIT_COMMIT: ${{ needs.init.outputs.sha }}
       run: |
-        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make bin/miren
+        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} bash hack/build-ci.sh
 
     - name: Import certificate and sign macOS binary
       if: matrix.os == 'darwin'


### PR DESCRIPTION
Backport of #1207 to `release/0.15`. Cherry-pick of 8bb16180, no changes.

## Why this branch needs it

The release workflow that runs for a tag push is the one on the tagged commit. Without this, a future v0.15.2 cut from `release/0.15` would ship its CLI binaries stamped `HEAD:<short sha>` again, even though `main` is fixed.

This is not needed to republish v0.15.1. A `workflow_dispatch` rebuild uses the workflow from the ref it is dispatched on, so dispatching from `main` already picks up the fix.

## What it changes

`build-binaries` builds with `hack/build-ci.sh` and the `GIT_BRANCH`/`GIT_COMMIT` the `package` job already passes, instead of `make bin/miren`. `build.sh`, which make runs, reads the version out of the checkout via `git describe --exact-match --tags` and the branch name; neither survives the `ref: <sha>` checkout, because a commit checkout is detached and fetches no tags. `build-ci.sh` takes the ref from the environment and recognizes a version tag by name.

Full diagnosis in #1207.

## Verification

- `.github/workflows/release.yml` on this branch is now byte-identical to `main`'s.
- `hack/build-ci.sh` was already identical to `main`'s on this branch, including the `^v[0-9]+\.[0-9]+\.[0-9]+` case the fix relies on.
- The step parses with the expected `env` and `run`.

No changelog entry: build/CI-only change with no observable surface, which the changelog policy excludes.

## Before merging

`release/0.15` has no branch protection and CI does not run on pushes to it, so this needs a real review and green checks here on the pull request — that is the only place they exist. `hack/release-tag.sh` verifies both at tag time for exactly this reason.
