### PR TITLE
Let a server describe itself: instance id, readiness, `miren version --server`

### DIFF
--- a/api/server/rpc.go
+++ b/api/server/rpc.go
@@ -1,0 +1,3 @@
+package server
+
+//go:generate go run ../../pkg/rpc/cmd/rpcgen -pkg server_v1alpha -input rpc.yml -output server_v1alpha/rpc.gen.go

--- a/api/server/rpc.yml
+++ b/api/server/rpc.yml
@@ -1,0 +1,39 @@
+name: server
+version: v1alpha
+doc: Server self-description and lifecycle
+
+imports:
+  standard:
+    path: ../../pkg/rpc/standard/standard.yml
+    import: miren.dev/runtime/pkg/rpc/standard
+
+interfaces:
+  - name: ServerInfo
+    doc: Read-only facts about the running server process
+    methods:
+      - name: Version
+        index: 0
+        public: true  # Read-only build and instance metadata; safe to answer before authentication
+        doc: Report the build and process identity of the server answering this call
+        results:
+          - name: version
+            type: string
+            doc: Build version, e.g. v0.14.0 or main:abc1234
+          - name: commit
+            type: string
+            doc: Source commit the binary was built from
+          - name: build_date
+            type: standard.Timestamp
+            doc: When the binary was built
+          - name: runtime_instance_id
+            type: string
+            doc: Identity of this server process. Changes on every restart.
+          - name: started_at
+            type: standard.Timestamp
+            doc: When this process started
+          - name: ready
+            type: bool
+            doc: True once the boot graph has started every component
+          - name: install_kind
+            type: string
+            doc: How the process is supervised (systemd, container, unknown)

