### PR TITLE
Ship runtime operational metrics through the managed-metrics vmagent

### DIFF
--- a/components/appmetrics/appmetrics.go
+++ b/components/appmetrics/appmetrics.go
@@ -200,6 +200,15 @@ func (c *Component) Stop(ctx context.Context) error {
 	return err
 }
 
+// ImportURL is the loopback base URL at which vmagent accepts pushed samples
+// (its /api/v1/import/prometheus and related handlers). Samples pushed here
+// ride the same remote-write destination, identity token, on-disk queue and
+// retry as the scraped application metrics. Unlike the scrape path, nothing
+// relabels a pushed sample, so the pusher owns its own cluster identity labels.
+func (c *Component) ImportURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", c.httpPort)
+}
+
 func (c *Component) stopBackground() {
 	if c.cancel != nil {
 		c.cancel()

--- a/components/appmetrics/integration_test.go
+++ b/components/appmetrics/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/components/appmetrics"
 	"miren.dev/runtime/internal/remotewrite"
+	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/entity"
 	entitytest "miren.dev/runtime/pkg/entity/testutils"
@@ -68,7 +69,7 @@ func TestManagedMetricsRemoteWriteIntegration(t *testing.T) {
 
 	var (
 		receivedMu sync.Mutex
-		received   []map[string]string
+		received   []remotewrite.Sample
 		authed     bool
 	)
 	remoteWrite := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -95,9 +96,7 @@ func TestManagedMetricsRemoteWriteIntegration(t *testing.T) {
 		}
 		receivedMu.Lock()
 		authed = true
-		for _, sample := range samples {
-			received = append(received, sample.Labels)
-		}
+		received = append(received, samples...)
 		receivedMu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -127,7 +126,8 @@ func TestManagedMetricsRemoteWriteIntegration(t *testing.T) {
 			return false
 		}
 		sandboxes := make(map[string]bool)
-		for _, labels := range received {
+		for _, sample := range received {
+			labels := sample.Labels
 			if labels["__name__"] != "demo_requests_total" ||
 				labels["miren_app"] != "shop" ||
 				labels["miren_app_version"] != "v7" ||
@@ -140,6 +140,40 @@ func TestManagedMetricsRemoteWriteIntegration(t *testing.T) {
 		}
 		return sandboxes[firstSandbox.String()] && sandboxes[secondSandbox.String()]
 	}, 90*time.Second, 500*time.Millisecond, "authenticated remote write should receive distinctly labeled samples from both replicas")
+
+	// The runtime's own operational gauges take the push path: the control
+	// process writes them to vmagent's import endpoint, stamped with the same
+	// identity labels the scrape path derives from targets.json, and they must
+	// come out of the same authenticated remote write.
+	pushed := metrics.NewVictoriaMetricsWriter(entitytest.TestLogger(t), component.ImportURL(), 10*time.Second)
+	shipping := &metrics.Labeled{
+		Sink:   pushed,
+		Labels: map[string]string{"miren_cluster": "cluster-123", "miren_runner": "coordinator"},
+	}
+	pushedAt := time.Now()
+	require.NoError(t, shipping.WritePoints(ctx, []metrics.MetricPoint{{
+		Name:      "go_goroutines",
+		Labels:    map[string]string{"entity": "miren/control"},
+		Value:     4242,
+		Timestamp: pushedAt,
+	}}))
+	pushed.Flush()
+
+	require.Eventually(t, func() bool {
+		receivedMu.Lock()
+		defer receivedMu.Unlock()
+		for _, sample := range received {
+			if sample.Labels["__name__"] != "go_goroutines" {
+				continue
+			}
+			return sample.Value == 4242 &&
+				sample.TimestampMS == pushedAt.UnixMilli() &&
+				sample.Labels["entity"] == "miren/control" &&
+				sample.Labels["miren_cluster"] == "cluster-123" &&
+				sample.Labels["miren_runner"] == "coordinator"
+		}
+		return false
+	}, 60*time.Second, 500*time.Millisecond, "a gauge pushed to vmagent's import endpoint should arrive labeled through the same remote write")
 }
 
 func seedMetricsReplicas(t *testing.T, ctx context.Context, server *entitytest.InMemEntityServer, port int) (entity.Id, entity.Id) {

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -53,7 +53,7 @@ type CoordinatorConfig struct {
 	Mem           *metrics.MemoryUsage
 	Cpu           *metrics.CPUUsage
 	HTTP          *metrics.HTTPMetrics
-	MetricsWriter *metrics.VictoriaMetricsWriter
+	MetricsWriter metrics.PointWriter
 
 	// MetricsReader queries the cluster's metrics directly, rather than through
 	// the app-shaped helpers on Cpu and Mem. The usage service needs arbitrary

--- a/components/distributedrunner/boot_telemetry.go
+++ b/components/distributedrunner/boot_telemetry.go
@@ -30,7 +30,9 @@ type telemetryBootInputs struct {
 type telemetryBootOutput struct {
 	sandboxMetrics *sandbox.Metrics
 	logWriter      observability.LogWriter
-	metricsWriter  *metrics.VictoriaMetricsWriter
+	// metricsWriter is nil, not a typed nil pointer, when metrics are not
+	// recorded, so consumers holding it as an interface can test it directly.
+	metricsWriter metrics.PointWriter
 }
 
 type telemetryBoot struct {
@@ -94,10 +96,10 @@ func (b *telemetryBoot) start(_ context.Context, access clusterAccessBootOutput)
 			metrics.WithHTTPClient(b.client.HTTP))
 		b.metrics.Start()
 		b.inputs.log.Info("metrics writer started", "endpoint", endpoint)
+		result.metricsWriter = b.metrics
 	} else {
 		b.inputs.log.Warn("no VictoriaMetrics address configured, sandbox metrics will not be recorded")
 	}
-	result.metricsWriter = b.metrics
 	result.sandboxMetrics = sandbox.NewMetrics()
 	result.sandboxMetrics.Log = b.inputs.log
 	result.sandboxMetrics.CPUUsage = metrics.NewCPUUsage(b.inputs.log, b.metrics, nil)

--- a/components/distributedrunner/boot_telemetry_test.go
+++ b/components/distributedrunner/boot_telemetry_test.go
@@ -96,7 +96,13 @@ func TestTelemetryConfiguredAndMissing(t *testing.T) {
 			require.Equal(t, tt.wantClient, telemetry.tokenSource != nil)
 			require.NotNil(t, telemetry.output.Value().sandboxMetrics)
 			require.NotNil(t, telemetry.output.Value().logWriter)
-			require.Equal(t, telemetry.metrics, telemetry.output.Value().metricsWriter)
+			if tt.wantMetrics {
+				require.Equal(t, telemetry.metrics, telemetry.output.Value().metricsWriter)
+			} else {
+				// A missing writer must be a true nil in the interface, not a
+				// typed nil pointer that consumers would mistake for a writer.
+				require.Nil(t, telemetry.output.Value().metricsWriter)
+			}
 			if tt.wantClient {
 				token, tokenErr := telemetry.tokenSource.Token()
 				require.NoError(t, tokenErr)

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -103,6 +103,15 @@ type EtcdComponent struct {
 	// and its maintenance loop have already started), so access is atomic. Nil-safe.
 	writer atomic.Pointer[metricsSink]
 
+	// noSpaceRecoveries counts NOSPACE self-recovery attempts this process has
+	// made. It exists because the alarm gauge cannot show a recovery that ran on
+	// the maintenance loop's first check: by the time a shipping sink attaches
+	// the alarm is disarmed and the backend reads healthy. A counter that steps
+	// up once and stays up for the process lifetime is still there to be seen.
+	// It is not persisted; PromQL's increase() treats the reset on restart as a
+	// counter reset, which is all fleet-level counting needs.
+	noSpaceRecoveries atomic.Uint64
+
 	// metricsKick nudges the maintenance loop to run a check the moment the metrics
 	// writer is attached. The writer only exists after the embedded VictoriaMetrics
 	// address is known, which is well after the loop's immediate startup check — so

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -101,7 +101,7 @@ type EtcdComponent struct {
 	// writer, when set, receives etcd health gauges from the maintenance loop. It is set
 	// via SetMetricsWriter after the metrics subsystem comes up (which happens after etcd
 	// and its maintenance loop have already started), so access is atomic. Nil-safe.
-	writer atomic.Pointer[metrics.VictoriaMetricsWriter]
+	writer atomic.Pointer[metricsSink]
 
 	// metricsKick nudges the maintenance loop to run a check the moment the metrics
 	// writer is attached. The writer only exists after the embedded VictoriaMetrics
@@ -112,13 +112,19 @@ type EtcdComponent struct {
 	metricsKick chan struct{}
 }
 
+// metricsSink boxes the interface so it can live behind an atomic.Pointer.
+type metricsSink struct {
+	metrics.PointWriter
+}
+
 // SetMetricsWriter configures the metrics sink for the maintenance loop's health gauges.
 // Safe to call with nil or at any time (the maintenance loop reads it atomically each tick).
-func (e *EtcdComponent) SetMetricsWriter(w *metrics.VictoriaMetricsWriter) {
-	e.writer.Store(w)
+func (e *EtcdComponent) SetMetricsWriter(w metrics.PointWriter) {
 	if w == nil {
+		e.writer.Store(nil)
 		return
 	}
+	e.writer.Store(&metricsSink{PointWriter: w})
 	// Land a fresh sample now instead of waiting for the next periodic tick. Coalesces:
 	// if a kick is already pending the loop will pick up the latest writer anyway.
 	select {

--- a/components/etcd/maintenance.go
+++ b/components/etcd/maintenance.go
@@ -297,7 +297,8 @@ func (e *EtcdComponent) reclaimSpace(ctx context.Context, client *clientv3.Clien
 // manual operator intervention into a self-healing event.
 func (e *EtcdComponent) recoverFromNoSpace(ctx context.Context, client *clientv3.Client, endpoint string, rev, dbSize int64, members []uint64) {
 	e.Log.Error("etcd NOSPACE alarm armed, attempting self-recovery (compact+defrag+disarm)",
-		"db_size_bytes", dbSize, "quota_bytes", e.quotaBackendBytes.Load())
+		"db_size_bytes", dbSize, "quota_bytes", e.quotaBackendBytes.Load(),
+		"nospace_recovery_total", e.noSpaceRecoveries.Add(1))
 
 	e.reclaimSpace(ctx, client, endpoint, rev, dbSize)
 
@@ -345,6 +346,9 @@ func (e *EtcdComponent) emitMetrics(ctx context.Context, dbSize, dbSizeInUse int
 		{Name: "etcd_quota_headroom_bytes", Value: float64(headroom), Timestamp: now},
 		{Name: "etcd_bloat_ratio", Value: bloatRatio, Timestamp: now},
 		{Name: "etcd_nospace_alarm", Value: alarm, Timestamp: now},
+		// A counter, unlike the gauges above, carries a recovery that finished
+		// before any sink was attached: the alarm gauge already reads 0 by then.
+		{Name: "etcd_nospace_recovery_total", Value: float64(e.noSpaceRecoveries.Load()), Timestamp: now},
 	}
 	if err := writer.WritePoints(ctx, points); err != nil {
 		e.Log.Warn("etcd maintenance: failed to write metrics", "error", err)

--- a/components/etcd/metrics_counter_test.go
+++ b/components/etcd/metrics_counter_test.go
@@ -1,0 +1,44 @@
+package etcd
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/metrics"
+)
+
+type recordingSink struct {
+	batches [][]metrics.MetricPoint
+}
+
+func (s *recordingSink) WritePoints(_ context.Context, points []metrics.MetricPoint) error {
+	s.batches = append(s.batches, points)
+	return nil
+}
+
+// TestEmitMetricsIncludesRecoveryCounter checks the counter rides along with
+// every gauge batch, so a sink attached after a recovery still sees it even
+// though the alarm gauge already reads healthy.
+func TestEmitMetricsIncludesRecoveryCounter(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	e := NewEtcdComponent(log, nil, "test", t.TempDir())
+	e.noSpaceRecoveries.Add(1)
+	sink := &recordingSink{}
+	e.SetMetricsWriter(sink)
+
+	e.emitMetrics(context.Background(), 100, 50, 2.0, false)
+
+	require.Len(t, sink.batches, 1)
+	values := make(map[string]float64)
+	for _, point := range sink.batches[0] {
+		values[point.Name] = point.Value
+	}
+	assert.Equal(t, 1.0, values["etcd_nospace_recovery_total"])
+	assert.Equal(t, 0.0, values["etcd_nospace_alarm"])
+	assert.Equal(t, 100.0, values["etcd_db_size_bytes"])
+}

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -86,7 +86,7 @@ type RunnerDeps struct {
 	// is the same writer the sandbox collectors use, taken directly rather than
 	// through them because node series are labeled by node rather than by
 	// sandbox. Nil disables host metrics, as it does for sandbox metrics.
-	MetricsWriter *metrics.VictoriaMetricsWriter
+	MetricsWriter metrics.PointWriter
 
 	// Network config
 	IPv4Routable    netip.Prefix

--- a/components/server/boot_app_metrics.go
+++ b/components/server/boot_app_metrics.go
@@ -6,12 +6,14 @@ import (
 	"context"
 
 	"miren.dev/runtime/components/appmetrics"
+	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/pkg/boot"
 )
 
 type appMetricsBootInputs struct {
 	config                appmetrics.Config
 	configuredClusterName string
+	runnerID              string
 	dataPath              string
 }
 
@@ -20,6 +22,12 @@ type appMetricsBoot struct {
 	inputs           appMetricsBootInputs
 	managed          *appmetrics.Component
 	disabledReporter *appmetrics.DisabledReporter
+
+	// shipping pushes the runtime's operational series into vmagent. It is
+	// attached to the observability fanout for as long as vmagent runs.
+	shipping    *metrics.Labeled
+	shipWriter  *metrics.VictoriaMetricsWriter
+	operational *metrics.Fanout
 }
 
 func appMetricsInputs(options StartOptions) appMetricsBootInputs {
@@ -29,6 +37,7 @@ func appMetricsInputs(options StartOptions) appMetricsBootInputs {
 			Audience:       options.Config.Metrics.RemoteWrite.GetWorkloadIdentityAudience(),
 		},
 		configuredClusterName: options.Config.Server.GetConfigClusterName(),
+		runnerID:              options.Config.Server.GetRunnerID(),
 		dataPath:              options.Config.Server.GetDataPath(),
 	}
 }
@@ -92,6 +101,25 @@ func (b *appMetricsBoot) start(
 		return nil
 	}
 	b.managed = managed
+
+	// The runtime's own operational series ride the same vmagent. Pushed
+	// samples skip fileSD relabeling, so the cluster identity the scrape path
+	// gets from targets.json is stamped here from the same clusterID. The
+	// embedded VictoriaMetrics keeps receiving the unlabeled series it always
+	// has; only the shipped copy carries the identity, since only at a shared
+	// destination do series from different clusters need telling apart.
+	identityLabels := map[string]string{"miren_cluster": config.ClusterID}
+	if b.inputs.runnerID != "" {
+		identityLabels["miren_runner"] = b.inputs.runnerID
+	}
+	// A zero timeout takes the writer's 30s default; vmagent is on loopback.
+	b.shipWriter = metrics.NewVictoriaMetricsWriter(log, managed.ImportURL(), 0)
+	b.shipWriter.Start()
+	b.shipping = &metrics.Labeled{Sink: b.shipWriter, Labels: identityLabels}
+	b.operational = observability.operationalMetrics
+	b.operational.Attach(b.shipping)
+	log.Info("runtime operational metrics shipping through managed metrics",
+		"cluster", config.ClusterID, "runner", b.inputs.runnerID)
 	return nil
 }
 
@@ -99,6 +127,18 @@ func (b *appMetricsBoot) stop(ctx context.Context) error {
 	if b.disabledReporter != nil {
 		b.disabledReporter.Stop()
 		b.disabledReporter = nil
+	}
+	if b.shipping != nil {
+		b.operational.Detach(b.shipping)
+		b.shipping = nil
+		b.operational = nil
+	}
+	if b.shipWriter != nil {
+		// Close flushes what it can into vmagent, whose own queue outlives this
+		// process; a final send that fails because vmagent is already stopping
+		// is reported by the writer and is not a shutdown error.
+		_ = b.shipWriter.Close()
+		b.shipWriter = nil
 	}
 	if b.managed == nil {
 		return nil

--- a/components/server/boot_etcd.go
+++ b/components/server/boot_etcd.go
@@ -78,7 +78,7 @@ func (b *etcdBoot) startEmbedded(ctx context.Context, ipDiscovery ipDiscoveryBoo
 	log := observability.log
 	log.Info("starting embedded etcd server", "client-port", b.inputs.config.GetClientPort(), "peer-port", b.inputs.config.GetPeerPort())
 	b.server = etcd.NewEtcdComponent(log, containerd.Client, containerd.Namespace, b.inputs.dataPath)
-	b.server.SetMetricsWriter(observability.metricsWriter)
+	b.server.SetMetricsWriter(observability.operationalMetrics)
 	config := etcd.EtcdConfig{
 		Name:              "miren-etcd",
 		ClientPort:        b.inputs.config.GetClientPort(),

--- a/components/server/boot_foundation.go
+++ b/components/server/boot_foundation.go
@@ -47,7 +47,7 @@ func (b *foundationBoot) start(ctx context.Context, ipDiscovery ipDiscoveryBootO
 	config.Mem = observability.memory
 	config.Cpu = observability.cpu
 	config.HTTP = observability.http
-	config.MetricsWriter = observability.metricsWriter
+	config.MetricsWriter = observability.operationalMetrics
 	config.MetricsReader = observability.metricsReader
 	config.Logs = observability.logs
 	config.LogWriter = observability.logWriter

--- a/components/server/boot_node_storage.go
+++ b/components/server/boot_node_storage.go
@@ -36,7 +36,7 @@ func (b *nodeStorageBoot) start(ctx context.Context, access clusterAccessBootOut
 	var err error
 	b.value, err = runner.NewNodeStorage(access.access, runner.RunnerDeps{
 		IsCoordinator: true,
-		MetricsWriter: observability.metricsWriter,
+		MetricsWriter: observability.operationalMetrics,
 	}, config)
 	if err != nil {
 		return nil, err

--- a/components/server/boot_observability.go
+++ b/components/server/boot_observability.go
@@ -19,8 +19,14 @@ type observabilityBootInputs struct {
 }
 
 type observabilityBootOutput struct {
-	log                    *slog.Logger
-	metricsWriter          *metrics.VictoriaMetricsWriter
+	log           *slog.Logger
+	metricsWriter *metrics.VictoriaMetricsWriter
+	// operationalMetrics is where the runtime's own health series go: the
+	// control process's memory, etcd backend health, host usage, controller
+	// queues. It always reaches the embedded VictoriaMetrics; the app-metrics
+	// boot attaches the sink that ships the same series off the cluster once
+	// its vmagent is up.
+	operationalMetrics     *metrics.Fanout
 	metricsReader          *metrics.VictoriaMetricsReader
 	cpu                    *metrics.CPUUsage
 	memory                 *metrics.MemoryUsage
@@ -60,6 +66,7 @@ func newObservabilityBoot(inputs observabilityBootInputs, tracing *boot.Componen
 func (b *observabilityBoot) start(ctx context.Context, victoriaLogs victoriaLogsBootOutput, victoriaMetrics victoriaMetricsBootOutput) (observabilityBootOutput, error) {
 	writer := metrics.NewVictoriaMetricsWriter(b.inputs.log, victoriaMetrics.address, b.inputs.timeout)
 	writer.Start()
+	operational := metrics.NewFanout(writer)
 	reader := metrics.NewVictoriaMetricsReader(b.inputs.log, victoriaMetrics.address, b.inputs.timeout)
 	cpu := metrics.NewCPUUsage(b.inputs.log, writer, reader)
 	memory := metrics.NewMemoryUsage(b.inputs.log, writer, reader)
@@ -69,7 +76,7 @@ func (b *observabilityBoot) start(ctx context.Context, victoriaLogs victoriaLogs
 	b.batchWriter = observability.NewBatchLogWriter(logWriter)
 	log := slog.New(observability.NewSystemLogHandler(b.inputs.log.Handler(), b.batchWriter))
 
-	runtimeMemory := metrics.NewRuntimeMemory(log, writer)
+	runtimeMemory := metrics.NewRuntimeMemory(log, operational)
 	go runtimeMemory.Monitor(ctx)
 
 	sandboxMetrics := sandbox.NewMetrics()
@@ -80,6 +87,7 @@ func (b *observabilityBoot) start(ctx context.Context, victoriaLogs victoriaLogs
 	b.result = observabilityBootOutput{
 		log:                    log,
 		metricsWriter:          writer,
+		operationalMetrics:     operational,
 		metricsReader:          reader,
 		cpu:                    cpu,
 		memory:                 memory,

--- a/components/server/boot_sandbox_host.go
+++ b/components/server/boot_sandbox_host.go
@@ -79,7 +79,7 @@ func (b *sandboxHostBoot) start(ctx context.Context, access clusterAccessBootOut
 		LogsMaintainer:  observability.logsMaintainer,
 		LogWriter:       observability.logWriter,
 		StatusMon:       observability.statusMonitor,
-		MetricsWriter:   observability.metricsWriter,
+		MetricsWriter:   observability.operationalMetrics,
 		IPv4Routable:    network.ipv4Routable,
 		ServicePrefixes: b.inputs.servicePrefixes,
 		DisableLocalNet: false,

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -50,6 +50,22 @@ This includes endpoint errors, invalid or oversized responses, authentication
 failures, and delivery retries. `miren logs app` includes only output written by
 the application itself.
 
+### Runtime operational metrics
+
+When a remote-write destination is configured, the coordinator also ships its
+own operational series through the same pipeline: the control process's Go
+heap, goroutine count and resident memory (`go_*`, `process_resident_memory_bytes`),
+embedded etcd backend health (`etcd_db_size_bytes`, `etcd_nospace_alarm`,
+`etcd_nospace_recovery_total`, and friends), host usage (`node_*`), and reconcile
+controller queue depths (`reconcile_controller_*`). Shipped copies carry
+`miren_cluster` and `miren_runner` so series pooled from many clusters stay
+distinct. These series also remain in the cluster's embedded VictoriaMetrics,
+unlabeled, where the node is implicit.
+
+There is no separate switch. Configuring the destination turns on application
+metrics and runtime metrics together, and delivery failures for both appear in
+the same `miren logs system vmagent` output.
+
 ## Distributed tracing
 
 ### Minimum working example

--- a/metrics/fanout.go
+++ b/metrics/fanout.go
@@ -48,22 +48,41 @@ func (f *Fanout) Attach(sink PointWriter) {
 	f.sinks = append(f.sinks, sink)
 }
 
+// Detach removes a sink. It takes the write lock, and WritePoints holds the
+// read lock for the whole delivery, so once Detach returns no batch is still
+// being handed to the removed sink; the caller can close it without a late
+// write landing after its final flush. Detaching a sink that was never
+// attached is a no-op.
+func (f *Fanout) Detach(sink PointWriter) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	remaining := make([]PointWriter, 0, len(f.sinks))
+	for _, existing := range f.sinks {
+		if existing != sink {
+			remaining = append(remaining, existing)
+		}
+	}
+	f.sinks = remaining
+}
+
 // WritePoints hands the batch to every sink. One sink failing does not stop
 // the others from receiving the batch; all failures are returned joined.
+//
+// The read lock is held across delivery, not just while reading the sink
+// list. Sinks only buffer (the writers flush on their own goroutines), so the
+// hold is brief, and it is what gives Detach its guarantee. The corollary is
+// that a sink must not call Attach or Detach from inside its own WritePoints;
+// those are lifecycle operations for whoever owns the sink, and a sink that
+// tried to detach itself mid-delivery would be waiting on its own read lock.
 func (f *Fanout) WritePoints(ctx context.Context, points []MetricPoint) error {
 	if f == nil {
 		return nil
 	}
-	// Copy under the lock rather than sharing the backing array with a
-	// concurrent Attach, so the iteration below runs without the lock held
-	// across sink writes and without any question of aliasing.
 	f.mu.RLock()
-	sinks := make([]PointWriter, len(f.sinks))
-	copy(sinks, f.sinks)
-	f.mu.RUnlock()
+	defer f.mu.RUnlock()
 
 	var errs []error
-	for _, sink := range sinks {
+	for _, sink := range f.sinks {
 		if err := sink.WritePoints(ctx, points); err != nil {
 			errs = append(errs, err)
 		}

--- a/metrics/fanout.go
+++ b/metrics/fanout.go
@@ -1,0 +1,118 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// PointWriter is the sink the runtime's operational collectors emit to. The
+// collectors only ever batch-write, so this is the whole surface they need;
+// keeping it this narrow is what lets a collector be pointed at one store, a
+// fan-out of several, or a labeling wrapper without knowing which.
+type PointWriter interface {
+	WritePoints(ctx context.Context, points []MetricPoint) error
+}
+
+// Fanout delivers every batch to each attached sink.
+//
+// Sinks can be attached after collectors have started emitting. The runtime's
+// operational gauges (control-process memory, etcd health, node usage) start
+// early in boot and write to the embedded VictoriaMetrics from their first
+// tick, while the sink that ships them off the cluster only exists once the
+// managed-metrics vmagent is up, several boot stages later. Attaching late is
+// how that sink joins without the collectors being restarted or made aware of
+// boot order.
+type Fanout struct {
+	mu    sync.RWMutex
+	sinks []PointWriter
+}
+
+// NewFanout creates a Fanout that starts with the given sinks.
+func NewFanout(sinks ...PointWriter) *Fanout {
+	f := &Fanout{}
+	for _, sink := range sinks {
+		f.Attach(sink)
+	}
+	return f
+}
+
+// Attach adds a sink. Batches written after Attach returns reach it; a batch
+// already in flight may not. A nil sink is ignored.
+func (f *Fanout) Attach(sink PointWriter) {
+	if sink == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sinks = append(f.sinks, sink)
+}
+
+// WritePoints hands the batch to every sink. One sink failing does not stop
+// the others from receiving the batch; all failures are returned joined.
+func (f *Fanout) WritePoints(ctx context.Context, points []MetricPoint) error {
+	if f == nil {
+		return nil
+	}
+	// Copy under the lock rather than sharing the backing array with a
+	// concurrent Attach, so the iteration below runs without the lock held
+	// across sink writes and without any question of aliasing.
+	f.mu.RLock()
+	sinks := make([]PointWriter, len(f.sinks))
+	copy(sinks, f.sinks)
+	f.mu.RUnlock()
+
+	var errs []error
+	for _, sink := range sinks {
+		if err := sink.WritePoints(ctx, points); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Labeled stamps constant labels onto every point before passing it on.
+//
+// This is how series pooled from many clusters into one store stay distinct.
+// The collectors themselves carry no cluster identity, because inside a
+// cluster's own store the cluster is implicit; the identity belongs to the
+// shipping path, so it is applied by the sink that ships rather than by every
+// emitter. A label the point already carries is kept, so a collector that
+// knows its own runner is not overwritten by a process-wide default.
+//
+// Label names are compared after the same sanitization the writer applies when
+// formatting, so a collector's "miren.runner" and a constant "miren_runner" are
+// recognized as the same label rather than emitted twice.
+type Labeled struct {
+	Sink   PointWriter
+	Labels map[string]string
+}
+
+// WritePoints copies each point's labels, merging in the constant labels, and
+// writes the result to the wrapped sink. The caller's points are not mutated;
+// collectors share one label map across every point in a batch.
+func (l *Labeled) WritePoints(ctx context.Context, points []MetricPoint) error {
+	if l == nil || l.Sink == nil {
+		return nil
+	}
+	if len(l.Labels) == 0 {
+		return l.Sink.WritePoints(ctx, points)
+	}
+
+	labeled := make([]MetricPoint, len(points))
+	for i, point := range points {
+		merged := make(map[string]string, len(point.Labels)+len(l.Labels))
+		for name, value := range point.Labels {
+			merged[sanitizeLabelName(name)] = value
+		}
+		for name, value := range l.Labels {
+			name = sanitizeLabelName(name)
+			if _, present := merged[name]; !present {
+				merged[name] = value
+			}
+		}
+		point.Labels = merged
+		labeled[i] = point
+	}
+	return l.Sink.WritePoints(ctx, labeled)
+}

--- a/metrics/fanout_test.go
+++ b/metrics/fanout_test.go
@@ -1,0 +1,129 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingSink struct {
+	batches [][]MetricPoint
+	err     error
+}
+
+func (s *recordingSink) WritePoints(_ context.Context, points []MetricPoint) error {
+	s.batches = append(s.batches, points)
+	return s.err
+}
+
+func TestFanoutDeliversToSinksAttachedLater(t *testing.T) {
+	first := &recordingSink{}
+	fanout := NewFanout(first)
+	ctx := context.Background()
+
+	require.NoError(t, fanout.WritePoints(ctx, []MetricPoint{{Name: "a", Value: 1}}))
+
+	late := &recordingSink{}
+	fanout.Attach(late)
+	require.NoError(t, fanout.WritePoints(ctx, []MetricPoint{{Name: "b", Value: 2}}))
+
+	require.Len(t, first.batches, 2, "original sink sees every batch")
+	require.Len(t, late.batches, 1, "late sink sees only batches written after Attach")
+	assert.Equal(t, "b", late.batches[0][0].Name)
+}
+
+func TestFanoutOneFailingSinkDoesNotStarveOthers(t *testing.T) {
+	failing := &recordingSink{err: errors.New("remote down")}
+	healthy := &recordingSink{}
+	fanout := NewFanout(failing, healthy)
+
+	err := fanout.WritePoints(context.Background(), []MetricPoint{{Name: "a", Value: 1}})
+	require.ErrorContains(t, err, "remote down")
+	require.Len(t, healthy.batches, 1)
+}
+
+func TestFanoutIgnoresNilSinks(t *testing.T) {
+	fanout := NewFanout(nil)
+	fanout.Attach(nil)
+	require.NoError(t, fanout.WritePoints(context.Background(), []MetricPoint{{Name: "a", Value: 1}}))
+
+	var none *Fanout
+	require.NoError(t, none.WritePoints(context.Background(), nil))
+}
+
+func TestLabeledStampsConstantLabelsWithoutMutatingInput(t *testing.T) {
+	sink := &recordingSink{}
+	labeled := &Labeled{
+		Sink:   sink,
+		Labels: map[string]string{"miren_cluster": "c1", "miren_runner": "node-a"},
+	}
+
+	// Collectors share one label map across a batch; the shipped copy must not
+	// leak constant labels back into it.
+	shared := map[string]string{"entity": "miren/control"}
+	ts := time.Now()
+	points := []MetricPoint{
+		{Name: "go_goroutines", Labels: shared, Value: 10, Timestamp: ts},
+		{Name: "go_mem_sys_bytes", Labels: shared, Value: 20, Timestamp: ts},
+		{Name: "etcd_db_size_bytes", Value: 30, Timestamp: ts},
+	}
+	require.NoError(t, labeled.WritePoints(context.Background(), points))
+
+	require.Len(t, sink.batches, 1)
+	got := sink.batches[0]
+	require.Len(t, got, 3)
+	for _, point := range got[:2] {
+		assert.Equal(t, map[string]string{
+			"entity":        "miren/control",
+			"miren_cluster": "c1",
+			"miren_runner":  "node-a",
+		}, point.Labels)
+	}
+	assert.Equal(t, map[string]string{"miren_cluster": "c1", "miren_runner": "node-a"}, got[2].Labels)
+	assert.Equal(t, 30.0, got[2].Value)
+	assert.Equal(t, ts, got[2].Timestamp)
+
+	assert.Equal(t, map[string]string{"entity": "miren/control"}, shared, "caller's labels are untouched")
+	assert.Nil(t, points[2].Labels, "caller's nil labels stay nil")
+}
+
+func TestLabeledKeepsCollectorLabelsAcrossSanitization(t *testing.T) {
+	sink := &recordingSink{}
+	labeled := &Labeled{
+		Sink:   sink,
+		Labels: map[string]string{"miren_runner": "process-default", "miren_cluster": "c1"},
+	}
+
+	// NodeUsage emits "miren.runner", which the writer formats as
+	// "miren_runner". The collector's value has to win and appear once.
+	points := []MetricPoint{{
+		Name:   "node_load1",
+		Labels: map[string]string{"miren.node": "n1", "miren.runner": "node-a"},
+		Value:  0.5,
+	}}
+	require.NoError(t, labeled.WritePoints(context.Background(), points))
+
+	require.Len(t, sink.batches, 1)
+	assert.Equal(t, map[string]string{
+		"miren_node":    "n1",
+		"miren_runner":  "node-a",
+		"miren_cluster": "c1",
+	}, sink.batches[0][0].Labels)
+}
+
+func TestLabeledWithoutLabelsPassesThrough(t *testing.T) {
+	sink := &recordingSink{}
+	labeled := &Labeled{Sink: sink}
+	points := []MetricPoint{{Name: "a", Value: 1}}
+	require.NoError(t, labeled.WritePoints(context.Background(), points))
+	require.Len(t, sink.batches, 1)
+	assert.Equal(t, points, sink.batches[0])
+
+	var none *Labeled
+	require.NoError(t, none.WritePoints(context.Background(), points))
+	require.NoError(t, (&Labeled{}).WritePoints(context.Background(), points))
+}

--- a/metrics/fanout_test.go
+++ b/metrics/fanout_test.go
@@ -46,6 +46,56 @@ func TestFanoutOneFailingSinkDoesNotStarveOthers(t *testing.T) {
 	require.Len(t, healthy.batches, 1)
 }
 
+// blockingSink parks inside WritePoints until released, standing in for a
+// delivery that is mid-flight when Detach is called.
+type blockingSink struct {
+	entered chan struct{}
+	release chan struct{}
+	writes  int
+}
+
+func (s *blockingSink) WritePoints(context.Context, []MetricPoint) error {
+	s.writes++
+	close(s.entered)
+	<-s.release
+	return nil
+}
+
+func TestFanoutDetachWaitsForInFlightWrite(t *testing.T) {
+	sink := &blockingSink{entered: make(chan struct{}), release: make(chan struct{})}
+	fanout := NewFanout(sink)
+
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		_ = fanout.WritePoints(context.Background(), []MetricPoint{{Name: "a", Value: 1}})
+	}()
+	<-sink.entered
+
+	detached := make(chan struct{})
+	go func() {
+		defer close(detached)
+		fanout.Detach(sink)
+	}()
+
+	select {
+	case <-detached:
+		t.Fatal("Detach returned while a write to the sink was still in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(sink.release)
+	<-writeDone
+	select {
+	case <-detached:
+	case <-time.After(time.Second):
+		t.Fatal("Detach did not return after the in-flight write finished")
+	}
+
+	require.NoError(t, fanout.WritePoints(context.Background(), []MetricPoint{{Name: "b", Value: 2}}))
+	assert.Equal(t, 1, sink.writes, "no batch reaches a sink after Detach returns")
+}
+
 func TestFanoutIgnoresNilSinks(t *testing.T) {
 	fanout := NewFanout(nil)
 	fanout.Attach(nil)

--- a/metrics/node_usage.go
+++ b/metrics/node_usage.go
@@ -24,7 +24,7 @@ import (
 // sandbox collectors now attach.
 type NodeUsage struct {
 	Log    *slog.Logger
-	Writer *VictoriaMetricsWriter
+	Writer PointWriter
 
 	// NodeID is the node entity ID these series describe, and RunnerID is the
 	// runner identifier for the same host. Both are emitted: the entity ID is
@@ -49,7 +49,7 @@ const defaultNodeUsageInterval = 10 * time.Second
 
 // NewNodeUsage creates a NodeUsage collector. Writer may be nil for
 // environments without metrics collection, in which case Monitor is a no-op.
-func NewNodeUsage(log *slog.Logger, writer *VictoriaMetricsWriter, nodeID, runnerID, dataPath string) *NodeUsage {
+func NewNodeUsage(log *slog.Logger, writer PointWriter, nodeID, runnerID, dataPath string) *NodeUsage {
 	return &NodeUsage{
 		Log:      log,
 		Writer:   writer,

--- a/metrics/runtime_memory.go
+++ b/metrics/runtime_memory.go
@@ -22,7 +22,7 @@ import (
 //   - RSS balloons, heap flat -> off-heap; pprof can't see it, look at bbolt/buildkit.
 type RuntimeMemory struct {
 	Log    *slog.Logger
-	Writer *VictoriaMetricsWriter
+	Writer PointWriter
 
 	// Entity is the value of the "entity" label on every emitted series.
 	Entity string
@@ -51,7 +51,7 @@ const (
 
 // NewRuntimeMemory creates a RuntimeMemory collector. Writer may be nil for
 // environments without metrics collection, in which case Monitor is a no-op.
-func NewRuntimeMemory(log *slog.Logger, writer *VictoriaMetricsWriter) *RuntimeMemory {
+func NewRuntimeMemory(log *slog.Logger, writer PointWriter) *RuntimeMemory {
 	return &RuntimeMemory{
 		Log:    log,
 		Writer: writer,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -80,7 +80,7 @@ type ReconcileController struct {
 	watcher      *indexwatch.Watcher
 	wg           sync.WaitGroup
 
-	metricWriter *metrics.VictoriaMetricsWriter
+	metricWriter metrics.PointWriter
 	metricLabels map[string]string
 	counters     controllerCounters
 
@@ -582,7 +582,7 @@ func AdaptReconcileController[
 // ControllerManager manages multiple controllers
 type ControllerManager struct {
 	controllers []Controller
-	metrics     *metrics.VictoriaMetricsWriter
+	metrics     metrics.PointWriter
 	labels      map[string]string
 }
 

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -11,7 +11,7 @@ import (
 
 type ManagerOption func(*ControllerManager)
 
-func WithMetrics(writer *metrics.VictoriaMetricsWriter, labels map[string]string) ManagerOption {
+func WithMetrics(writer metrics.PointWriter, labels map[string]string) ManagerOption {
 	return func(manager *ControllerManager) {
 		manager.metrics = writer
 		manager.labels = maps.Clone(labels)


### PR DESCRIPTION
Every cluster already records the control process's goroutine count, heap and RSS, etcd backend health, host usage and controller queue depths, but only into its own embedded VictoriaMetrics. That's how a v0.15.0 goroutine leak got to 454k goroutines and locked up a host before anyone saw it: the series were sitting right there, on a 10s interval, never leaving the box.

The managed app metrics work gave every cluster a vmagent with an authenticated remote-write path out, and vmagent's loopback listener accepts pushed samples in the format our writer already speaks. So this teaches the runtime's operational collectors to write through a small fanout, and has the app-metrics boot attach a second writer aimed at vmagent once it's up. Shipped copies get `miren_cluster` and `miren_runner` stamped on; the embedded store keeps getting exactly what it got before. No new config: setting a remote-write destination now ships app metrics and runtime metrics together, and both fail into the same `miren logs system vmagent`.

We looked at scraping a `/metrics` endpoint on the control process and at federating off the embedded VM instead. Push won on having one emission model: distributed runners already push to the coordinator because reachability back to them isn't guaranteed, and a fanout means shipping their series later is a one-line rewire (MIR-1827).

The last rev adds a small `etcd_nospace_recovery_total` counter, because a NOSPACE recovery on the maintenance loop's first check finishes before the shipping sink attaches and would otherwise leave no trace in the fleet view.

Closes MIR-1390