--- a/api/server/server_v1alpha/rpc.gen.go
+++ b/api/server/server_v1alpha/rpc.gen.go
@@ -1,0 +1,252 @@
+package server_v1alpha
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/fxamacker/cbor/v2"
+	rpc "miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+type serverInfoVersionArgsData struct{}
+
+type ServerInfoVersionArgs struct {
+	call rpc.Call
+	data serverInfoVersionArgsData
+}
+
+func (v *ServerInfoVersionArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ServerInfoVersionArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ServerInfoVersionArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ServerInfoVersionArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type serverInfoVersionResultsData struct {
+	Version           *string             `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
+	Commit            *string             `cbor:"1,keyasint,omitempty" json:"commit,omitempty"`
+	BuildDate         *standard.Timestamp `cbor:"2,keyasint,omitempty" json:"build_date,omitempty"`
+	RuntimeInstanceId *string             `cbor:"3,keyasint,omitempty" json:"runtime_instance_id,omitempty"`
+	StartedAt         *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"started_at,omitempty"`
+	Ready             *bool               `cbor:"5,keyasint,omitempty" json:"ready,omitempty"`
+	InstallKind       *string             `cbor:"6,keyasint,omitempty" json:"install_kind,omitempty"`
+}
+
+type ServerInfoVersionResults struct {
+	call rpc.Call
+	data serverInfoVersionResultsData
+}
+
+func (v *ServerInfoVersionResults) SetVersion(version string) {
+	v.data.Version = &version
+}
+
+func (v *ServerInfoVersionResults) SetCommit(commit string) {
+	v.data.Commit = &commit
+}
+
+func (v *ServerInfoVersionResults) SetBuildDate(build_date *standard.Timestamp) {
+	v.data.BuildDate = build_date
+}
+
+func (v *ServerInfoVersionResults) SetRuntimeInstanceId(runtime_instance_id string) {
+	v.data.RuntimeInstanceId = &runtime_instance_id
+}
+
+func (v *ServerInfoVersionResults) SetStartedAt(started_at *standard.Timestamp) {
+	v.data.StartedAt = started_at
+}
+
+func (v *ServerInfoVersionResults) SetReady(ready bool) {
+	v.data.Ready = &ready
+}
+
+func (v *ServerInfoVersionResults) SetInstallKind(install_kind string) {
+	v.data.InstallKind = &install_kind
+}
+
+func (v *ServerInfoVersionResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ServerInfoVersionResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ServerInfoVersionResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ServerInfoVersionResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type ServerInfoVersion struct {
+	rpc.Call
+	args    ServerInfoVersionArgs
+	results ServerInfoVersionResults
+}
+
+func (t *ServerInfoVersion) Args() *ServerInfoVersionArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ServerInfoVersion) Results() *ServerInfoVersionResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ServerInfo interface {
+	Version(ctx context.Context, state *ServerInfoVersion) error
+}
+
+type reexportServerInfo struct {
+	client rpc.Client
+}
+
+func (reexportServerInfo) Version(ctx context.Context, state *ServerInfoVersion) error {
+	panic("not implemented")
+}
+
+func (t reexportServerInfo) CapabilityClient() rpc.Client {
+	return t.client
+}
+
+func AdaptServerInfo(t ServerInfo) *rpc.Interface {
+	methods := []rpc.Method{
+		{
+			Name:          "Version",
+			InterfaceName: "ServerInfo",
+			Index:         0,
+			Public:        true,
+			Params:        []string{},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.Version(ctx, &ServerInfoVersion{Call: call})
+			},
+		},
+	}
+
+	return rpc.NewInterface(methods, t)
+}
+
+type ServerInfoClient struct {
+	rpc.Client
+}
+
+func NewServerInfoClient(client rpc.Client) *ServerInfoClient {
+	return &ServerInfoClient{Client: client}
+}
+
+func (c ServerInfoClient) Export() ServerInfo {
+	return reexportServerInfo{client: c.Client}
+}
+
+type ServerInfoClientVersionResults struct {
+	client rpc.Client
+	data   serverInfoVersionResultsData
+}
+
+func (v *ServerInfoClientVersionResults) HasVersion() bool {
+	return v.data.Version != nil
+}
+
+func (v *ServerInfoClientVersionResults) Version() string {
+	if v.data.Version == nil {
+		return ""
+	}
+	return *v.data.Version
+}
+
+func (v *ServerInfoClientVersionResults) HasCommit() bool {
+	return v.data.Commit != nil
+}
+
+func (v *ServerInfoClientVersionResults) Commit() string {
+	if v.data.Commit == nil {
+		return ""
+	}
+	return *v.data.Commit
+}
+
+func (v *ServerInfoClientVersionResults) HasBuildDate() bool {
+	return v.data.BuildDate != nil
+}
+
+func (v *ServerInfoClientVersionResults) BuildDate() *standard.Timestamp {
+	return v.data.BuildDate
+}
+
+func (v *ServerInfoClientVersionResults) HasRuntimeInstanceId() bool {
+	return v.data.RuntimeInstanceId != nil
+}
+
+func (v *ServerInfoClientVersionResults) RuntimeInstanceId() string {
+	if v.data.RuntimeInstanceId == nil {
+		return ""
+	}
+	return *v.data.RuntimeInstanceId
+}
+
+func (v *ServerInfoClientVersionResults) HasStartedAt() bool {
+	return v.data.StartedAt != nil
+}
+
+func (v *ServerInfoClientVersionResults) StartedAt() *standard.Timestamp {
+	return v.data.StartedAt
+}
+
+func (v *ServerInfoClientVersionResults) HasReady() bool {
+	return v.data.Ready != nil
+}
+
+func (v *ServerInfoClientVersionResults) Ready() bool {
+	if v.data.Ready == nil {
+		return false
+	}
+	return *v.data.Ready
+}
+
+func (v *ServerInfoClientVersionResults) HasInstallKind() bool {
+	return v.data.InstallKind != nil
+}
+
+func (v *ServerInfoClientVersionResults) InstallKind() string {
+	if v.data.InstallKind == nil {
+		return ""
+	}
+	return *v.data.InstallKind
+}
+
+func (v ServerInfoClient) Version(ctx context.Context) (*ServerInfoClientVersionResults, error) {
+	args := ServerInfoVersionArgs{}
+
+	var ret serverInfoVersionResultsData
+
+	err := v.Call(ctx, "Version", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServerInfoClientVersionResults{client: v.Client, data: ret}, nil
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -16,6 +16,10 @@ func RegisterAll(d *mflags.Dispatcher) {
 			Name: "JSON output",
 			Body: "miren version --format json",
 		}),
+		WithExample(mflags.Example{
+			Name: "Compare with the cluster's server",
+			Body: "miren version --server",
+		}),
 	))
 	d.Dispatch("login", Infer("login", "Authenticate with miren.cloud", Login,
 		WithGroup(GroupClient),

--- a/cli/commands/doctor_check.go
+++ b/cli/commands/doctor_check.go
@@ -94,6 +94,11 @@ type doctorEnv struct {
 	// blocked API port, whereas TCP refusing means nothing is running at all.
 	tcp probe
 	udp probe
+
+	// serverVersionErr distinguishes "could not ask" from "asked, and the
+	// server is too old to answer".
+	serverVersion    *serverVersion
+	serverVersionErr error
 }
 
 // local reports whether the active cluster runs on this machine, which decides
@@ -135,7 +140,7 @@ func gatherDoctorEnv(ctx *Context, opts ConfigCentric) *doctorEnv {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4)
 
 	go func() {
 		defer wg.Done()
@@ -144,6 +149,11 @@ func gatherDoctorEnv(ctx *Context, opts ConfigCentric) *doctorEnv {
 			defer client.Close()
 		}
 		env.connErr = err
+	}()
+
+	go func() {
+		defer wg.Done()
+		env.serverVersion, env.serverVersionErr = fetchServerVersion(ctx)
 	}()
 
 	go func() {
@@ -167,6 +177,7 @@ func doctorChecks() []check {
 	return []check{
 		{Name: "Configuration", Group: groupConfig, Run: checkConfiguration},
 		{Name: "Server", Group: groupServer, Run: checkServer},
+		{Name: "Version", Group: groupServer, Run: checkVersion},
 		{Name: "Authentication", Group: groupAuth, Run: checkAuthentication},
 	}
 }

--- a/cli/commands/doctor_version.go
+++ b/cli/commands/doctor_version.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+
+	"miren.dev/runtime/pkg/ui"
+	"miren.dev/runtime/version"
+)
+
+// checkVersion compares the CLI build with the server build.
+func checkVersion(env *doctorEnv) checkResult {
+	if !env.configured() {
+		return checkResult{Status: checkSkip, Summary: "no cluster selected"}
+	}
+	if env.connErr != nil {
+		return checkResult{Status: checkSkip, Summary: "server not reachable"}
+	}
+
+	cli := version.GetInfo()
+
+	if env.serverVersionErr != nil {
+		if errors.Is(env.serverVersionErr, errServerVersionUnsupported) {
+			return checkResult{
+				Status:  checkWarn,
+				Summary: fmt.Sprintf("server does not report its version (CLI %s)", cli.Version),
+				Problem: &ui.Diagnostic{
+					Summary: "the server is too old to report its version",
+					Detail: "The server answered but has no version endpoint, which means it " +
+						"predates this CLI by several releases. Newer CLI commands may not " +
+						"work against it until it is upgraded.",
+					Actions: serverUpgradeActions(env),
+					Cause:   env.serverVersionErr,
+				},
+			}
+		}
+		// No fix to name, so a fact rather than a diagnosis.
+		return checkResult{
+			Status:  checkSkip,
+			Summary: fmt.Sprintf("could not read server version: %v", env.serverVersionErr),
+		}
+	}
+
+	server := env.serverVersion
+	summary := fmt.Sprintf("CLI %s, server %s", cli.Version, server.Version)
+	if !server.Ready {
+		summary += " (server still starting)"
+	}
+
+	switch compareVersions(cli.Version, server.Version) {
+	case skewServerBehind:
+		return checkResult{
+			Status:  checkWarn,
+			Summary: summary,
+			Problem: &ui.Diagnostic{
+				Summary: fmt.Sprintf("server %s is behind CLI %s", server.Version, cli.Version),
+				Detail: "The server is running an older release than this CLI. Commands that " +
+					"rely on newer server behavior may fail or misreport.",
+				Actions: serverUpgradeActions(env),
+			},
+		}
+	case skewCLIBehind:
+		return checkResult{
+			Status:  checkWarn,
+			Summary: summary,
+			Problem: &ui.Diagnostic{
+				Summary: fmt.Sprintf("CLI %s is behind server %s", cli.Version, server.Version),
+				Detail:  "This CLI is running an older release than the server it is talking to.",
+				Actions: []ui.Action{
+					{Command: "miren upgrade", Note: "update this CLI"},
+				},
+			},
+		}
+	case skewUnordered:
+		return checkResult{Status: checkOK, Summary: summary + " (different builds)"}
+	case skewNone:
+	}
+	return checkResult{Status: checkOK, Summary: summary}
+}
+
+func serverUpgradeActions(env *doctorEnv) []ui.Action {
+	if env.local() {
+		return []ui.Action{
+			{Command: "sudo miren server upgrade", Note: "upgrade the server on this machine"},
+		}
+	}
+	return []ui.Action{
+		{Command: "sudo miren server upgrade", Note: "run on the server host to upgrade it"},
+	}
+}

--- a/cli/commands/doctor_version_test.go
+++ b/cli/commands/doctor_version_test.go
@@ -1,0 +1,167 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/version"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		cli, server string
+		want        versionSkew
+	}{
+		{"v0.14.0", "v0.14.0", skewNone},
+		{"v0.14.0", "v0.13.2", skewServerBehind},
+		{"v0.13.2", "v0.14.0", skewCLIBehind},
+		{"v0.14.0", "v0.14.0-rc1", skewServerBehind},
+		{"main:abc1234", "main:def5678", skewUnordered},
+		{"main:abc1234", "v0.14.0", skewUnordered},
+		{"unknown", "v0.14.0", skewUnordered},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s vs %s", tt.cli, tt.server), func(t *testing.T) {
+			if got := compareVersions(tt.cli, tt.server); got != tt.want {
+				t.Fatalf("compareVersions(%q, %q) = %v, want %v", tt.cli, tt.server, got, tt.want)
+			}
+		})
+	}
+}
+
+func withCLIVersion(t *testing.T, v string) {
+	t.Helper()
+	prev := version.Version
+	version.Version = v
+	t.Cleanup(func() { version.Version = prev })
+}
+
+func versionEnv(server *serverVersion, err error) *doctorEnv {
+	return &doctorEnv{
+		cfg:              &clientconfig.Config{},
+		cluster:          &clientconfig.ClusterConfig{Hostname: remoteHost},
+		clusterName:      "prod",
+		clusterCount:     1,
+		serverVersion:    server,
+		serverVersionErr: err,
+	}
+}
+
+func TestVersionCheckTable(t *testing.T) {
+	withCLIVersion(t, "v0.14.0")
+
+	lookupErr := fmt.Errorf("%w: %w", errServerVersionUnsupported,
+		rpc.NewResolveLookupError(serverInfoService, remoteHost, "unknown service"))
+
+	tests := []struct {
+		name        string
+		env         *doctorEnv
+		wantStatus  checkStatus
+		wantSummary string
+		wantAction  string
+	}{
+		{
+			name:        "matching versions",
+			env:         versionEnv(&serverVersion{Version: "v0.14.0", Ready: true}, nil),
+			wantStatus:  checkOK,
+			wantSummary: "CLI v0.14.0, server v0.14.0",
+		},
+		{
+			name:        "server predates version reporting",
+			env:         versionEnv(nil, lookupErr),
+			wantStatus:  checkWarn,
+			wantSummary: "server does not report its version",
+			wantAction:  "sudo miren server upgrade",
+		},
+		{
+			name:        "server behind",
+			env:         versionEnv(&serverVersion{Version: "v0.9.0", Ready: true}, nil),
+			wantStatus:  checkWarn,
+			wantSummary: "CLI v0.14.0, server v0.9.0",
+			wantAction:  "sudo miren server upgrade",
+		},
+		{
+			name:        "cli behind",
+			env:         versionEnv(&serverVersion{Version: "v0.15.0", Ready: true}, nil),
+			wantStatus:  checkWarn,
+			wantSummary: "CLI v0.14.0, server v0.15.0",
+			wantAction:  "miren upgrade",
+		},
+		{
+			name:        "still starting is a fact not a fault",
+			env:         versionEnv(&serverVersion{Version: "v0.14.0", Ready: false}, nil),
+			wantStatus:  checkOK,
+			wantSummary: "server still starting",
+		},
+		{
+			name:        "dev builds differ",
+			env:         versionEnv(&serverVersion{Version: "main:def5678", Ready: true}, nil),
+			wantStatus:  checkOK,
+			wantSummary: "different builds",
+		},
+		{
+			name:        "other query failure is skipped",
+			env:         versionEnv(nil, errors.New("boom")),
+			wantStatus:  checkSkip,
+			wantSummary: "could not read server version",
+		},
+		{
+			name: "unreachable server defers to the server check",
+			env: func() *doctorEnv {
+				env := versionEnv(nil, errors.New("boom"))
+				env.connErr = unreachableErr(remoteHost)
+				return env
+			}(),
+			wantStatus:  checkSkip,
+			wantSummary: "not reachable",
+		},
+		{
+			name:        "no cluster",
+			env:         &doctorEnv{},
+			wantStatus:  checkSkip,
+			wantSummary: "no cluster selected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkVersion(tt.env)
+			if got.Status != tt.wantStatus {
+				t.Fatalf("status = %v, want %v (summary %q)", got.Status, tt.wantStatus, got.Summary)
+			}
+			if !strings.Contains(got.Summary, tt.wantSummary) {
+				t.Fatalf("summary = %q, want it to contain %q", got.Summary, tt.wantSummary)
+			}
+			if tt.wantAction == "" {
+				return
+			}
+			if got.Problem == nil {
+				t.Fatalf("expected a problem naming %q, got none", tt.wantAction)
+			}
+			found := false
+			for _, a := range got.Problem.Actions {
+				if a.Command == tt.wantAction {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("actions %+v do not include %q", got.Problem.Actions, tt.wantAction)
+			}
+		})
+	}
+}
+
+func TestServerVersionJSONOmitsAbsentTimestamps(t *testing.T) {
+	data, err := json.Marshal(serverVersion{Version: "v0.14.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "0001-01-01") {
+		t.Fatalf("zero timestamps leaked into JSON: %s", data)
+	}
+}

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -1,22 +1,43 @@
 package commands
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"runtime/debug"
+	"time"
 
 	"miren.dev/runtime/version"
 )
 
 type VersionOptions struct {
+	ConfigCentric
 	Deps   bool   `long:"deps" description:"Show dependencies"`
 	Format string `long:"format" description:"Output format (text, json)" default:"text"`
+	Server bool   `short:"s" long:"server" description:"Also report the version of the active cluster's server"`
+}
+
+// versionReport is the --server shape. Without --server the output stays the
+// flat build info pkg/release already parses.
+type versionReport struct {
+	CLI         version.Info   `json:"cli"`
+	Cluster     string         `json:"cluster,omitempty"`
+	Server      *serverVersion `json:"server,omitempty"`
+	ServerError string         `json:"server_error,omitempty"`
+	Skew        string         `json:"skew,omitempty"`
+	Advice      string         `json:"advice,omitempty"`
 }
 
 func Version(ctx *Context, opts VersionOptions) error {
-	// Get version info
 	info := version.GetInfo()
 
-	// Handle JSON format
+	if opts.Server {
+		if opts.Deps {
+			return fmt.Errorf("--deps and --server cannot be combined")
+		}
+		return versionWithServer(ctx, info, opts.Format == "json")
+	}
+
 	if opts.Format == "json" {
 		jsonStr, err := info.JSON()
 		if err != nil {
@@ -26,7 +47,6 @@ func Version(ctx *Context, opts VersionOptions) error {
 		return nil
 	}
 
-	// Handle dependencies flag
 	if opts.Deps {
 		bi, ok := debug.ReadBuildInfo()
 		if ok {
@@ -47,7 +67,113 @@ func Version(ctx *Context, opts VersionOptions) error {
 		return nil
 	}
 
-	// Default text format
 	fmt.Println(info.String())
 	return nil
+}
+
+func versionWithServer(ctx *Context, cli version.Info, asJSON bool) error {
+	report := versionReport{CLI: cli, Cluster: ctx.ClusterName}
+
+	server, err := fetchServerVersion(ctx)
+	if err != nil {
+		report.ServerError = err.Error()
+		if errors.Is(err, errServerVersionUnsupported) {
+			report.Skew = "server_behind"
+			report.Advice = serverBehindAdvice
+		}
+	} else {
+		report.Server = server
+		report.Skew, report.Advice = describeSkew(compareVersions(cli.Version, server.Version))
+	}
+
+	if asJSON {
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	ctx.Printf("CLI\n")
+	printBuildLines(ctx, cli.Version, cli.Commit, cli.BuildDate)
+
+	if report.Cluster != "" {
+		ctx.Printf("\nServer (%s)\n", report.Cluster)
+	} else {
+		ctx.Printf("\nServer\n")
+	}
+	if server == nil {
+		if errors.Is(err, errServerVersionUnsupported) {
+			ctx.Printf("  Version: not reported (server predates version reporting)\n")
+		} else {
+			ctx.Printf("  Version: unavailable\n")
+			ctx.Printf("  Error:   %v\n", err)
+		}
+	} else {
+		printBuildLines(ctx, server.Version, server.Commit, server.BuildDate)
+		ctx.Printf("  Instance: %s\n", server.InstanceID)
+		if !server.StartedAt.IsZero() {
+			started := server.StartedAt.Local().Format("2006-01-02 15:04:05 MST")
+			// Clock skew between client and server can make this negative.
+			if uptime := time.Since(server.StartedAt); uptime >= 0 {
+				ctx.Printf("  Started:  %s (up %s)\n", started, roundUptime(uptime))
+			} else {
+				ctx.Printf("  Started:  %s\n", started)
+			}
+		}
+		if server.Ready {
+			ctx.Printf("  Ready:    yes\n")
+		} else {
+			ctx.Printf("  Ready:    no (still starting)\n")
+		}
+		if server.InstallKind != "" {
+			ctx.Printf("  Install:  %s\n", server.InstallKind)
+		}
+	}
+
+	if report.Advice != "" {
+		ctx.Printf("\n")
+		ctx.Warn("%s", report.Advice)
+	}
+	return nil
+}
+
+func printBuildLines(ctx *Context, ver, commit string, built time.Time) {
+	ctx.Printf("  Version:  %s\n", ver)
+	if commit != "" && commit != "unknown" {
+		ctx.Printf("  Commit:   %s\n", commit)
+	}
+	if !built.IsZero() {
+		ctx.Printf("  Built:    %s\n", built.Format("2006-01-02 15:04:05 UTC"))
+	}
+}
+
+const (
+	serverBehindAdvice = "The server is older than this CLI. Run 'sudo miren server upgrade' on the server host to update it."
+	cliBehindAdvice    = "This CLI is older than the server. Run 'miren upgrade' to update it."
+)
+
+func describeSkew(skew versionSkew) (name, advice string) {
+	switch skew {
+	case skewServerBehind:
+		return "server_behind", serverBehindAdvice
+	case skewCLIBehind:
+		return "cli_behind", cliBehindAdvice
+	case skewUnordered:
+		return "different", ""
+	case skewNone:
+	}
+	return "none", ""
+}
+
+func roundUptime(d time.Duration) time.Duration {
+	switch {
+	case d > 24*time.Hour:
+		return d.Round(time.Hour)
+	case d > time.Hour:
+		return d.Round(time.Minute)
+	default:
+		return d.Round(time.Second)
+	}
 }

--- a/cli/commands/version_server.go
+++ b/cli/commands/version_server.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"miren.dev/runtime/api/server/server_v1alpha"
+	"miren.dev/runtime/pkg/release"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// Mirrors components/server.ServerInfoService; that package is linux-only.
+const serverInfoService = "dev.miren.runtime/server-info"
+
+type serverVersion struct {
+	Version     string    `json:"version"`
+	Commit      string    `json:"commit"`
+	BuildDate   time.Time `json:"build_date,omitzero"`
+	InstanceID  string    `json:"runtime_instance_id"`
+	StartedAt   time.Time `json:"started_at,omitzero"`
+	Ready       bool      `json:"ready"`
+	InstallKind string    `json:"install_kind"`
+}
+
+// errServerVersionUnsupported: the server answered but predates the version
+// RPC, which itself means it is older than this CLI.
+var errServerVersionUnsupported = errors.New("server does not report its version")
+
+func fetchServerVersion(ctx *Context) (*serverVersion, error) {
+	client, err := ctx.RPCClient(serverInfoService)
+	if err != nil {
+		if re, ok := errors.AsType[*rpc.ResolveError](err); ok && re.Kind == rpc.ResolveLookupError {
+			return nil, fmt.Errorf("%w: %w", errServerVersionUnsupported, err)
+		}
+		return nil, err
+	}
+	defer client.Close()
+
+	results, err := server_v1alpha.NewServerInfoClient(client).Version(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query server version: %w", err)
+	}
+	info := &serverVersion{
+		Version:     results.Version(),
+		Commit:      results.Commit(),
+		InstanceID:  results.RuntimeInstanceId(),
+		Ready:       results.Ready(),
+		InstallKind: results.InstallKind(),
+	}
+	if results.HasBuildDate() {
+		info.BuildDate = standard.FromTimestamp(results.BuildDate())
+	}
+	if results.HasStartedAt() {
+		info.StartedAt = standard.FromTimestamp(results.StartedAt())
+	}
+	return info, nil
+}
+
+type versionSkew int
+
+const (
+	skewNone versionSkew = iota
+	skewServerBehind
+	skewCLIBehind
+	// skewUnordered: different builds that are not both semver releases, such
+	// as two main-branch commits.
+	skewUnordered
+)
+
+func compareVersions(cli, server string) versionSkew {
+	if cli == server {
+		return skewNone
+	}
+	cliSem, cliErr := release.ParseSemVer(cli)
+	serverSem, serverErr := release.ParseSemVer(server)
+	if cliErr != nil || serverErr != nil {
+		return skewUnordered
+	}
+	switch {
+	case cliSem.IsNewer(serverSem):
+		return skewServerBehind
+	case serverSem.IsNewer(cliSem):
+		return skewCLIBehind
+	default:
+		return skewNone
+	}
+}

--- a/components/coordinate/cloud_control.go
+++ b/components/coordinate/cloud_control.go
@@ -22,6 +22,7 @@ import (
 	"miren.dev/runtime/pkg/entitysync"
 	"miren.dev/runtime/pkg/labs"
 	"miren.dev/runtime/pkg/registration"
+	"miren.dev/runtime/pkg/serverinfo"
 	"miren.dev/runtime/pkg/sysstats"
 	"miren.dev/runtime/pkg/uplink"
 	"miren.dev/runtime/servers/httpingress"
@@ -51,6 +52,9 @@ type CloudControl struct {
 	// the same AppInfo backing the app RPC surface, so the console cannot
 	// disagree with `miren app list`.
 	applications *ApplicationManagement
+
+	// Instance is optional; when nil reports omit the instance id.
+	Instance *serverinfo.Source
 
 	entitySyncDiagnostics   *entitysync.Diagnostics
 	publishedKeysMu         sync.Mutex
@@ -103,7 +107,10 @@ func (c *CloudControl) RunCloudUplink(ctx context.Context, ingress *httpingress.
 
 	uplinkOptions := []uplink.ClientOption{uplink.WithStatus(c.entitySyncDiagnostics.ObserveUplink)}
 	if labs.AppVisibility() {
-		uplinkOptions = append(uplinkOptions, uplink.WithSession(version.GetInfo().Version))
+		uplinkOptions = append(uplinkOptions, uplink.WithSession(uplink.SessionIdentity{
+			RuntimeVersion:    version.GetInfo().Version,
+			RuntimeInstanceID: c.instanceID(),
+		}))
 	} else {
 		c.entitySyncDiagnostics.SetCapabilityDisabled("app-visibility-disabled")
 	}
@@ -362,6 +369,7 @@ func (c *CloudControl) ReportStatus(ctx context.Context) error {
 		ClusterID:     c.CloudAuth.ClusterID,
 		State:         "active",
 		Version:       versionInfo.Version,
+		InstanceID:    c.instanceID(),
 		NodeCount:     1, // Static value for now
 		WorkloadCount: workloadCount,
 		ResourceUsage: resourceUsage,
@@ -377,6 +385,13 @@ func (c *CloudControl) ReportStatus(ctx context.Context) error {
 
 	c.recordIdentityAnchor(result.IdentityIssuerURL)
 	return nil
+}
+
+func (c *CloudControl) instanceID() string {
+	if c.Instance == nil {
+		return ""
+	}
+	return c.Instance.InstanceID()
 }
 
 // collectResourceUsage gathers basic host system resource usage metrics

--- a/components/server/boot_cloud_control.go
+++ b/components/server/boot_cloud_control.go
@@ -8,6 +8,7 @@ import (
 	"miren.dev/runtime/components/coordinate"
 	"miren.dev/runtime/pkg/boot"
 	"miren.dev/runtime/pkg/entitysync"
+	"miren.dev/runtime/pkg/serverinfo"
 )
 
 type cloudControlBootOutput struct {
@@ -19,10 +20,11 @@ type cloudControlBoot struct {
 	output      boot.Output[cloudControlBootOutput]
 	value       *coordinate.CloudControl
 	diagnostics *entitysync.Diagnostics
+	instance    *serverinfo.Source
 }
 
-func newCloudControlBoot(foundation boot.Output[foundationBootOutput], applications boot.Output[applicationManagementBootOutput], maintenance, workloads *boot.Component, diagnostics *entitysync.Diagnostics) *cloudControlBoot {
-	b := &cloudControlBoot{diagnostics: diagnostics}
+func newCloudControlBoot(foundation boot.Output[foundationBootOutput], applications boot.Output[applicationManagementBootOutput], maintenance, workloads *boot.Component, diagnostics *entitysync.Diagnostics, instance *serverinfo.Source) *cloudControlBoot {
+	b := &cloudControlBoot{diagnostics: diagnostics, instance: instance}
 	b.component, b.output = boot.Provide2(
 		"cloud-control", foundation, applications, b.start,
 		// Cloud startup status means the management, maintenance, and workload
@@ -38,6 +40,7 @@ func newCloudControlBoot(foundation boot.Output[foundationBootOutput], applicati
 
 func (b *cloudControlBoot) start(ctx context.Context, foundation foundationBootOutput, applications applicationManagementBootOutput) (cloudControlBootOutput, error) {
 	cloud := coordinate.NewCloudControl(foundation.foundation, applications.applications, b.diagnostics)
+	cloud.Instance = b.instance
 	if err := cloud.Start(ctx); err != nil {
 		return cloudControlBootOutput{}, err
 	}

--- a/components/server/boot_ingress.go
+++ b/components/server/boot_ingress.go
@@ -14,6 +14,7 @@ import (
 	"miren.dev/runtime/components/autotls"
 	"miren.dev/runtime/pkg/boot"
 	"miren.dev/runtime/pkg/serverconfig"
+	"miren.dev/runtime/pkg/serverinfo"
 	"miren.dev/runtime/servers/httpingress"
 )
 
@@ -23,6 +24,7 @@ type ingressBootInputs struct {
 	group          *errgroup.Group
 	dataPath       string
 	requestTimeout time.Duration
+	instance       *serverinfo.Source
 }
 
 type ingressBoot struct {
@@ -36,8 +38,9 @@ type ingressBootOutput struct {
 	server *httpingress.Server
 }
 
-func ingressInputs(options StartOptions) ingressBootInputs {
+func ingressInputs(options StartOptions, instance *serverinfo.Source) ingressBootInputs {
 	return ingressBootInputs{
+		instance:       instance,
 		ingress:        options.Config.Ingress,
 		tls:            options.Config.TLS,
 		group:          options.Group,
@@ -62,6 +65,7 @@ func (b *ingressBoot) start(ctx context.Context, workloadControlOutput workloadC
 		RequestTimeout: b.inputs.requestTimeout,
 		DataPath:       b.inputs.dataPath,
 		WorkloadIssuer: identity.issuer,
+		Instance:       b.inputs.instance,
 	}, entityAccess.rpcClient, workloadControl.Activator(), observability.http, observability.logWriter)
 	if err := b.serve(ctx, handler, workloadControl.CertificateProvider(), workloadControl.AutocertReadySignal()); err != nil {
 		return ingressBootOutput{}, err

--- a/components/server/boot_server_info.go
+++ b/components/server/boot_server_info.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package server
+
+import (
+	"context"
+
+	"miren.dev/runtime/api/server/server_v1alpha"
+	"miren.dev/runtime/pkg/boot"
+	"miren.dev/runtime/pkg/serverinfo"
+	serverinfosrv "miren.dev/runtime/servers/serverinfo"
+)
+
+const ServerInfoService = "dev.miren.runtime/server-info"
+
+type serverInfoBoot struct {
+	component *boot.Component
+	source    *serverinfo.Source
+}
+
+// Exposed as soon as the RPC server is up so callers can watch the process
+// become ready.
+func newServerInfoBoot(source *serverinfo.Source, foundation boot.Output[foundationBootOutput]) *serverInfoBoot {
+	b := &serverInfoBoot{source: source}
+	b.component = boot.Run1("server-info", foundation, b.start)
+	return b
+}
+
+func (b *serverInfoBoot) start(_ context.Context, foundation foundationBootOutput) error {
+	foundation.foundation.Server().ExposeValue(ServerInfoService, server_v1alpha.AdaptServerInfo(serverinfosrv.NewServer(b.source)))
+	return nil
+}

--- a/components/server/runtime.go
+++ b/components/server/runtime.go
@@ -12,6 +12,7 @@ import (
 	"miren.dev/runtime/components/coordinate"
 	"miren.dev/runtime/components/runner"
 	"miren.dev/runtime/pkg/boot"
+	"miren.dev/runtime/pkg/serverinfo"
 )
 
 const (
@@ -28,6 +29,9 @@ type Runtime struct {
 	graph         *boot.Graph
 	once          sync.Once
 	observability boot.Output[observabilityBootOutput]
+	// instance is created before the graph so every component reports the
+	// same id, and marked ready only after the whole graph has started.
+	instance *serverinfo.Source
 
 	ControlPlane *coordinate.ControlPlane
 	Runner       *runner.Runner
@@ -37,7 +41,7 @@ type Runtime struct {
 
 // Start assembles, validates, and starts the server dependency graph.
 func Start(options StartOptions) (*Runtime, error) {
-	runtime := &Runtime{graph: boot.NewGraph()}
+	runtime := &Runtime{graph: boot.NewGraph(), instance: serverinfo.New()}
 	components := newStartup(runtime, options)
 	runtime.observability = components.observability.output
 
@@ -53,6 +57,7 @@ func Start(options StartOptions) (*Runtime, error) {
 		_ = runtime.Stop(stopCtx)
 		return nil, err
 	}
+	runtime.instance.MarkReady()
 	components.sandboxHost.enableShutdownCleanup()
 	runtime.ControlPlane = coordinate.NewControlPlane(
 		components.foundation.output.Value().foundation,
@@ -74,6 +79,10 @@ func Start(options StartOptions) (*Runtime, error) {
 		Presence:     components.nodePresence.Output.Value(),
 	}
 	return runtime, nil
+}
+
+func (r *Runtime) Instance() *serverinfo.Source {
+	return r.instance
 }
 
 // Log returns the system-log-enabled logger produced during server boot.
@@ -115,6 +124,7 @@ func (s *startup) addComponents() error {
 		s.cloudControl.component,
 		s.ingress.component,
 		s.admin.component,
+		s.serverInfo.component,
 		s.registryHostMapping.component,
 		s.ociRegistry.component,
 		s.workAdmission.component,

--- a/components/server/startup.go
+++ b/components/server/startup.go
@@ -65,6 +65,7 @@ type startup struct {
 	nodePresence          *runnercomp.CapabilityBoot[*runnercomp.NodePresence]
 	ingress               *ingressBoot
 	admin                 *adminBoot
+	serverInfo            *serverInfoBoot
 	registryHostMapping   *registryHostMappingBoot
 	ociRegistry           *ociRegistryBoot
 	workAdmission         *workAdmissionBoot
@@ -77,6 +78,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 	// the components that share it.
 	resolver, hostMapper := netresolve.NewLocalResolver()
 	secretRegistry := secret.NewRegistry()
+	instance := runtime.instance
 	entitySyncDiagnostics := entitysync.NewDiagnostics(core_v1alpha.CloudExportContract.Digest())
 	address := NormalizeServerAddress(options.Log, options.Config.Server.GetAddress())
 
@@ -145,9 +147,10 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 	sandboxAgent := runnercomp.NewSandboxAgentBoot(sandboxHost.output, componentStopTimeout, workloadControl.component)
 	nodePresence := runnercomp.NewNodePresenceBoot(sandboxHost.output, storageAgent.Component, sandboxAgent.Component, componentStopTimeout)
 	maintenance := newEntityMaintenanceBoot(foundation.output, appData.component)
-	cloudControl := newCloudControlBoot(foundation.output, applicationManagement.output, maintenance.component, workloadControl.component, entitySyncDiagnostics)
-	ingress := newIngressBoot(ingressInputs(options), workloadControl.output, nodePresence.Component, workloadIdentity.output, entityAccess.output, observability.output)
+	cloudControl := newCloudControlBoot(foundation.output, applicationManagement.output, maintenance.component, workloadControl.component, entitySyncDiagnostics, instance)
+	ingress := newIngressBoot(ingressInputs(options, instance), workloadControl.output, nodePresence.Component, workloadIdentity.output, entityAccess.output, observability.output)
 	adminAPI := newAdminBoot(foundation.output, entityAccess.output, ingress.output, observability.output)
+	serverInfo := newServerInfoBoot(instance, foundation.output)
 	cloudUplink := newCloudUplinkBoot(cloudControl.output, deploymentAttempts.output, ingress.output)
 	ociRegistry := newOCIRegistryBoot(ociRegistryInputs(options), workloadIdentity.output, entityAccess.output, registryHostMapping.component, observability.output)
 	workAdmission := newWorkAdmissionBoot(applicationManagement.output, workloadControl.component, nodePresence.Component, buildkit.component, ociRegistry.component, registryHostMapping.component)
@@ -192,6 +195,7 @@ func newStartup(runtime *Runtime, options StartOptions) *startup {
 		nodePresence:          nodePresence,
 		ingress:               ingress,
 		admin:                 adminAPI,
+		serverInfo:            serverInfo,
 		registryHostMapping:   registryHostMapping,
 		ociRegistry:           ociRegistry,
 		workAdmission:         workAdmission,

--- a/docs/docs/command/version.md
+++ b/docs/docs/command/version.md
@@ -16,8 +16,11 @@ miren version [flags]
 
 ## Flags
 
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
 - `--deps` — Show dependencies
 - `--format` — Output format (text, json) (default: `text`)
+- `--server, -s` — Also report the version of the active cluster's server
 
 ## Global Options
 
@@ -37,4 +40,10 @@ miren version
 
 ```bash
 miren version --format json
+```
+
+**Compare with the cluster's server:**
+
+```bash
+miren version --server
 ```

--- a/pkg/cloudauth/status.go
+++ b/pkg/cloudauth/status.go
@@ -21,8 +21,10 @@ type ResourceUsage struct {
 
 // StatusReport represents the cluster status to report
 type StatusReport struct {
-	ClusterID         string            `json:"cluster_id"`
-	Version           string            `json:"version,omitempty"`
+	ClusterID string `json:"cluster_id"`
+	Version   string `json:"version,omitempty"`
+	// InstanceID changes on every restart while Version may not.
+	InstanceID        string            `json:"runtime_instance_id,omitempty"`
 	State             string            `json:"state"` // required: active, degraded, inactive, unknown
 	NodeCount         int               `json:"node_count,omitempty"`
 	WorkloadCount     int               `json:"workload_count,omitempty"`

--- a/pkg/serverinfo/serverinfo.go
+++ b/pkg/serverinfo/serverinfo.go
@@ -1,0 +1,93 @@
+// Package serverinfo describes the running server process: build, instance
+// identity, and readiness. One source feeds the Version RPC, the health
+// endpoint, and the cloud uplink so they cannot disagree.
+package serverinfo
+
+import (
+	"crypto/rand"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"miren.dev/runtime/pkg/containerenv"
+	"miren.dev/runtime/version"
+)
+
+// InstallKind is how the process is supervised, which decides whether an
+// upgrade can restart it. Container installs are not upgradable yet (MIR-882).
+type InstallKind string
+
+const (
+	InstallKindSystemd   InstallKind = "systemd"
+	InstallKindContainer InstallKind = "container"
+	InstallKindUnknown   InstallKind = "unknown"
+)
+
+// Info is a snapshot of the server process.
+type Info struct {
+	Version   string    `json:"version"`
+	Commit    string    `json:"commit"`
+	BuildDate time.Time `json:"build_date"`
+
+	// InstanceID changes on every restart even when Version does not.
+	InstanceID string    `json:"runtime_instance_id"`
+	StartedAt  time.Time `json:"started_at"`
+
+	// Ready flips once the boot graph has started every component.
+	Ready bool `json:"ready"`
+
+	InstallKind InstallKind `json:"install_kind"`
+}
+
+// Source is created once per process at boot and marked ready when the boot
+// graph finishes.
+type Source struct {
+	instanceID  string
+	startedAt   time.Time
+	installKind InstallKind
+	ready       atomic.Bool
+}
+
+func New() *Source {
+	return &Source{
+		instanceID:  ulid.MustNew(ulid.Now(), rand.Reader).String(),
+		startedAt:   time.Now().UTC(),
+		installKind: detectInstallKind(),
+	}
+}
+
+func (s *Source) MarkReady() {
+	s.ready.Store(true)
+}
+
+func (s *Source) InstanceID() string {
+	return s.instanceID
+}
+
+func (s *Source) Info() Info {
+	build := version.GetInfo()
+	return Info{
+		Version:     build.Version,
+		Commit:      build.Commit,
+		BuildDate:   build.BuildDate,
+		InstanceID:  s.instanceID,
+		StartedAt:   s.startedAt,
+		Ready:       s.ready.Load(),
+		InstallKind: s.installKind,
+	}
+}
+
+// systemd wins over the container check: if systemd started this process,
+// `systemctl restart` works wherever that systemd lives (including a
+// systemd-in-docker test host). A real container install runs miren as the
+// container's own PID 1, with no INVOCATION_ID.
+func detectInstallKind() InstallKind {
+	if os.Getenv("INVOCATION_ID") != "" {
+		return InstallKindSystemd
+	}
+	if containerenv.InContainer() {
+		return InstallKindContainer
+	}
+	return InstallKindUnknown
+}

--- a/pkg/serverinfo/serverinfo_test.go
+++ b/pkg/serverinfo/serverinfo_test.go
@@ -1,0 +1,22 @@
+package serverinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceReadyFlipsOnce(t *testing.T) {
+	s := New()
+	require.NotEmpty(t, s.InstanceID())
+	require.False(t, s.Info().Ready)
+	require.False(t, s.Info().StartedAt.IsZero())
+
+	s.MarkReady()
+	require.True(t, s.Info().Ready)
+	require.Equal(t, s.InstanceID(), s.Info().InstanceID)
+}
+
+func TestNewMintsDistinctInstances(t *testing.T) {
+	require.NotEqual(t, New().InstanceID(), New().InstanceID())
+}

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -13,6 +13,7 @@ import (
 	"miren.dev/runtime/api/admin/admin_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/server/server_v1alpha"
 	"miren.dev/runtime/components/coordinate"
 	"miren.dev/runtime/components/ipalloc"
 	"miren.dev/runtime/components/netresolve"
@@ -22,10 +23,12 @@ import (
 	"miren.dev/runtime/network"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/serverinfo"
 	"miren.dev/runtime/pkg/slogfmt"
 	"miren.dev/runtime/pkg/testutils"
 	"miren.dev/runtime/servers/admin"
 	"miren.dev/runtime/servers/httpingress"
+	serverinfosrv "miren.dev/runtime/servers/serverinfo"
 )
 
 func TestServerConfig(t *testing.T) (string, error) {
@@ -138,12 +141,16 @@ func TestServer(t *testing.T) error {
 
 	// Ingress is a data-plane participant even when it shares this process with
 	// the control plane.
+	instance := serverinfo.New()
+	instance.MarkReady()
 	hs := httpingress.NewServer(ctx, log, httpingress.IngressConfig{
 		RequestTimeout: 60 * time.Second,
 		DataPath:       filepath.Join(tempDir, "coordinator"),
+		Instance:       instance,
 	}, client, co.WorkloadControl().Activator(), testDeps.HTTPMetrics, testDeps.LogWriter)
 	adminServer := admin.NewServer(log, ec, hs, testDeps.LogWriter)
 	co.Server().ExposeValue("dev.miren.runtime/admin", admin_v1alpha.AdaptAdmin(adminServer))
+	co.Server().ExposeValue("dev.miren.runtime/server-info", server_v1alpha.AdaptServerInfo(serverinfosrv.NewServer(instance)))
 
 	rcfg, err := co.RunnerConfig(optsRunnerAddress)
 	if err != nil {

--- a/pkg/uplink/client.go
+++ b/pkg/uplink/client.go
@@ -82,7 +82,12 @@ type Client struct {
 }
 
 type sessionConfig struct {
-	runtimeVersion string
+	identity SessionIdentity
+}
+
+type SessionIdentity struct {
+	RuntimeVersion    string
+	RuntimeInstanceID string
 }
 
 // Status describes the current state of the reconnecting uplink client.
@@ -113,9 +118,9 @@ type ClientOption func(*Client)
 // WithSession enables the negotiated session handshake. Callers should gate
 // this while the protocol is experimental; cloud must support the handshake
 // before a runtime starts requiring a welcome.
-func WithSession(runtimeVersion string) ClientOption {
+func WithSession(identity SessionIdentity) ClientOption {
 	return func(c *Client) {
-		c.session = &sessionConfig{runtimeVersion: runtimeVersion}
+		c.session = &sessionConfig{identity: identity}
 	}
 }
 
@@ -553,7 +558,8 @@ func (c *Client) establishSession(ctx context.Context, conn *websocket.Conn) (Se
 	offers, callbacks := c.sessionSnapshot(ctx)
 	hello := SessionHello{
 		HandshakeVersions: []uint{HandshakeVersion1},
-		RuntimeVersion:    c.session.runtimeVersion,
+		RuntimeVersion:    c.session.identity.RuntimeVersion,
+		RuntimeInstanceID: c.session.identity.RuntimeInstanceID,
 		ClientTime:        time.Now().UTC(),
 		Capabilities:      offers,
 	}

--- a/pkg/uplink/client_test.go
+++ b/pkg/uplink/client_test.go
@@ -477,7 +477,7 @@ func TestNegotiatedSessionStartsCallbacksAfterWelcome(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestClient(srv.URL, "test-token", NewMessageRouter())
-	WithSession("v1.2.3")(client)
+	WithSession(SessionIdentity{RuntimeVersion: "v1.2.3", RuntimeInstanceID: "01TESTINSTANCE"})(client)
 	client.OfferCapability(CapabilityOffer{Name: CapabilityPopConnect, Versions: []uint{1}})
 	client.OnSession(func(_ context.Context, session Session) { sessionStarted <- session })
 	client.OnConnect(func(context.Context) { connectStarted <- struct{}{} })
@@ -494,6 +494,9 @@ func TestNegotiatedSessionStartsCallbacksAfterWelcome(t *testing.T) {
 	}
 	if hello.RuntimeVersion != "v1.2.3" {
 		t.Fatalf("runtime version = %q, want v1.2.3", hello.RuntimeVersion)
+	}
+	if hello.RuntimeInstanceID != "01TESTINSTANCE" {
+		t.Fatalf("runtime instance id = %q, want 01TESTINSTANCE", hello.RuntimeInstanceID)
 	}
 	if len(hello.Capabilities) != 1 || hello.Capabilities[0].Name != CapabilityPopConnect {
 		t.Fatalf("capability offers = %+v", hello.Capabilities)
@@ -543,7 +546,7 @@ func TestNegotiatedSessionRejectDoesNotStartTenants(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestClient(srv.URL, "test-token", NewMessageRouter())
-	WithSession("test")(client)
+	WithSession(SessionIdentity{RuntimeVersion: "test"})(client)
 	started := false
 	client.OnSession(func(context.Context, Session) { started = true })
 	client.OnConnect(func(context.Context) { started = true })

--- a/pkg/uplink/session.go
+++ b/pkg/uplink/session.go
@@ -46,8 +46,11 @@ type CapabilitySelection struct {
 // The bootstrap shape is deliberately small: future protocol families evolve
 // behind capabilities rather than adding their state directly here.
 type SessionHello struct {
-	HandshakeVersions []uint            `json:"handshake_versions"`
-	RuntimeVersion    string            `json:"runtime_version"`
+	HandshakeVersions []uint `json:"handshake_versions"`
+	RuntimeVersion    string `json:"runtime_version"`
+	// RuntimeInstanceID lets cloud tell a reconnect from a restart. Optional
+	// so older runtimes stay decodable.
+	RuntimeInstanceID string            `json:"runtime_instance_id,omitempty"`
 	ClientTime        time.Time         `json:"client_time"`
 	Capabilities      []CapabilityOffer `json:"capabilities"`
 }

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -40,6 +40,7 @@ import (
 	"miren.dev/runtime/pkg/httputil"
 	"miren.dev/runtime/pkg/oidc"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/serverinfo"
 	"miren.dev/runtime/pkg/waf"
 	"miren.dev/runtime/pkg/workloadidentity"
 )
@@ -80,6 +81,8 @@ type IngressConfig struct {
 	RequestTimeout time.Duration
 	DataPath       string
 	WorkloadIssuer *workloadidentity.Issuer
+	// Instance, when set, adds process identity and readiness to /health.
+	Instance *serverinfo.Source
 }
 
 type Server struct {
@@ -1256,6 +1259,10 @@ func isProxyConnectionError(err error) bool {
 type HealthResponse struct {
 	Status string                 `json:"status"`
 	Checks map[string]HealthCheck `json:"checks"`
+
+	// Server.Ready is the boot-graph signal an upgrade waits for; Status stays
+	// the dependency check it always was.
+	Server *serverinfo.Info `json:"server,omitempty"`
 }
 
 // HealthCheck represents a single component health check
@@ -1272,6 +1279,10 @@ func (h *Server) handleHealth(w http.ResponseWriter, req *http.Request) {
 	response := HealthResponse{
 		Status: "healthy",
 		Checks: make(map[string]HealthCheck),
+	}
+	if h.config.Instance != nil {
+		info := h.config.Instance.Info()
+		response.Server = &info
 	}
 
 	// Check etcd connection by listing apps (lightweight query)
@@ -1290,7 +1301,9 @@ func (h *Server) handleHealth(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	// Set response headers and status
+	// The status code reflects dependency health only. Boot readiness is
+	// reported in the body as server.ready, and a booting server still answers
+	// 200 here so callers watching dependencies do not confuse the two.
 	w.Header().Set("Content-Type", "application/json")
 	if response.Status == "healthy" {
 		w.WriteHeader(http.StatusOK)

--- a/servers/serverinfo/serverinfo.go
+++ b/servers/serverinfo/serverinfo.go
@@ -1,0 +1,37 @@
+// Package serverinfo serves the ServerInfo RPC from a serverinfo.Source.
+package serverinfo
+
+import (
+	"context"
+
+	"miren.dev/runtime/api/server/server_v1alpha"
+	"miren.dev/runtime/pkg/rpc/standard"
+	"miren.dev/runtime/pkg/serverinfo"
+)
+
+// Server answers ServerInfo calls. Version is public so an unauthenticated
+// upgrade process can check whether a restart took.
+type Server struct {
+	source *serverinfo.Source
+}
+
+var _ server_v1alpha.ServerInfo = (*Server)(nil)
+
+func NewServer(source *serverinfo.Source) *Server {
+	return &Server{source: source}
+}
+
+func (s *Server) Version(_ context.Context, state *server_v1alpha.ServerInfoVersion) error {
+	info := s.source.Info()
+	results := state.Results()
+	results.SetVersion(info.Version)
+	results.SetCommit(info.Commit)
+	if !info.BuildDate.IsZero() {
+		results.SetBuildDate(standard.ToTimestamp(info.BuildDate))
+	}
+	results.SetRuntimeInstanceId(info.InstanceID)
+	results.SetStartedAt(standard.ToTimestamp(info.StartedAt))
+	results.SetReady(info.Ready)
+	results.SetInstallKind(string(info.InstallKind))
+	return nil
+}

--- a/servers/serverinfo/serverinfo_test.go
+++ b/servers/serverinfo/serverinfo_test.go
@@ -1,0 +1,43 @@
+package serverinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/server/server_v1alpha"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/serverinfo"
+)
+
+type noopCall struct{}
+
+func (noopCall) NewClient(*rpc.Capability) rpc.Client         { return nil }
+func (noopCall) Args(any)                                     {}
+func (noopCall) Results(any)                                  {}
+func (noopCall) NewCapability(*rpc.Interface) *rpc.Capability { return nil }
+func (noopCall) IsAuthenticated() bool                        { return false }
+
+func TestVersionReportsSourceSnapshot(t *testing.T) {
+	source := serverinfo.New()
+	srv := NewServer(source)
+
+	call := func() *server_v1alpha.ServerInfoVersionResults {
+		state := &server_v1alpha.ServerInfoVersion{Call: noopCall{}}
+		require.NoError(t, srv.Version(context.Background(), state))
+		return state.Results()
+	}
+
+	before := call()
+	data, err := before.MarshalJSON()
+	require.NoError(t, err)
+	require.Contains(t, string(data), source.InstanceID())
+	require.Contains(t, string(data), `"ready":false`)
+
+	source.MarkReady()
+	after := call()
+	data, err = after.MarshalJSON()
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"ready":true`)
+	require.NotContains(t, string(data), `"started_at":null`)
+}


### PR DESCRIPTION
A running server had no way to describe itself. The CLI's `miren version` only ever reported the CLI, the health endpoint said "healthy" and nothing else, and after a restart nothing told you whether you'd reached a new process or the old one still limping. This is the version-discovery half of RFD 66, and it lays the groundwork the upgrade executor needs next.

The first rev gives the server one source of truth about itself (`pkg/serverinfo`): build info, a per-process instance id, a start time, an install kind, and a `ready` flag that flips only once the boot graph has started everything. Three surfaces read from it: a new public `Version` RPC, a `server` block in the health response, and `runtime_instance_id` in the cloud uplink's hello and status report. All additive; cloud can start reading the new field whenever it wants, no handshake rev.

The second rev puts it in front of people. `miren version --server` shows CLI and server side by side from any remote client and says which one to upgrade when they disagree. `doctor` gets a Version check that treats a server too old to answer as exactly the diagnosis it is, with the upgrade command as the fix.

```
$ miren doctor
  [✓] Configuration   1 cluster, active: prod
  [✓] Server          connected to cluster.example.com:8443
  [!] Version         server does not report its version (CLI v0.14.0)
  [✓] Authentication  ...
```

Container installs report `install_kind: container` here; that's the signal the next PR uses to refuse an upgrade cleanly rather than half-doing one.

Part of MIR-1707
