### PR TITLE
Serve app usage from the metrics store, with time series and a per-sandbox breakdown

### DIFF
--- a/api/usage/rpc.yml
+++ b/api/usage/rpc.yml
@@ -319,6 +319,17 @@ types:
           app still gets a row: an app that has stopped reporting is a finding,
           and dropping it would make a broken telemetry pipeline look like an
           idle cluster.
+      - name: historical
+        type: bool
+        index: 9
+        doc: |
+          True when this app has no live sandboxes and the row exists only
+          because the window contains its samples. Rows are sourced from the
+          metrics store, which keeps samples far longer than the entity store
+          keeps a dead sandbox, so a window reaching into the past can name an
+          app that has since been deleted. That is the right answer to a
+          historical question and the wrong one to "what is running", and this
+          is what tells the two apart.
 
   - type: Selector
     doc: |
@@ -422,6 +433,30 @@ types:
           Per-container breakdown. The stored series sum a sandbox's containers
           before they are written, so this needs the live per-node probe and is
           not yet served from the metrics store.
+      - name: step_seconds
+        type: int64
+        index: 2
+        doc: Resolution of any returned series; 0 derives one from the window
+
+  - type: AppDetailOptions
+    doc: |
+      What to include alongside one app's usage.
+
+      Separate from DetailOptions rather than shared with it: a sandbox can be
+      asked for a per-container split and an app cannot, and an app can be asked
+      to leave out its addons and a sandbox cannot. One type would carry a field
+      that is meaningless on whichever surface it reached.
+    fields:
+      - name: include_series
+        type: bool
+        index: 0
+        doc: Include CPU and memory over time, summed across the app's sandboxes
+      - name: include_addons
+        type: bool
+        index: 1
+        doc: |
+          Count the app's dedicated addons toward its figures. Absent means yes;
+          set it false for the app's own code alone.
       - name: step_seconds
         type: int64
         index: 2
@@ -651,6 +686,39 @@ interfaces:
             type: list
             element: string
 
+      - name: getApp
+        doc: |
+          One app in detail, optionally with its recent history.
+
+          The series is what listApps cannot give: a row collapses the window to
+          one number, and "what has this app been doing" needs the shape of it.
+          Both the row and the series are read from the metrics store rather
+          than assembled from the sandboxes that happen to be alive, so a window
+          longer than the current deployment answers for the whole of it.
+
+          One app at a time, deliberately. A range query grouped across every
+          app in a cluster over a long window is a cardinality question nobody
+          has measured yet.
+        parameters:
+          - name: app
+            type: string
+            doc: App name, as the metrics label it
+          - name: window
+            type: Window
+          - name: options
+            type: AppDetailOptions
+        results:
+          - name: usage
+            type: AppUsage
+          - name: series
+            type: list
+            element: UsageSeries
+          - name: window
+            type: UsageWindow
+          - name: warnings
+            type: list
+            element: string
+
       # --- REST surface: flat scalars, GET bindings ---
       #
       # since and until are duration strings here ("30s", "5m", "1h") rather
@@ -874,6 +942,12 @@ interfaces:
             type: string
           - name: addons
             type: bool
+          - name: series
+            type: bool
+            doc: Include CPU and memory history
+          - name: step
+            type: string
+            doc: Series resolution as a duration ("30s"); derived from the window when empty
         results:
           - name: usage
             type: AppUsage
@@ -882,3 +956,6 @@ interfaces:
           - name: warnings
             type: list
             element: string
+          - name: series
+            type: list
+            element: UsageSeries

--- a/api/usage/rpc.yml
+++ b/api/usage/rpc.yml
@@ -461,6 +461,109 @@ types:
         type: int64
         index: 2
         doc: Resolution of any returned series; 0 derives one from the window
+      - name: include_contributors
+        type: bool
+        index: 3
+        doc: |
+          Break the figures down by the sandboxes that produced them, including
+          the ones that have since been replaced.
+      - name: contributor_series
+        type: bool
+        index: 4
+        doc: |
+          Give each contributor its own history as well. Costs two more range
+          queries in total, not two per sandbox.
+
+  - type: AppContributor
+    doc: |
+      One sandbox's share of an app's usage over the window.
+
+      This is what an app-level figure cannot say on its own: an app that used
+      two cores last Tuesday used them somewhere, and over a window longer than
+      a deployment the somewhere is usually a sandbox that no longer exists.
+
+      Every field here except the short ids and alive is read from the metric
+      labels, which is what lets a swept sandbox still account for itself.
+    fields:
+      - name: sandbox
+        type: string
+        index: 0
+        doc: Sandbox entity id, as the metrics label it
+      - name: sandbox_short_id
+        type: string
+        index: 1
+        doc: |
+          Empty for a sandbox the entity store has already swept. A short id is
+          allocated and stored on the entity rather than derived from its id, so
+          there is nothing left to recover it from once the entity is gone.
+      - name: service
+        type: string
+        index: 2
+        doc: Service name within the app, such as web or worker
+      - name: version
+        type: string
+        index: 3
+        doc: App version entity id this sandbox was running
+      - name: version_short_id
+        type: string
+        index: 4
+        doc: Empty for a swept version, for the same reason as sandbox_short_id
+      - name: node
+        type: string
+        index: 5
+        doc: Node entity id the sandbox ran on
+      - name: kind
+        type: string
+        index: 6
+        doc: app for one of the app's own services, addon for infrastructure it owns
+      - name: cpu
+        type: CpuUsage
+        index: 7
+        doc: |
+          Average cores used *while this sandbox was running*, not averaged
+          across the whole window. The distinction matters as soon as the window
+          is longer than a deployment: a sandbox that ran hot for ten minutes of
+          a week averages to almost nothing across the week, which answers a
+          question nobody asked. percent_of_node is not set here.
+      - name: memory
+        type: MemoryUsage
+        index: 8
+        doc: Memory while this sandbox was running, collapsed by the window's aggregate
+      - name: cpu_seconds
+        type: float64
+        index: 13
+        doc: |
+          Total CPU time this sandbox consumed inside the window.
+
+          This is the figure that actually adds up. Cores and bytes describe a
+          rate and a level, so they cannot be compared between sandboxes that
+          ran for different lengths of time; seconds can, and they sum to the
+          app's consumption for the window. "400 of the app's 1200 CPU-seconds"
+          is what "contributed" means.
+      - name: first_seen
+        type: standard.Timestamp
+        index: 9
+        doc: |
+          When this sandbox's first sample inside the window was written. Taken
+          together with last_seen this is the span it accounted for, which is
+          what makes a list of a week's sandboxes readable as a sequence of
+          deployments rather than an undated pile.
+      - name: last_seen
+        type: standard.Timestamp
+        index: 10
+      - name: alive
+        type: bool
+        index: 11
+        doc: |
+          Whether the sandbox is still in the entity store. False means it can
+          no longer be inspected, only accounted for.
+      - name: series
+        type: list
+        element: UsageSeries
+        index: 12
+        doc: |
+          This sandbox's own history, when contributor_series was asked for.
+          Enough to stack the contributors and see the app series come back.
 
   - type: ContainerUsage
     doc: |
@@ -718,6 +821,14 @@ interfaces:
           - name: warnings
             type: list
             element: string
+          - name: contributors
+            type: list
+            element: AppContributor
+            doc: |
+              Which sandboxes made up the figures, busiest first. Sourced from
+              the metric labels, so it reaches the sandboxes the entity store
+              has already forgotten -- which over any window longer than a
+              deployment is most of them.
 
       # --- REST surface: flat scalars, GET bindings ---
       #
@@ -948,6 +1059,12 @@ interfaces:
           - name: step
             type: string
             doc: Series resolution as a duration ("30s"); derived from the window when empty
+          - name: contributors
+            type: bool
+            doc: Break the figures down by the sandboxes that produced them
+          - name: contributor_series
+            type: bool
+            doc: Give each contributor its own history as well
         results:
           - name: usage
             type: AppUsage
@@ -959,3 +1076,6 @@ interfaces:
           - name: series
             type: list
             element: UsageSeries
+          - name: contributors
+            type: list
+            element: AppContributor

--- a/api/usage/usage_v1alpha/rpc.gen.go
+++ b/api/usage/usage_v1alpha/rpc.gen.go
@@ -1000,6 +1000,7 @@ type appUsageData struct {
 	ServiceCount *int64          `cbor:"6,keyasint,omitempty" json:"service_count,omitempty"`
 	AddonCount   *int64          `cbor:"7,keyasint,omitempty" json:"addon_count,omitempty"`
 	Stale        *bool           `cbor:"8,keyasint,omitempty" json:"stale,omitempty"`
+	Historical   *bool           `cbor:"9,keyasint,omitempty" json:"historical,omitempty"`
 }
 
 type AppUsage struct {
@@ -1130,6 +1131,21 @@ func (v *AppUsage) Stale() bool {
 
 func (v *AppUsage) SetStale(stale bool) {
 	v.data.Stale = &stale
+}
+
+func (v *AppUsage) HasHistorical() bool {
+	return v.data.Historical != nil
+}
+
+func (v *AppUsage) Historical() bool {
+	if v.data.Historical == nil {
+		return false
+	}
+	return *v.data.Historical
+}
+
+func (v *AppUsage) SetHistorical(historical bool) {
+	v.data.Historical = &historical
 }
 
 func (v *AppUsage) MarshalCBOR() ([]byte, error) {
@@ -1487,6 +1503,77 @@ func (v *DetailOptions) MarshalJSON() ([]byte, error) {
 }
 
 func (v *DetailOptions) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type appDetailOptionsData struct {
+	IncludeSeries *bool  `cbor:"0,keyasint,omitempty" json:"include_series,omitempty"`
+	IncludeAddons *bool  `cbor:"1,keyasint,omitempty" json:"include_addons,omitempty"`
+	StepSeconds   *int64 `cbor:"2,keyasint,omitempty" json:"step_seconds,omitempty"`
+}
+
+type AppDetailOptions struct {
+	data appDetailOptionsData
+}
+
+func (v *AppDetailOptions) HasIncludeSeries() bool {
+	return v.data.IncludeSeries != nil
+}
+
+func (v *AppDetailOptions) IncludeSeries() bool {
+	if v.data.IncludeSeries == nil {
+		return false
+	}
+	return *v.data.IncludeSeries
+}
+
+func (v *AppDetailOptions) SetIncludeSeries(include_series bool) {
+	v.data.IncludeSeries = &include_series
+}
+
+func (v *AppDetailOptions) HasIncludeAddons() bool {
+	return v.data.IncludeAddons != nil
+}
+
+func (v *AppDetailOptions) IncludeAddons() bool {
+	if v.data.IncludeAddons == nil {
+		return false
+	}
+	return *v.data.IncludeAddons
+}
+
+func (v *AppDetailOptions) SetIncludeAddons(include_addons bool) {
+	v.data.IncludeAddons = &include_addons
+}
+
+func (v *AppDetailOptions) HasStepSeconds() bool {
+	return v.data.StepSeconds != nil
+}
+
+func (v *AppDetailOptions) StepSeconds() int64 {
+	if v.data.StepSeconds == nil {
+		return 0
+	}
+	return *v.data.StepSeconds
+}
+
+func (v *AppDetailOptions) SetStepSeconds(step_seconds int64) {
+	v.data.StepSeconds = &step_seconds
+}
+
+func (v *AppDetailOptions) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *AppDetailOptions) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *AppDetailOptions) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *AppDetailOptions) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
@@ -2240,6 +2327,106 @@ func (v *ResourceUsageListAppsResults) MarshalJSON() ([]byte, error) {
 }
 
 func (v *ResourceUsageListAppsResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageGetAppArgsData struct {
+	App     *string           `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	Window  *Window           `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Options *AppDetailOptions `cbor:"2,keyasint,omitempty" json:"options,omitempty"`
+}
+
+type ResourceUsageGetAppArgs struct {
+	call rpc.Call
+	data resourceUsageGetAppArgsData
+}
+
+func (v *ResourceUsageGetAppArgs) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *ResourceUsageGetAppArgs) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *ResourceUsageGetAppArgs) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageGetAppArgs) Window() *Window {
+	return v.data.Window
+}
+
+func (v *ResourceUsageGetAppArgs) HasOptions() bool {
+	return v.data.Options != nil
+}
+
+func (v *ResourceUsageGetAppArgs) Options() *AppDetailOptions {
+	return v.data.Options
+}
+
+func (v *ResourceUsageGetAppArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageGetAppArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageGetAppArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageGetAppArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type resourceUsageGetAppResultsData struct {
+	Usage    *AppUsage       `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
+	Series   *[]*UsageSeries `cbor:"1,keyasint,omitempty" json:"series,omitempty"`
+	Window   *UsageWindow    `cbor:"2,keyasint,omitempty" json:"window,omitempty"`
+	Warnings *[]string       `cbor:"3,keyasint,omitempty" json:"warnings,omitempty"`
+}
+
+type ResourceUsageGetAppResults struct {
+	call rpc.Call
+	data resourceUsageGetAppResultsData
+}
+
+func (v *ResourceUsageGetAppResults) SetUsage(usage *AppUsage) {
+	v.data.Usage = usage
+}
+
+func (v *ResourceUsageGetAppResults) SetSeries(series []*UsageSeries) {
+	x := slices.Clone(series)
+	v.data.Series = &x
+}
+
+func (v *ResourceUsageGetAppResults) SetWindow(window *UsageWindow) {
+	v.data.Window = window
+}
+
+func (v *ResourceUsageGetAppResults) SetWarnings(warnings []string) {
+	x := slices.Clone(warnings)
+	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageGetAppResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ResourceUsageGetAppResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ResourceUsageGetAppResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ResourceUsageGetAppResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
@@ -3093,6 +3280,8 @@ type resourceUsageHttpGetAppArgsData struct {
 	Until     *string `cbor:"2,keyasint,omitempty" json:"until,omitempty"`
 	Aggregate *string `cbor:"3,keyasint,omitempty" json:"aggregate,omitempty"`
 	Addons    *bool   `cbor:"4,keyasint,omitempty" json:"addons,omitempty"`
+	Series    *bool   `cbor:"5,keyasint,omitempty" json:"series,omitempty"`
+	Step      *string `cbor:"6,keyasint,omitempty" json:"step,omitempty"`
 }
 
 type ResourceUsageHttpGetAppArgs struct {
@@ -3155,6 +3344,28 @@ func (v *ResourceUsageHttpGetAppArgs) Addons() bool {
 	return *v.data.Addons
 }
 
+func (v *ResourceUsageHttpGetAppArgs) HasSeries() bool {
+	return v.data.Series != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) Series() bool {
+	if v.data.Series == nil {
+		return false
+	}
+	return *v.data.Series
+}
+
+func (v *ResourceUsageHttpGetAppArgs) HasStep() bool {
+	return v.data.Step != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) Step() string {
+	if v.data.Step == nil {
+		return ""
+	}
+	return *v.data.Step
+}
+
 func (v *ResourceUsageHttpGetAppArgs) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
@@ -3172,9 +3383,10 @@ func (v *ResourceUsageHttpGetAppArgs) UnmarshalJSON(data []byte) error {
 }
 
 type resourceUsageHttpGetAppResultsData struct {
-	Usage    *AppUsage    `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
-	Window   *UsageWindow `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
-	Warnings *[]string    `cbor:"2,keyasint,omitempty" json:"warnings,omitempty"`
+	Usage    *AppUsage       `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
+	Window   *UsageWindow    `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Warnings *[]string       `cbor:"2,keyasint,omitempty" json:"warnings,omitempty"`
+	Series   *[]*UsageSeries `cbor:"3,keyasint,omitempty" json:"series,omitempty"`
 }
 
 type ResourceUsageHttpGetAppResults struct {
@@ -3193,6 +3405,11 @@ func (v *ResourceUsageHttpGetAppResults) SetWindow(window *UsageWindow) {
 func (v *ResourceUsageHttpGetAppResults) SetWarnings(warnings []string) {
 	x := slices.Clone(warnings)
 	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageHttpGetAppResults) SetSeries(series []*UsageSeries) {
+	x := slices.Clone(series)
+	v.data.Series = &x
 }
 
 func (v *ResourceUsageHttpGetAppResults) MarshalCBOR() ([]byte, error) {
@@ -3306,6 +3523,32 @@ func (t *ResourceUsageListApps) Args() *ResourceUsageListAppsArgs {
 }
 
 func (t *ResourceUsageListApps) Results() *ResourceUsageListAppsResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type ResourceUsageGetApp struct {
+	rpc.Call
+	args    ResourceUsageGetAppArgs
+	results ResourceUsageGetAppResults
+}
+
+func (t *ResourceUsageGetApp) Args() *ResourceUsageGetAppArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *ResourceUsageGetApp) Results() *ResourceUsageGetAppResults {
 	results := &t.results
 	if results.call != nil {
 		return results
@@ -3476,6 +3719,7 @@ type ResourceUsage interface {
 	GetSandbox(ctx context.Context, state *ResourceUsageGetSandbox) error
 	ListNodes(ctx context.Context, state *ResourceUsageListNodes) error
 	ListApps(ctx context.Context, state *ResourceUsageListApps) error
+	GetApp(ctx context.Context, state *ResourceUsageGetApp) error
 	HttpListSandboxes(ctx context.Context, state *ResourceUsageHttpListSandboxes) error
 	HttpGetSandbox(ctx context.Context, state *ResourceUsageHttpGetSandbox) error
 	HttpListNodes(ctx context.Context, state *ResourceUsageHttpListNodes) error
@@ -3501,6 +3745,10 @@ func (reexportResourceUsage) ListNodes(ctx context.Context, state *ResourceUsage
 }
 
 func (reexportResourceUsage) ListApps(ctx context.Context, state *ResourceUsageListApps) error {
+	panic("not implemented")
+}
+
+func (reexportResourceUsage) GetApp(ctx context.Context, state *ResourceUsageGetApp) error {
 	panic("not implemented")
 }
 
@@ -3572,6 +3820,16 @@ func AdaptResourceUsage(t ResourceUsage) *rpc.Interface {
 			Params:        []string{"selector", "window", "ordering"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListApps(ctx, &ResourceUsageListApps{Call: call})
+			},
+		},
+		{
+			Name:          "getApp",
+			InterfaceName: "ResourceUsage",
+			Index:         0,
+			Public:        false,
+			Params:        []string{"app", "window", "options"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.GetApp(ctx, &ResourceUsageGetApp{Call: call})
 			},
 		},
 		{
@@ -3710,7 +3968,7 @@ func AdaptResourceUsage(t ResourceUsage) *rpc.Interface {
 			Index:         0,
 			Public:        false,
 			RestOnly:      true,
-			Params:        []string{"app", "since", "until", "aggregate", "addons"},
+			Params:        []string{"app", "since", "until", "aggregate", "addons", "series", "step"},
 			HTTP: &rpc.HTTPBinding{
 				Verb:       "GET",
 				Path:       "/api/v1/usage/apps/{app}",
@@ -3721,6 +3979,8 @@ func AdaptResourceUsage(t ResourceUsage) *rpc.Interface {
 					{Name: "until", Kind: "string"},
 					{Name: "aggregate", Kind: "string"},
 					{Name: "addons", Kind: "bool"},
+					{Name: "series", Kind: "bool"},
+					{Name: "step", Kind: "string"},
 				},
 			},
 			Handler: func(ctx context.Context, call rpc.Call) error {
@@ -4081,4 +4341,63 @@ func (v ResourceUsageClient) ListApps(ctx context.Context, selector *Selector, w
 	}
 
 	return &ResourceUsageClientListAppsResults{client: v.Client, data: ret}, nil
+}
+
+type ResourceUsageClientGetAppResults struct {
+	client rpc.Client
+	data   resourceUsageGetAppResultsData
+}
+
+func (v *ResourceUsageClientGetAppResults) HasUsage() bool {
+	return v.data.Usage != nil
+}
+
+func (v *ResourceUsageClientGetAppResults) Usage() *AppUsage {
+	return v.data.Usage
+}
+
+func (v *ResourceUsageClientGetAppResults) HasSeries() bool {
+	return v.data.Series != nil
+}
+
+func (v *ResourceUsageClientGetAppResults) Series() []*UsageSeries {
+	if v.data.Series == nil {
+		return nil
+	}
+	return *v.data.Series
+}
+
+func (v *ResourceUsageClientGetAppResults) HasWindow() bool {
+	return v.data.Window != nil
+}
+
+func (v *ResourceUsageClientGetAppResults) Window() *UsageWindow {
+	return v.data.Window
+}
+
+func (v *ResourceUsageClientGetAppResults) HasWarnings() bool {
+	return v.data.Warnings != nil
+}
+
+func (v *ResourceUsageClientGetAppResults) Warnings() []string {
+	if v.data.Warnings == nil {
+		return nil
+	}
+	return *v.data.Warnings
+}
+
+func (v ResourceUsageClient) GetApp(ctx context.Context, app string, window *Window, options *AppDetailOptions) (*ResourceUsageClientGetAppResults, error) {
+	args := ResourceUsageGetAppArgs{}
+	args.data.App = &app
+	args.data.Window = window
+	args.data.Options = options
+
+	var ret resourceUsageGetAppResultsData
+
+	err := v.Call(ctx, "getApp", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceUsageClientGetAppResults{client: v.Client, data: ret}, nil
 }

--- a/api/usage/usage_v1alpha/rpc.gen.go
+++ b/api/usage/usage_v1alpha/rpc.gen.go
@@ -1507,9 +1507,11 @@ func (v *DetailOptions) UnmarshalJSON(data []byte) error {
 }
 
 type appDetailOptionsData struct {
-	IncludeSeries *bool  `cbor:"0,keyasint,omitempty" json:"include_series,omitempty"`
-	IncludeAddons *bool  `cbor:"1,keyasint,omitempty" json:"include_addons,omitempty"`
-	StepSeconds   *int64 `cbor:"2,keyasint,omitempty" json:"step_seconds,omitempty"`
+	IncludeSeries       *bool  `cbor:"0,keyasint,omitempty" json:"include_series,omitempty"`
+	IncludeAddons       *bool  `cbor:"1,keyasint,omitempty" json:"include_addons,omitempty"`
+	StepSeconds         *int64 `cbor:"2,keyasint,omitempty" json:"step_seconds,omitempty"`
+	IncludeContributors *bool  `cbor:"3,keyasint,omitempty" json:"include_contributors,omitempty"`
+	ContributorSeries   *bool  `cbor:"4,keyasint,omitempty" json:"contributor_series,omitempty"`
 }
 
 type AppDetailOptions struct {
@@ -1561,6 +1563,36 @@ func (v *AppDetailOptions) SetStepSeconds(step_seconds int64) {
 	v.data.StepSeconds = &step_seconds
 }
 
+func (v *AppDetailOptions) HasIncludeContributors() bool {
+	return v.data.IncludeContributors != nil
+}
+
+func (v *AppDetailOptions) IncludeContributors() bool {
+	if v.data.IncludeContributors == nil {
+		return false
+	}
+	return *v.data.IncludeContributors
+}
+
+func (v *AppDetailOptions) SetIncludeContributors(include_contributors bool) {
+	v.data.IncludeContributors = &include_contributors
+}
+
+func (v *AppDetailOptions) HasContributorSeries() bool {
+	return v.data.ContributorSeries != nil
+}
+
+func (v *AppDetailOptions) ContributorSeries() bool {
+	if v.data.ContributorSeries == nil {
+		return false
+	}
+	return *v.data.ContributorSeries
+}
+
+func (v *AppDetailOptions) SetContributorSeries(contributor_series bool) {
+	v.data.ContributorSeries = &contributor_series
+}
+
 func (v *AppDetailOptions) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
@@ -1574,6 +1606,242 @@ func (v *AppDetailOptions) MarshalJSON() ([]byte, error) {
 }
 
 func (v *AppDetailOptions) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type appContributorData struct {
+	Sandbox        *string             `cbor:"0,keyasint,omitempty" json:"sandbox,omitempty"`
+	SandboxShortId *string             `cbor:"1,keyasint,omitempty" json:"sandbox_short_id,omitempty"`
+	Service        *string             `cbor:"2,keyasint,omitempty" json:"service,omitempty"`
+	Version        *string             `cbor:"3,keyasint,omitempty" json:"version,omitempty"`
+	VersionShortId *string             `cbor:"4,keyasint,omitempty" json:"version_short_id,omitempty"`
+	Node           *string             `cbor:"5,keyasint,omitempty" json:"node,omitempty"`
+	Kind           *string             `cbor:"6,keyasint,omitempty" json:"kind,omitempty"`
+	Cpu            *CpuUsage           `cbor:"7,keyasint,omitempty" json:"cpu,omitempty"`
+	Memory         *MemoryUsage        `cbor:"8,keyasint,omitempty" json:"memory,omitempty"`
+	FirstSeen      *standard.Timestamp `cbor:"9,keyasint,omitempty" json:"first_seen,omitempty"`
+	LastSeen       *standard.Timestamp `cbor:"10,keyasint,omitempty" json:"last_seen,omitempty"`
+	Alive          *bool               `cbor:"11,keyasint,omitempty" json:"alive,omitempty"`
+	Series         *[]*UsageSeries     `cbor:"12,keyasint,omitempty" json:"series,omitempty"`
+	CpuSeconds     *float64            `cbor:"13,keyasint,omitempty" json:"cpu_seconds,omitempty"`
+}
+
+type AppContributor struct {
+	data appContributorData
+}
+
+func (v *AppContributor) HasSandbox() bool {
+	return v.data.Sandbox != nil
+}
+
+func (v *AppContributor) Sandbox() string {
+	if v.data.Sandbox == nil {
+		return ""
+	}
+	return *v.data.Sandbox
+}
+
+func (v *AppContributor) SetSandbox(sandbox string) {
+	v.data.Sandbox = &sandbox
+}
+
+func (v *AppContributor) HasSandboxShortId() bool {
+	return v.data.SandboxShortId != nil
+}
+
+func (v *AppContributor) SandboxShortId() string {
+	if v.data.SandboxShortId == nil {
+		return ""
+	}
+	return *v.data.SandboxShortId
+}
+
+func (v *AppContributor) SetSandboxShortId(sandbox_short_id string) {
+	v.data.SandboxShortId = &sandbox_short_id
+}
+
+func (v *AppContributor) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *AppContributor) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *AppContributor) SetService(service string) {
+	v.data.Service = &service
+}
+
+func (v *AppContributor) HasVersion() bool {
+	return v.data.Version != nil
+}
+
+func (v *AppContributor) Version() string {
+	if v.data.Version == nil {
+		return ""
+	}
+	return *v.data.Version
+}
+
+func (v *AppContributor) SetVersion(version string) {
+	v.data.Version = &version
+}
+
+func (v *AppContributor) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *AppContributor) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
+}
+
+func (v *AppContributor) SetVersionShortId(version_short_id string) {
+	v.data.VersionShortId = &version_short_id
+}
+
+func (v *AppContributor) HasNode() bool {
+	return v.data.Node != nil
+}
+
+func (v *AppContributor) Node() string {
+	if v.data.Node == nil {
+		return ""
+	}
+	return *v.data.Node
+}
+
+func (v *AppContributor) SetNode(node string) {
+	v.data.Node = &node
+}
+
+func (v *AppContributor) HasKind() bool {
+	return v.data.Kind != nil
+}
+
+func (v *AppContributor) Kind() string {
+	if v.data.Kind == nil {
+		return ""
+	}
+	return *v.data.Kind
+}
+
+func (v *AppContributor) SetKind(kind string) {
+	v.data.Kind = &kind
+}
+
+func (v *AppContributor) HasCpu() bool {
+	return v.data.Cpu != nil
+}
+
+func (v *AppContributor) Cpu() *CpuUsage {
+	return v.data.Cpu
+}
+
+func (v *AppContributor) SetCpu(cpu *CpuUsage) {
+	v.data.Cpu = cpu
+}
+
+func (v *AppContributor) HasMemory() bool {
+	return v.data.Memory != nil
+}
+
+func (v *AppContributor) Memory() *MemoryUsage {
+	return v.data.Memory
+}
+
+func (v *AppContributor) SetMemory(memory *MemoryUsage) {
+	v.data.Memory = memory
+}
+
+func (v *AppContributor) HasFirstSeen() bool {
+	return v.data.FirstSeen != nil
+}
+
+func (v *AppContributor) FirstSeen() *standard.Timestamp {
+	return v.data.FirstSeen
+}
+
+func (v *AppContributor) SetFirstSeen(first_seen *standard.Timestamp) {
+	v.data.FirstSeen = first_seen
+}
+
+func (v *AppContributor) HasLastSeen() bool {
+	return v.data.LastSeen != nil
+}
+
+func (v *AppContributor) LastSeen() *standard.Timestamp {
+	return v.data.LastSeen
+}
+
+func (v *AppContributor) SetLastSeen(last_seen *standard.Timestamp) {
+	v.data.LastSeen = last_seen
+}
+
+func (v *AppContributor) HasAlive() bool {
+	return v.data.Alive != nil
+}
+
+func (v *AppContributor) Alive() bool {
+	if v.data.Alive == nil {
+		return false
+	}
+	return *v.data.Alive
+}
+
+func (v *AppContributor) SetAlive(alive bool) {
+	v.data.Alive = &alive
+}
+
+func (v *AppContributor) HasSeries() bool {
+	return v.data.Series != nil
+}
+
+func (v *AppContributor) Series() []*UsageSeries {
+	if v.data.Series == nil {
+		return nil
+	}
+	return *v.data.Series
+}
+
+func (v *AppContributor) SetSeries(series []*UsageSeries) {
+	x := slices.Clone(series)
+	v.data.Series = &x
+}
+
+func (v *AppContributor) HasCpuSeconds() bool {
+	return v.data.CpuSeconds != nil
+}
+
+func (v *AppContributor) CpuSeconds() float64 {
+	if v.data.CpuSeconds == nil {
+		return 0
+	}
+	return *v.data.CpuSeconds
+}
+
+func (v *AppContributor) SetCpuSeconds(cpu_seconds float64) {
+	v.data.CpuSeconds = &cpu_seconds
+}
+
+func (v *AppContributor) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *AppContributor) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *AppContributor) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *AppContributor) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
@@ -2385,10 +2653,11 @@ func (v *ResourceUsageGetAppArgs) UnmarshalJSON(data []byte) error {
 }
 
 type resourceUsageGetAppResultsData struct {
-	Usage    *AppUsage       `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
-	Series   *[]*UsageSeries `cbor:"1,keyasint,omitempty" json:"series,omitempty"`
-	Window   *UsageWindow    `cbor:"2,keyasint,omitempty" json:"window,omitempty"`
-	Warnings *[]string       `cbor:"3,keyasint,omitempty" json:"warnings,omitempty"`
+	Usage        *AppUsage          `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
+	Series       *[]*UsageSeries    `cbor:"1,keyasint,omitempty" json:"series,omitempty"`
+	Window       *UsageWindow       `cbor:"2,keyasint,omitempty" json:"window,omitempty"`
+	Warnings     *[]string          `cbor:"3,keyasint,omitempty" json:"warnings,omitempty"`
+	Contributors *[]*AppContributor `cbor:"4,keyasint,omitempty" json:"contributors,omitempty"`
 }
 
 type ResourceUsageGetAppResults struct {
@@ -2412,6 +2681,11 @@ func (v *ResourceUsageGetAppResults) SetWindow(window *UsageWindow) {
 func (v *ResourceUsageGetAppResults) SetWarnings(warnings []string) {
 	x := slices.Clone(warnings)
 	v.data.Warnings = &x
+}
+
+func (v *ResourceUsageGetAppResults) SetContributors(contributors []*AppContributor) {
+	x := slices.Clone(contributors)
+	v.data.Contributors = &x
 }
 
 func (v *ResourceUsageGetAppResults) MarshalCBOR() ([]byte, error) {
@@ -3275,13 +3549,15 @@ func (v *ResourceUsageHttpListAppsResults) UnmarshalJSON(data []byte) error {
 }
 
 type resourceUsageHttpGetAppArgsData struct {
-	App       *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
-	Since     *string `cbor:"1,keyasint,omitempty" json:"since,omitempty"`
-	Until     *string `cbor:"2,keyasint,omitempty" json:"until,omitempty"`
-	Aggregate *string `cbor:"3,keyasint,omitempty" json:"aggregate,omitempty"`
-	Addons    *bool   `cbor:"4,keyasint,omitempty" json:"addons,omitempty"`
-	Series    *bool   `cbor:"5,keyasint,omitempty" json:"series,omitempty"`
-	Step      *string `cbor:"6,keyasint,omitempty" json:"step,omitempty"`
+	App               *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	Since             *string `cbor:"1,keyasint,omitempty" json:"since,omitempty"`
+	Until             *string `cbor:"2,keyasint,omitempty" json:"until,omitempty"`
+	Aggregate         *string `cbor:"3,keyasint,omitempty" json:"aggregate,omitempty"`
+	Addons            *bool   `cbor:"4,keyasint,omitempty" json:"addons,omitempty"`
+	Series            *bool   `cbor:"5,keyasint,omitempty" json:"series,omitempty"`
+	Step              *string `cbor:"6,keyasint,omitempty" json:"step,omitempty"`
+	Contributors      *bool   `cbor:"7,keyasint,omitempty" json:"contributors,omitempty"`
+	ContributorSeries *bool   `cbor:"8,keyasint,omitempty" json:"contributor_series,omitempty"`
 }
 
 type ResourceUsageHttpGetAppArgs struct {
@@ -3366,6 +3642,28 @@ func (v *ResourceUsageHttpGetAppArgs) Step() string {
 	return *v.data.Step
 }
 
+func (v *ResourceUsageHttpGetAppArgs) HasContributors() bool {
+	return v.data.Contributors != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) Contributors() bool {
+	if v.data.Contributors == nil {
+		return false
+	}
+	return *v.data.Contributors
+}
+
+func (v *ResourceUsageHttpGetAppArgs) HasContributorSeries() bool {
+	return v.data.ContributorSeries != nil
+}
+
+func (v *ResourceUsageHttpGetAppArgs) ContributorSeries() bool {
+	if v.data.ContributorSeries == nil {
+		return false
+	}
+	return *v.data.ContributorSeries
+}
+
 func (v *ResourceUsageHttpGetAppArgs) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
@@ -3383,10 +3681,11 @@ func (v *ResourceUsageHttpGetAppArgs) UnmarshalJSON(data []byte) error {
 }
 
 type resourceUsageHttpGetAppResultsData struct {
-	Usage    *AppUsage       `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
-	Window   *UsageWindow    `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
-	Warnings *[]string       `cbor:"2,keyasint,omitempty" json:"warnings,omitempty"`
-	Series   *[]*UsageSeries `cbor:"3,keyasint,omitempty" json:"series,omitempty"`
+	Usage        *AppUsage          `cbor:"0,keyasint,omitempty" json:"usage,omitempty"`
+	Window       *UsageWindow       `cbor:"1,keyasint,omitempty" json:"window,omitempty"`
+	Warnings     *[]string          `cbor:"2,keyasint,omitempty" json:"warnings,omitempty"`
+	Series       *[]*UsageSeries    `cbor:"3,keyasint,omitempty" json:"series,omitempty"`
+	Contributors *[]*AppContributor `cbor:"4,keyasint,omitempty" json:"contributors,omitempty"`
 }
 
 type ResourceUsageHttpGetAppResults struct {
@@ -3410,6 +3709,11 @@ func (v *ResourceUsageHttpGetAppResults) SetWarnings(warnings []string) {
 func (v *ResourceUsageHttpGetAppResults) SetSeries(series []*UsageSeries) {
 	x := slices.Clone(series)
 	v.data.Series = &x
+}
+
+func (v *ResourceUsageHttpGetAppResults) SetContributors(contributors []*AppContributor) {
+	x := slices.Clone(contributors)
+	v.data.Contributors = &x
 }
 
 func (v *ResourceUsageHttpGetAppResults) MarshalCBOR() ([]byte, error) {
@@ -3968,7 +4272,7 @@ func AdaptResourceUsage(t ResourceUsage) *rpc.Interface {
 			Index:         0,
 			Public:        false,
 			RestOnly:      true,
-			Params:        []string{"app", "since", "until", "aggregate", "addons", "series", "step"},
+			Params:        []string{"app", "since", "until", "aggregate", "addons", "series", "step", "contributors", "contributor_series"},
 			HTTP: &rpc.HTTPBinding{
 				Verb:       "GET",
 				Path:       "/api/v1/usage/apps/{app}",
@@ -3981,6 +4285,8 @@ func AdaptResourceUsage(t ResourceUsage) *rpc.Interface {
 					{Name: "addons", Kind: "bool"},
 					{Name: "series", Kind: "bool"},
 					{Name: "step", Kind: "string"},
+					{Name: "contributors", Kind: "bool"},
+					{Name: "contributor_series", Kind: "bool"},
 				},
 			},
 			Handler: func(ctx context.Context, call rpc.Call) error {
@@ -4384,6 +4690,17 @@ func (v *ResourceUsageClientGetAppResults) Warnings() []string {
 		return nil
 	}
 	return *v.data.Warnings
+}
+
+func (v *ResourceUsageClientGetAppResults) HasContributors() bool {
+	return v.data.Contributors != nil
+}
+
+func (v *ResourceUsageClientGetAppResults) Contributors() []*AppContributor {
+	if v.data.Contributors == nil {
+		return nil
+	}
+	return *v.data.Contributors
 }
 
 func (v ResourceUsageClient) GetApp(ctx context.Context, app string, window *Window, options *AppDetailOptions) (*ResourceUsageClientGetAppResults, error) {

--- a/cli/commands/sandbox_inspect.go
+++ b/cli/commands/sandbox_inspect.go
@@ -270,7 +270,17 @@ func inspectJSON(res *usage_v1alpha.ResourceUsageClientGetSandboxResults) inspec
 		})
 	}
 
-	for _, s := range res.Series() {
+	out.Series = seriesJSON(res.Series())
+
+	return out
+}
+
+// seriesJSON renders a history for a machine reader. Shared by the sandbox and
+// app detail views, which return the same series type.
+func seriesJSON(series []*usage_v1alpha.UsageSeries) []usageSeriesJSON {
+	out := make([]usageSeriesJSON, 0, len(series))
+
+	for _, s := range series {
 		sj := usageSeriesJSON{Metric: s.Metric()}
 		for _, p := range s.Points() {
 			sj.Points = append(sj.Points, usagePointJSON{
@@ -278,7 +288,7 @@ func inspectJSON(res *usage_v1alpha.ResourceUsageClientGetSandboxResults) inspec
 				Value: p.Value(),
 			})
 		}
-		out.Series = append(out.Series, sj)
+		out = append(out, sj)
 	}
 
 	return out

--- a/cli/commands/top.go
+++ b/cli/commands/top.go
@@ -59,8 +59,9 @@ type topOptions struct {
 	Since     string `long:"since" description:"Measure over this window, e.g. 30s, 5m, 1h (default 1m)"`
 	Aggregate string `long:"aggregate" description:"How to collapse the window: avg, max, min, last" default:"avg"`
 
-	Series bool   `long:"series" description:"With --apps --app, show one app's CPU and memory over time"`
-	Step   string `long:"step" description:"Resolution of --series, e.g. 30s, 5m (default: derived from --since)"`
+	Series       bool   `long:"series" description:"With --apps --app, show one app's CPU and memory over time"`
+	Step         string `long:"step" description:"Resolution of --series, e.g. 30s, 5m (default: derived from --since)"`
+	Contributors bool   `long:"contributors" description:"With --apps --app, list the sandboxes that made up the figures"`
 
 	Sort  string `long:"sort" description:"Sort by: cpu, memory, name, app, service, node" default:"cpu"`
 	Order string `long:"order" description:"Sort direction: desc or asc (default: desc for usage, asc for names)"`
@@ -77,21 +78,26 @@ type topOptions struct {
 // over a long window is a cost nobody has measured, so the server offers the
 // series per app and the flag has to name one.
 func checkSeriesFlags(opts topOptions) error {
-	if !opts.Series {
+	if !opts.Series && !opts.Contributors {
 		if opts.Step != "" {
 			return fmt.Errorf("--step only means something with --series")
 		}
 		return nil
 	}
 
+	flag := "--series"
+	if !opts.Series {
+		flag = "--contributors"
+	}
+
 	if !opts.Apps || strings.TrimSpace(opts.App) == "" {
-		return fmt.Errorf("--series needs --apps and --app <name>")
+		return fmt.Errorf("%s needs --apps and --app <name>", flag)
 	}
 
 	// A history already covers the window. Redrawing one every few seconds
 	// would re-run the same range query to show the same chart.
 	if opts.Watch || opts.Samples > 1 {
-		return fmt.Errorf("--series and --watch ask for opposite things: a history already spans the window")
+		return fmt.Errorf("%s and --watch ask for opposite things: the answer already spans the window", flag)
 	}
 
 	return nil
@@ -252,15 +258,16 @@ func (q topQuery) fetchApps(ctx context.Context) (*usage_v1alpha.ResourceUsageCl
 
 func (q topQuery) fetchApp(ctx context.Context) (*usage_v1alpha.ResourceUsageClientGetAppResults, error) {
 	var o usage_v1alpha.AppDetailOptions
-	o.SetIncludeSeries(true)
+	o.SetIncludeSeries(q.opts.Series)
 	o.SetIncludeAddons(!q.opts.NoAddons)
 	o.SetStepSeconds(int64(q.step.Seconds()))
+	o.SetIncludeContributors(q.opts.Contributors)
 
 	return q.client.GetApp(ctx, q.opts.App, q.window(), &o)
 }
 
 func (q topQuery) renderJSON(ctx *Context) error {
-	if q.opts.Series {
+	if q.opts.Series || q.opts.Contributors {
 		res, err := q.fetchApp(ctx)
 		if err != nil {
 			return err
@@ -292,7 +299,7 @@ func (q topQuery) renderJSON(ctx *Context) error {
 }
 
 func (q topQuery) render(ctx context.Context) (string, error) {
-	if q.opts.Series {
+	if q.opts.Series || q.opts.Contributors {
 		res, err := q.fetchApp(ctx)
 		if err != nil {
 			return "", err
@@ -446,7 +453,7 @@ func renderFooter(cluster *usage_v1alpha.ResourceTotals, w *usage_v1alpha.UsageW
 
 	if w != nil && w.HasStart() && w.HasEnd() {
 		span := standard.FromTimestamp(w.End()).Sub(standard.FromTimestamp(w.Start()))
-		fmt.Fprintf(&b, " over %s (%s)", formatDuration(span), w.Aggregate())
+		fmt.Fprintf(&b, " over %s (%s)", formatSpan(span), w.Aggregate())
 	}
 
 	if total > shown {
@@ -808,13 +815,14 @@ to contain its samples. Samples are kept for a month, so a long enough --since
 will name apps that have since been deleted.
 
 --series adds that app's CPU and memory over time, which a row cannot show: a
-row collapses the window to one number. It needs --apps and --app, because a
-history is one app's:
+row collapses the window to one number. --contributors breaks the figures down
+by the sandboxes that produced them, including the ones already replaced. Both
+need --apps and --app, because they answer for one app:
 
-  miren top --apps --app shop --since 24h --series
+  miren top --apps --app shop --since 168h --series --contributors
 
-Use --format json to get the points themselves, and --step to choose their
-resolution.
+Use --format json to get the points and the breakdown as data, and --step to
+choose the resolution of the history.
 
 There is no restart column. Miren replaces a failed sandbox rather than
 restarting it, so no single sandbox accumulates a restart count; repeated
@@ -901,11 +909,15 @@ func renderAppDetail(res *usage_v1alpha.ResourceUsageClientGetAppResults) string
 		}
 	}
 
+	if c := res.Contributors(); len(c) > 0 {
+		out += "\n" + renderContributors(c)
+	}
+
 	if w := res.Window(); w != nil && w.HasStart() && w.HasEnd() {
 		span := standard.FromTimestamp(w.End()).Sub(standard.FromTimestamp(w.Start()))
-		note := fmt.Sprintf("measured over %s (%s)", formatDuration(span), w.Aggregate())
+		note := fmt.Sprintf("measured over %s (%s)", formatSpan(span), w.Aggregate())
 		if step := w.StepSeconds(); step > 0 {
-			note += fmt.Sprintf(", one point every %s", formatDuration(time.Duration(step)*time.Second))
+			note += fmt.Sprintf(", one point every %s", formatSpan(time.Duration(step)*time.Second))
 		}
 		out += "\n" + mutedStyle.Render(note) + "\n"
 	}
@@ -913,6 +925,113 @@ func renderAppDetail(res *usage_v1alpha.ResourceUsageClientGetAppResults) string
 	out += renderWarnings(res.Warnings())
 
 	return out
+}
+
+// renderContributors lists the sandboxes behind an app's figures.
+//
+// Over any window longer than one deployment most of these no longer exist, so
+// the ACTIVE column -- when each was reporting -- is what makes the list read
+// as a sequence of deployments rather than a pile of ids.
+func renderContributors(contributors []*usage_v1alpha.AppContributor) string {
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Muted)
+
+	// CPU TIME is the column that compares: cores is a rate, and these
+	// sandboxes ran for wildly different lengths of time. CPU is what each was
+	// doing while it ran.
+	headers := []string{"SANDBOX", "SERVICE", "VERSION", "CPU", "CPU TIME", "MEM", "ACTIVE"}
+	rows := make([]ui.Row, 0, len(contributors))
+
+	for _, c := range contributors {
+		rows = append(rows, ui.Row{
+			contributorName(c),
+			orDash(c.Service()),
+			orDash(shortOrClean(c.VersionShortId(), c.Version())),
+			formatCores(c.Cpu().Cores()),
+			formatCPUSeconds(c.CpuSeconds()),
+			units.Bytes(c.Memory().Bytes()).Short(),
+			activeSpan(c),
+		})
+	}
+
+	return fmt.Sprintf("%s\n%s", labelStyle.Render("Contributing sandboxes:"), renderUsageTable(headers, rows))
+}
+
+// formatSpan renders a length of time at the scale it happens to be.
+//
+// formatDuration, which the download views use, stops rolling up at minutes --
+// fine for an ETA, unreadable for a week, which it renders as "10080m0s". These
+// views span seconds to weeks, so the unit has to follow the number.
+func formatSpan(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		if m := int(d.Minutes()) % 60; m > 0 {
+			return fmt.Sprintf("%dh%dm", int(d.Hours()), m)
+		}
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		days := int(d.Hours()) / 24
+		if h := int(d.Hours()) % 24; h > 0 {
+			return fmt.Sprintf("%dd%dh", days, h)
+		}
+		return fmt.Sprintf("%dd", days)
+	}
+}
+
+// formatCPUSeconds renders consumed CPU time. Sub-second values keep their
+// precision rather than rounding to "0s", which would hide the difference
+// between an idle sandbox and one that never ran.
+func formatCPUSeconds(seconds float64) string {
+	switch {
+	case seconds <= 0:
+		return "-"
+	case seconds < 1:
+		return fmt.Sprintf("%.3fs", seconds)
+	case seconds < 60:
+		return fmt.Sprintf("%.1fs", seconds)
+	default:
+		return formatSpan(time.Duration(seconds) * time.Second)
+	}
+}
+
+// contributorName marks a sandbox that can no longer be inspected, because the
+// first thing someone does with one of these ids is try to look it up.
+func contributorName(c *usage_v1alpha.AppContributor) string {
+	name := shortOrClean(c.SandboxShortId(), c.Sandbox())
+	if !c.Alive() {
+		name += " (gone)"
+	}
+	return name
+}
+
+// shortOrClean prefers the short id someone can type. A swept entity has none
+// -- it is allocated and stored rather than derived -- so the full id with its
+// prefix trimmed is the best that can be offered.
+func shortOrClean(short, full string) string {
+	if short != "" {
+		return short
+	}
+	return ui.CleanEntityID(full)
+}
+
+// activeSpan says when a sandbox was reporting, relative to now, so a week's
+// rows read as "3d ago for 6h" rather than as two timestamps to subtract.
+func activeSpan(c *usage_v1alpha.AppContributor) string {
+	if !c.HasFirstSeen() || !c.HasLastSeen() {
+		return "-"
+	}
+
+	first := standard.FromTimestamp(c.FirstSeen())
+	last := standard.FromTimestamp(c.LastSeen())
+
+	return fmt.Sprintf("%s ago for %s", formatSpan(time.Since(first)), formatSpan(last.Sub(first)))
 }
 
 type appUsageJSON struct {
@@ -980,19 +1099,66 @@ func appJSON(a *usage_v1alpha.AppUsage) appUsageJSON {
 // so a chart can label its axis without inferring the resolution from the gaps
 // between points.
 type appDetailResultJSON struct {
-	App         appUsageJSON      `json:"app"`
-	Series      []usageSeriesJSON `json:"series,omitempty"`
-	WindowStart string            `json:"window_start,omitempty"`
-	WindowEnd   string            `json:"window_end,omitempty"`
-	Aggregate   string            `json:"aggregate,omitempty"`
-	StepSeconds int64             `json:"step_seconds,omitempty"`
-	Warnings    []string          `json:"warnings,omitempty"`
+	App          appUsageJSON      `json:"app"`
+	Series       []usageSeriesJSON `json:"series,omitempty"`
+	Contributors []contributorJSON `json:"contributors,omitempty"`
+	WindowStart  string            `json:"window_start,omitempty"`
+	WindowEnd    string            `json:"window_end,omitempty"`
+	Aggregate    string            `json:"aggregate,omitempty"`
+	StepSeconds  int64             `json:"step_seconds,omitempty"`
+	Warnings     []string          `json:"warnings,omitempty"`
+}
+
+// contributorJSON is one sandbox's share of an app's usage. Ids are the full
+// entity ids rather than the display forms, because a machine reader joins on
+// them; short ids are absent for a sandbox the entity store has swept.
+type contributorJSON struct {
+	Sandbox        string            `json:"sandbox"`
+	SandboxShortID string            `json:"sandbox_short_id,omitempty"`
+	Service        string            `json:"service,omitempty"`
+	Version        string            `json:"version,omitempty"`
+	VersionShortID string            `json:"version_short_id,omitempty"`
+	Node           string            `json:"node,omitempty"`
+	Kind           string            `json:"kind,omitempty"`
+	CPUCores       float64           `json:"cpu_cores"`
+	CPUSeconds     float64           `json:"cpu_seconds"`
+	MemoryBytes    int64             `json:"memory_bytes"`
+	FirstSeen      string            `json:"first_seen,omitempty"`
+	LastSeen       string            `json:"last_seen,omitempty"`
+	Alive          bool              `json:"alive"`
+	Series         []usageSeriesJSON `json:"series,omitempty"`
+}
+
+func contributorsJSON(contributors []*usage_v1alpha.AppContributor) []contributorJSON {
+	out := make([]contributorJSON, 0, len(contributors))
+
+	for _, c := range contributors {
+		out = append(out, contributorJSON{
+			Sandbox:        c.Sandbox(),
+			SandboxShortID: c.SandboxShortId(),
+			Service:        c.Service(),
+			Version:        c.Version(),
+			VersionShortID: c.VersionShortId(),
+			Node:           c.Node(),
+			Kind:           c.Kind(),
+			CPUCores:       c.Cpu().Cores(),
+			CPUSeconds:     c.CpuSeconds(),
+			MemoryBytes:    c.Memory().Bytes(),
+			FirstSeen:      timestampRFC3339(c.FirstSeen()),
+			LastSeen:       timestampRFC3339(c.LastSeen()),
+			Alive:          c.Alive(),
+			Series:         seriesJSON(c.Series()),
+		})
+	}
+
+	return out
 }
 
 func appDetailJSON(res *usage_v1alpha.ResourceUsageClientGetAppResults) appDetailResultJSON {
 	out := appDetailResultJSON{
-		Series:   seriesJSON(res.Series()),
-		Warnings: res.Warnings(),
+		Series:       seriesJSON(res.Series()),
+		Contributors: contributorsJSON(res.Contributors()),
+		Warnings:     res.Warnings(),
 	}
 
 	if a := res.Usage(); a != nil {

--- a/cli/commands/top.go
+++ b/cli/commands/top.go
@@ -59,6 +59,9 @@ type topOptions struct {
 	Since     string `long:"since" description:"Measure over this window, e.g. 30s, 5m, 1h (default 1m)"`
 	Aggregate string `long:"aggregate" description:"How to collapse the window: avg, max, min, last" default:"avg"`
 
+	Series bool   `long:"series" description:"With --apps --app, show one app's CPU and memory over time"`
+	Step   string `long:"step" description:"Resolution of --series, e.g. 30s, 5m (default: derived from --since)"`
+
 	Sort  string `long:"sort" description:"Sort by: cpu, memory, name, app, service, node" default:"cpu"`
 	Order string `long:"order" description:"Sort direction: desc or asc (default: desc for usage, asc for names)"`
 	Limit int    `long:"limit" description:"Show at most this many rows (0 for all)"`
@@ -66,6 +69,32 @@ type topOptions struct {
 	Watch    bool   `short:"w" long:"watch" description:"Refresh continuously until interrupted"`
 	Interval string `long:"interval" description:"Refresh interval when watching" default:"5s"`
 	Samples  int    `long:"samples" description:"Stop after this many refreshes (0 for unlimited)"`
+}
+
+// checkSeriesFlags rejects the flag combinations --series cannot serve.
+//
+// A history is one app's. A range query grouped across every app in a cluster
+// over a long window is a cost nobody has measured, so the server offers the
+// series per app and the flag has to name one.
+func checkSeriesFlags(opts topOptions) error {
+	if !opts.Series {
+		if opts.Step != "" {
+			return fmt.Errorf("--step only means something with --series")
+		}
+		return nil
+	}
+
+	if !opts.Apps || strings.TrimSpace(opts.App) == "" {
+		return fmt.Errorf("--series needs --apps and --app <name>")
+	}
+
+	// A history already covers the window. Redrawing one every few seconds
+	// would re-run the same range query to show the same chart.
+	if opts.Watch || opts.Samples > 1 {
+		return fmt.Errorf("--series and --watch ask for opposite things: a history already spans the window")
+	}
+
+	return nil
 }
 
 // Top reports what a cluster is spending its CPU and memory on.
@@ -83,7 +112,16 @@ func Top(ctx *Context, opts topOptions) error {
 		return fmt.Errorf("--since: %w", err)
 	}
 
-	q := topQuery{client: uc, opts: opts, lookback: lookback}
+	step, err := parseTopDuration(opts.Step)
+	if err != nil {
+		return fmt.Errorf("--step: %w", err)
+	}
+
+	if err := checkSeriesFlags(opts); err != nil {
+		return err
+	}
+
+	q := topQuery{client: uc, opts: opts, lookback: lookback, step: step}
 
 	// JSON is a single snapshot even under --watch: a stream of whole documents
 	// is not something a consumer can parse, and the flags contradict rather
@@ -158,6 +196,7 @@ type topQuery struct {
 	client   *usage_v1alpha.ResourceUsageClient
 	opts     topOptions
 	lookback time.Duration
+	step     time.Duration
 }
 
 // selector, window and ordering build the three request groups once, so all
@@ -211,7 +250,24 @@ func (q topQuery) fetchApps(ctx context.Context) (*usage_v1alpha.ResourceUsageCl
 	return q.client.ListApps(ctx, q.selector(), q.window(), q.ordering())
 }
 
+func (q topQuery) fetchApp(ctx context.Context) (*usage_v1alpha.ResourceUsageClientGetAppResults, error) {
+	var o usage_v1alpha.AppDetailOptions
+	o.SetIncludeSeries(true)
+	o.SetIncludeAddons(!q.opts.NoAddons)
+	o.SetStepSeconds(int64(q.step.Seconds()))
+
+	return q.client.GetApp(ctx, q.opts.App, q.window(), &o)
+}
+
 func (q topQuery) renderJSON(ctx *Context) error {
+	if q.opts.Series {
+		res, err := q.fetchApp(ctx)
+		if err != nil {
+			return err
+		}
+		return PrintJSON(appDetailJSON(res))
+	}
+
 	if q.opts.Apps {
 		res, err := q.fetchApps(ctx)
 		if err != nil {
@@ -236,6 +292,14 @@ func (q topQuery) renderJSON(ctx *Context) error {
 }
 
 func (q topQuery) render(ctx context.Context) (string, error) {
+	if q.opts.Series {
+		res, err := q.fetchApp(ctx)
+		if err != nil {
+			return "", err
+		}
+		return renderAppDetail(res), nil
+	}
+
 	if q.opts.Apps {
 		res, err := q.fetchApps(ctx)
 		if err != nil {
@@ -736,6 +800,22 @@ asked for it -- and the SERVICES and ADDONS columns show how the total divides,
 so "2.1 cores, 1.6 of it Postgres" is one line rather than an investigation.
 Pass --no-addons to count only the app's own code.
 
+App rows are read from the metrics store rather than from the sandboxes that
+happen to be alive, so --since covers the whole window it names -- including the
+deployment before the current one. An app with nothing left running is marked
+"(gone)": it is in the listing only because the window reaches back far enough
+to contain its samples. Samples are kept for a month, so a long enough --since
+will name apps that have since been deleted.
+
+--series adds that app's CPU and memory over time, which a row cannot show: a
+row collapses the window to one number. It needs --apps and --app, because a
+history is one app's:
+
+  miren top --apps --app shop --since 24h --series
+
+Use --format json to get the points themselves, and --step to choose their
+resolution.
+
 There is no restart column. Miren replaces a failed sandbox rather than
 restarting it, so no single sandbox accumulates a restart count; repeated
 failure shows up as a crash loop on the pool, which "miren sandbox inspect"
@@ -746,42 +826,90 @@ finding rather than an omission: either it has just started, or metrics
 collection is down for it.
 `
 
+// SERVICES and ADDONS break the total down, so a busy app can be attributed to
+// the code someone wrote or to the database it depends on.
+var appTableHeaders = []string{"APP", "CPU", "SERVICES", "ADDONS", "MEM", "SANDBOXES"}
+
+func appTableRow(a *usage_v1alpha.AppUsage) ui.Row {
+	cpu, services, addons, mem := "-", "-", "-", "-"
+	if !a.Stale() {
+		cpu = formatCores(a.Total().CpuCores())
+		services = formatCores(a.Services().CpuCores())
+		addons = formatCores(a.Addons().CpuCores())
+		mem = units.Bytes(a.Total().MemoryBytes()).Short()
+	}
+
+	// An app with no addons shows a dash rather than 0%, so an empty column
+	// reads as "none of these" rather than "these are idle".
+	if a.AddonCount() == 0 {
+		addons = "-"
+	}
+
+	counts := fmt.Sprintf("%d", a.SandboxCount())
+	if a.AddonCount() > 0 {
+		counts = fmt.Sprintf("%d (+%d addon)", a.ServiceCount(), a.AddonCount())
+	}
+
+	// An app with no sandboxes left is in the listing only because the window
+	// reaches back far enough to contain its samples. Saying so beats a row
+	// that reads as something you could go and look at.
+	name := orDash(a.App())
+	if a.Historical() {
+		name += " (gone)"
+	}
+
+	return ui.Row{name, cpu, services, addons, mem, counts}
+}
+
 func renderAppTable(res *usage_v1alpha.ResourceUsageClientListAppsResults) string {
 	apps := res.Apps()
 	if len(apps) == 0 {
 		return "No apps are reporting usage.\n" + renderWarnings(res.Warnings())
 	}
 
-	// SERVICES and ADDONS break the total down, so a busy app can be attributed
-	// to the code someone wrote or to the database it depends on.
-	headers := []string{"APP", "CPU", "SERVICES", "ADDONS", "MEM", "SANDBOXES"}
 	rows := make([]ui.Row, 0, len(apps))
-
 	for _, a := range apps {
-		cpu, services, addons, mem := "-", "-", "-", "-"
-		if !a.Stale() {
-			cpu = formatCores(a.Total().CpuCores())
-			services = formatCores(a.Services().CpuCores())
-			addons = formatCores(a.Addons().CpuCores())
-			mem = units.Bytes(a.Total().MemoryBytes()).Short()
-		}
-
-		// An app with no addons shows a dash rather than 0%, so an empty column
-		// reads as "none of these" rather than "these are idle".
-		if a.AddonCount() == 0 {
-			addons = "-"
-		}
-
-		counts := fmt.Sprintf("%d", a.SandboxCount())
-		if a.AddonCount() > 0 {
-			counts = fmt.Sprintf("%d (+%d addon)", a.ServiceCount(), a.AddonCount())
-		}
-
-		rows = append(rows, ui.Row{orDash(a.App()), cpu, services, addons, mem, counts})
+		rows = append(rows, appTableRow(a))
 	}
 
-	out := renderUsageTable(headers, rows)
+	out := renderUsageTable(appTableHeaders, rows)
 	out += "\n" + renderFooter(res.Cluster(), res.Window(), int(res.TotalCount()), len(apps))
+	out += renderWarnings(res.Warnings())
+
+	return out
+}
+
+// renderAppDetail shows one app's row and what its history is made of.
+//
+// The points are counted rather than drawn, the way "miren sandbox inspect"
+// reports a sandbox's: a terminal chart of sixty points says less than the
+// numbers themselves, and --format json is there for anything that wants to
+// draw one.
+func renderAppDetail(res *usage_v1alpha.ResourceUsageClientGetAppResults) string {
+	a := res.Usage()
+	if a == nil {
+		return "No usage for that app in this window.\n" + renderWarnings(res.Warnings())
+	}
+
+	out := renderUsageTable(appTableHeaders, []ui.Row{appTableRow(a)})
+
+	if series := res.Series(); len(series) > 0 {
+		labelStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Muted)
+		out += fmt.Sprintf("\n%s\n", labelStyle.Render("History:"))
+		for _, sr := range series {
+			out += fmt.Sprintf("  %s: %d points\n", sr.Metric(), len(sr.Points()))
+		}
+	}
+
+	if w := res.Window(); w != nil && w.HasStart() && w.HasEnd() {
+		span := standard.FromTimestamp(w.End()).Sub(standard.FromTimestamp(w.Start()))
+		note := fmt.Sprintf("measured over %s (%s)", formatDuration(span), w.Aggregate())
+		if step := w.StepSeconds(); step > 0 {
+			note += fmt.Sprintf(", one point every %s", formatDuration(time.Duration(step)*time.Second))
+		}
+		out += "\n" + mutedStyle.Render(note) + "\n"
+	}
+
 	out += renderWarnings(res.Warnings())
 
 	return out
@@ -800,6 +928,7 @@ type appUsageJSON struct {
 	ServiceCount       int64   `json:"service_count"`
 	AddonCount         int64   `json:"addon_count"`
 	Stale              bool    `json:"stale"`
+	Historical         bool    `json:"historical,omitempty"`
 }
 
 type appListJSON struct {
@@ -823,20 +952,58 @@ func appsJSON(res *usage_v1alpha.ResourceUsageClientListAppsResults) appListJSON
 	}
 
 	for _, a := range res.Apps() {
-		out.Apps = append(out.Apps, appUsageJSON{
-			App:                a.App(),
-			AppID:              a.AppId(),
-			CPUCores:           a.Total().CpuCores(),
-			CPUCoresServices:   a.Services().CpuCores(),
-			CPUCoresAddons:     a.Addons().CpuCores(),
-			MemoryBytes:        a.Total().MemoryBytes(),
-			MemoryBytesService: a.Services().MemoryBytes(),
-			MemoryBytesAddons:  a.Addons().MemoryBytes(),
-			SandboxCount:       a.SandboxCount(),
-			ServiceCount:       a.ServiceCount(),
-			AddonCount:         a.AddonCount(),
-			Stale:              a.Stale(),
-		})
+		out.Apps = append(out.Apps, appJSON(a))
+	}
+
+	return out
+}
+
+func appJSON(a *usage_v1alpha.AppUsage) appUsageJSON {
+	return appUsageJSON{
+		App:                a.App(),
+		AppID:              a.AppId(),
+		CPUCores:           a.Total().CpuCores(),
+		CPUCoresServices:   a.Services().CpuCores(),
+		CPUCoresAddons:     a.Addons().CpuCores(),
+		MemoryBytes:        a.Total().MemoryBytes(),
+		MemoryBytesService: a.Services().MemoryBytes(),
+		MemoryBytesAddons:  a.Addons().MemoryBytes(),
+		SandboxCount:       a.SandboxCount(),
+		ServiceCount:       a.ServiceCount(),
+		AddonCount:         a.AddonCount(),
+		Stale:              a.Stale(),
+		Historical:         a.Historical(),
+	}
+}
+
+// appDetailResultJSON is one app with its history. The window carries the step
+// so a chart can label its axis without inferring the resolution from the gaps
+// between points.
+type appDetailResultJSON struct {
+	App         appUsageJSON      `json:"app"`
+	Series      []usageSeriesJSON `json:"series,omitempty"`
+	WindowStart string            `json:"window_start,omitempty"`
+	WindowEnd   string            `json:"window_end,omitempty"`
+	Aggregate   string            `json:"aggregate,omitempty"`
+	StepSeconds int64             `json:"step_seconds,omitempty"`
+	Warnings    []string          `json:"warnings,omitempty"`
+}
+
+func appDetailJSON(res *usage_v1alpha.ResourceUsageClientGetAppResults) appDetailResultJSON {
+	out := appDetailResultJSON{
+		Series:   seriesJSON(res.Series()),
+		Warnings: res.Warnings(),
+	}
+
+	if a := res.Usage(); a != nil {
+		out.App = appJSON(a)
+	}
+
+	if w := res.Window(); w != nil {
+		out.WindowStart = timestampRFC3339(w.Start())
+		out.WindowEnd = timestampRFC3339(w.End())
+		out.Aggregate = w.Aggregate()
+		out.StepSeconds = w.StepSeconds()
 	}
 
 	return out

--- a/cli/commands/top_test.go
+++ b/cli/commands/top_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,4 +80,25 @@ func TestTopWatchReportsAnErrorFromAnySuperseededChain(t *testing.T) {
 
 	r.Equal(boom, m.err)
 	r.NotNil(cmd, "an error quits rather than waiting for the current chain")
+}
+
+// formatDuration stops rolling up at minutes, which renders a week as
+// "10080m0s". These views span seconds to weeks, so the unit has to follow.
+func TestFormatSpanFollowsTheScale(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{45 * time.Second, "45s"},
+		{90 * time.Second, "1m"},
+		{2 * time.Hour, "2h"},
+		{2*time.Hour + 30*time.Minute, "2h30m"},
+		{7 * 24 * time.Hour, "7d"},
+		{50 * time.Hour, "2d2h"},
+		{-time.Second, "0s"},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, formatSpan(c.in), "formatSpan(%s)", c.in)
+	}
 }

--- a/docs/docs/command/top.md
+++ b/docs/docs/command/top.md
@@ -35,6 +35,22 @@ asked for it -- and the SERVICES and ADDONS columns show how the total divides,
 so "2.1 cores, 1.6 of it Postgres" is one line rather than an investigation.
 Pass --no-addons to count only the app's own code.
 
+App rows are read from the metrics store rather than from the sandboxes that
+happen to be alive, so --since covers the whole window it names -- including the
+deployment before the current one. An app with nothing left running is marked
+"(gone)": it is in the listing only because the window reaches back far enough
+to contain its samples. Samples are kept for a month, so a long enough --since
+will name apps that have since been deleted.
+
+--series adds that app's CPU and memory over time, which a row cannot show: a
+row collapses the window to one number. It needs --apps and --app, because a
+history is one app's:
+
+  miren top --apps --app shop --since 24h --series
+
+Use --format json to get the points themselves, and --step to choose their
+resolution.
+
 There is no restart column. Miren replaces a failed sandbox rather than
 restarting it, so no single sandbox accumulates a restart count; repeated
 failure shows up as a crash loop on the pool, which "miren sandbox inspect"
@@ -67,10 +83,12 @@ miren top [flags]
 - `--order` — Sort direction: desc or asc (default: desc for usage, asc for names)
 - `--runner` — Only show sandboxes on this runner (name, ID, or short ID)
 - `--samples` — Stop after this many refreshes (0 for unlimited) (default: `0`)
+- `--series` — With --apps --app, show one app's CPU and memory over time
 - `--service` — Only show sandboxes of this service (e.g. web, worker)
 - `--since` — Measure over this window, e.g. 30s, 5m, 1h (default 1m)
 - `--sort` — Sort by: cpu, memory, name, app, service, node (default: `cpu`)
 - `--status` — Only show sandboxes in this status
+- `--step` — Resolution of --series, e.g. 30s, 5m (default: derived from --since)
 - `--system` — Include addon and platform sandboxes
 - `--watch, -w` — Refresh continuously until interrupted
 

--- a/docs/docs/command/top.md
+++ b/docs/docs/command/top.md
@@ -43,13 +43,14 @@ to contain its samples. Samples are kept for a month, so a long enough --since
 will name apps that have since been deleted.
 
 --series adds that app's CPU and memory over time, which a row cannot show: a
-row collapses the window to one number. It needs --apps and --app, because a
-history is one app's:
+row collapses the window to one number. --contributors breaks the figures down
+by the sandboxes that produced them, including the ones already replaced. Both
+need --apps and --app, because they answer for one app:
 
-  miren top --apps --app shop --since 24h --series
+  miren top --apps --app shop --since 168h --series --contributors
 
-Use --format json to get the points themselves, and --step to choose their
-resolution.
+Use --format json to get the points and the breakdown as data, and --step to
+choose the resolution of the history.
 
 There is no restart column. Miren replaces a failed sandbox rather than
 restarting it, so no single sandbox accumulates a restart count; repeated
@@ -73,6 +74,7 @@ miren top [flags]
 - `--apps` — Show per-app totals instead of per-sandbox
 - `--cluster, -C` — Cluster name
 - `--config` — Path to the config file
+- `--contributors` — With --apps --app, list the sandboxes that made up the figures
 - `--format` — Output format (text, json) (default: `text`)
 - `--interval` — Refresh interval when watching (default: `5s`)
 - `--json` — Shorthand for --format json

--- a/pkg/workloadroles/roles.go
+++ b/pkg/workloadroles/roles.go
@@ -111,8 +111,8 @@ var (
 		// app the way rpc.AllowApp confines the blocks above.
 		"resourceusage": set(
 			// RPC surface.
-			"listsandboxes", "getsandbox", "listnodes", "listapps",
-			// The same six questions over plain HTTP GET.
+			"listsandboxes", "getsandbox", "listnodes", "listapps", "getapp",
+			// The same questions over plain HTTP GET.
 			"httplistsandboxes", "httpgetsandbox",
 			"httplistnodes", "httpgetnode",
 			"httplistapps", "httpgetapp",

--- a/servers/usage/apps.go
+++ b/servers/usage/apps.go
@@ -1,8 +1,10 @@
 package usage
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -29,18 +31,20 @@ type appListing struct {
 // different kind. Doing it here means "what is app X using" has one answer that
 // does not depend on the caller reconstructing Miren's model.
 func (s *Server) listApps(ctx context.Context, f filter, w window, ord ordering) (*appListing, error) {
-	// Every kind is loaded regardless of the addon setting: addons are needed
-	// either to be counted or to be reported as the zero they were excluded at.
-	// The app filter is applied per row rather than in the directory, since an
-	// addon's app comes from a different label than a service's.
+	// The directory is still loaded, but for a narrower job than it used to do.
+	// It no longer supplies the figures -- those come from the store, grouped
+	// by app -- only each app's entity id, and a row for an app that exists but
+	// has gone quiet. Every kind is loaded regardless of the addon setting:
+	// addons are needed either to be counted or to be reported as the zero they
+	// were excluded at.
 	dir, err := s.loadDirectory(ctx, filter{node: f.node, includeSystem: true})
 	if err != nil {
 		return nil, err
 	}
 
-	cpu, memory, warnings := s.appSamples(ctx, f.node, w, dir)
+	m, warnings := s.appSamples(ctx, f.node, w, dir)
 
-	rows, cluster := buildAppRows(dir, cpu, memory, f.app, f.includeAddons)
+	rows, cluster := buildAppRows(dir, m, f.app, f.includeAddons)
 
 	out := &appListing{cluster: cluster, warnings: warnings, total: int32(len(rows))}
 
@@ -95,37 +99,213 @@ func (s *Server) HttpListApps(ctx context.Context, state *usage_v1alpha.Resource
 	return nil
 }
 
-// HttpGetApp serves GET /api/v1/usage/apps/{app}, addressing one app.
-func (s *Server) HttpGetApp(ctx context.Context, state *usage_v1alpha.ResourceUsageHttpGetApp) error {
-	args := state.Args()
+// appDetailOptions is what a caller wants alongside one app's usage.
+type appDetailOptions struct {
+	series        bool
+	includeAddons bool
+	step          time.Duration
+}
 
-	name := args.App()
+// appDetailResult is what the core produces, before either surface shapes it
+// into its own generated result type. Those types are write-only, so the core
+// cannot hand one to the other -- it returns plain values instead.
+type appDetailResult struct {
+	usage    *usage_v1alpha.AppUsage
+	series   []*usage_v1alpha.UsageSeries
+	warnings []string
+
+	// step is the resolution the series were rendered at, zero when none were
+	// asked for.
+	step time.Duration
+}
+
+// appDetailSetter is the shape both surfaces' result types share.
+type appDetailSetter interface {
+	SetUsage(*usage_v1alpha.AppUsage)
+	SetSeries([]*usage_v1alpha.UsageSeries)
+	SetWindow(*usage_v1alpha.UsageWindow)
+	SetWarnings([]string)
+}
+
+func (d *appDetailResult) apply(set appDetailSetter, w window) {
+	set.SetUsage(d.usage)
+	set.SetSeries(d.series)
+
+	// The window reports the step the series actually used, not the one asked
+	// for: an unset or too-fine request is resolved server-side.
+	w.step = d.step
+	set.SetWindow(w.encode())
+	set.SetWarnings(d.warnings)
+}
+
+// appDetail is the one implementation behind GetApp (RPC) and HttpGetApp
+// (REST).
+//
+// The row is what listApps would have produced for this one app; the series is
+// what a row cannot say. A row collapses the window to one number, and "what
+// has this app been doing" needs the shape of it.
+func (s *Server) appDetail(
+	ctx context.Context,
+	name string,
+	w window,
+	opts appDetailOptions,
+) (*appDetailResult, error) {
 	if name == "" {
-		return fmt.Errorf("an app name is required")
+		return nil, fmt.Errorf("an app name is required")
 	}
 
-	w := restWindow(args.Since(), args.Until(), args.Aggregate())
-	f := filter{app: name, includeAddons: !args.HasAddons() || args.Addons()}
+	listing, err := s.listApps(ctx, filter{app: name, includeAddons: opts.includeAddons}, w, ordering{})
+	if err != nil {
+		return nil, err
+	}
 
-	listing, err := s.listApps(ctx, f, w, ordering{})
+	if len(listing.rows) == 0 {
+		// Not "has no running sandboxes" any more. Rows are sourced from the
+		// metrics store, so an app deleted this morning still answers for a
+		// window that contains it; an empty result means the window genuinely
+		// holds nothing.
+		return nil, fmt.Errorf("app %q has no usage in this window", name)
+	}
+
+	out := &appDetailResult{usage: listing.rows[0], warnings: listing.warnings}
+
+	if opts.series {
+		out.step = resolveStep(w, opts.step)
+
+		sel := labelSelector(map[string]string{labelApp: name})
+		series, warnings := s.appSeries(ctx, sel, w, out.step, opts.includeAddons)
+		out.series = series
+		out.warnings = append(out.warnings, warnings...)
+	}
+
+	return out, nil
+}
+
+// GetApp is the RPC surface.
+func (s *Server) GetApp(ctx context.Context, state *usage_v1alpha.ResourceUsageGetApp) error {
+	args := state.Args()
+
+	// Addons count toward an app's figures unless the caller says otherwise, so
+	// the absent case has to be told apart from an explicit false. The
+	// generated getter cannot do that on its own.
+	opts := appDetailOptions{includeAddons: true}
+	if o := args.Options(); o != nil {
+		opts.series = o.IncludeSeries()
+		opts.includeAddons = !o.HasIncludeAddons() || o.IncludeAddons()
+		opts.step = time.Duration(o.StepSeconds()) * time.Second
+	}
+
+	w := windowFrom(args.Window())
+
+	detail, err := s.appDetail(ctx, args.App(), w, opts)
 	if err != nil {
 		return err
 	}
 
-	res := state.Results()
-	res.SetWindow(w.encode())
-	res.SetWarnings(listing.warnings)
-
-	if len(listing.rows) == 0 {
-		return fmt.Errorf("app %q has no running sandboxes", name)
-	}
-
-	res.SetUsage(listing.rows[0])
+	detail.apply(state.Results(), w)
 
 	return nil
 }
 
-// appTally accumulates one app's sandboxes before they become a row.
+// HttpGetApp serves GET /api/v1/usage/apps/{app}, addressing one app.
+func (s *Server) HttpGetApp(ctx context.Context, state *usage_v1alpha.ResourceUsageHttpGetApp) error {
+	args := state.Args()
+
+	opts := appDetailOptions{
+		series:        args.Series(),
+		includeAddons: !args.HasAddons() || args.Addons(),
+	}
+	if d, ok := parseRESTDuration(args.Step()); ok {
+		opts.step = d
+	}
+
+	w := restWindow(args.Since(), args.Until(), args.Aggregate())
+
+	detail, err := s.appDetail(ctx, args.App(), w, opts)
+	if err != nil {
+		return err
+	}
+
+	detail.apply(state.Results(), w)
+
+	return nil
+}
+
+// appKey identifies one slice of an app's usage as the metrics store holds it:
+// the app, and whether the sandboxes behind it are the app's own services or
+// the addons it owns.
+type appKey struct {
+	app  string
+	kind string
+}
+
+// appMetrics is what the store says about every app in the window.
+type appMetrics struct {
+	cpu    map[appKey]float64
+	memory map[appKey]float64
+
+	// counts is how many sandboxes reported, which is not the same as how many
+	// were scheduled. A sandbox that never started never reports and so is
+	// never counted.
+	counts map[appKey]int64
+}
+
+func newAppMetrics() appMetrics {
+	return appMetrics{
+		cpu:    map[appKey]float64{},
+		memory: map[appKey]float64{},
+		counts: map[appKey]int64{},
+	}
+}
+
+// keys returns every group the store returned, in a fixed order.
+//
+// The order matters because it decides where an app the entity store has
+// already forgotten lands in the listing, and a row that moved between two
+// identical calls would read as a change in the cluster.
+func (m appMetrics) keys() []appKey {
+	seen := map[appKey]bool{}
+	var keys []appKey
+
+	add := func(k appKey) {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+
+	for k := range m.cpu {
+		add(k)
+	}
+	for k := range m.memory {
+		add(k)
+	}
+	for k := range m.counts {
+		add(k)
+	}
+
+	slices.SortFunc(keys, func(a, b appKey) int {
+		if c := cmp.Compare(a.app, b.app); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.kind, b.kind)
+	})
+
+	return keys
+}
+
+// appKeyOf reads a group out of a query result's labels. A row with no app
+// label belongs to no app -- a shared addon server, or an unclassifiable
+// sandbox -- and has nothing to roll up into.
+func appKeyOf(labels map[string]string) (appKey, bool) {
+	app := labels[labelApp]
+	if app == "" {
+		return appKey{}, false
+	}
+	return appKey{app: app, kind: labels[labelKind]}, true
+}
+
+// appTally accumulates one app's groups before they become a row.
 type appTally struct {
 	app      string
 	appID    string
@@ -135,26 +315,51 @@ type appTally struct {
 	serviceCount int64
 	addonCount   int64
 
-	// sampled records whether any sandbox of this app reported anything. An app
-	// whose every sandbox is silent is reported as stale rather than as idle.
+	// sampled records whether this app reported anything. An app that is
+	// entirely silent is reported as stale rather than as idle.
 	sampled bool
+
+	// live records whether the app still has sandboxes in the entity store. An
+	// app that does not is reported as historical: it is in the listing only
+	// because the window reaches back far enough to contain its samples.
+	live bool
 }
 
-// buildAppRows groups the directory's sandboxes by app and attaches their
-// samples.
+// buildAppRows unions what the metrics store measured with what the entity
+// store still knows about.
 //
-// The entity pass drives the row set here exactly as it does for sandboxes: an
-// app is a row because it has sandboxes, not because it has metrics. An app
-// whose sandboxes have all stopped reporting still appears, marked stale.
+// Neither source alone is the row set. The store holds the numbers, and holds
+// them for a month, so it is the only source that can answer a window longer
+// than the current deployment -- an app redeployed on Tuesday has no live
+// sandbox that can account for Monday. But an app whose sandboxes have all
+// stopped reporting has no samples at all, and dropping it would make a broken
+// telemetry pipeline look like an idle cluster.
+//
+// So: the entity pass contributes the apps that exist and their entity ids, the
+// metric pass contributes the figures and any app the entity store has already
+// swept, and a row says which of the two it came from through stale and
+// historical.
 func buildAppRows(
 	dir *directory,
-	cpu, memory map[string]float64,
+	m appMetrics,
 	appFilter string,
 	includeAddons bool,
 ) ([]*usage_v1alpha.AppUsage, totals) {
 	tallies := map[string]*appTally{}
 	order := []string{}
 
+	tally := func(app string) *appTally {
+		t, ok := tallies[app]
+		if !ok {
+			t = &appTally{app: app}
+			tallies[app] = t
+			order = append(order, app)
+		}
+		return t
+	}
+
+	// Entities first, so a live app keeps the position it has always had and
+	// only the historical ones are appended after.
 	for _, sb := range dir.sandboxes {
 		app := sb.ref.App()
 		if app == "" {
@@ -165,25 +370,31 @@ func buildAppRows(
 		if appFilter != "" && app != appFilter {
 			continue
 		}
+		if sb.ref.Kind() == string(compute.KindAddon) && !includeAddons {
+			continue
+		}
 
-		isAddon := sb.ref.Kind() == string(compute.KindAddon)
+		t := tally(app)
+		t.live = true
+		if t.appID == "" {
+			t.appID = sb.ref.AppId()
+		}
+	}
+
+	for _, k := range m.keys() {
+		if appFilter != "" && k.app != appFilter {
+			continue
+		}
+
+		isAddon := k.kind == string(compute.KindAddon)
 		if isAddon && !includeAddons {
 			continue
 		}
 
-		t, ok := tallies[app]
-		if !ok {
-			t = &appTally{app: app, appID: sb.ref.AppId()}
-			tallies[app] = t
-			order = append(order, app)
-		}
-		if t.appID == "" {
-			t.appID = sb.ref.AppId()
-		}
+		t := tally(k.app)
 
-		id := sb.ref.Sandbox()
-		cores, haveCPU := cpu[id]
-		bytes, haveMem := memory[id]
+		cores, haveCPU := m.cpu[k]
+		bytes, haveMem := m.memory[k]
 		if haveCPU || haveMem {
 			t.sampled = true
 		}
@@ -191,11 +402,11 @@ func buildAppRows(
 		if isAddon {
 			t.addons.cpuCores += cores
 			t.addons.memoryBytes += int64(bytes)
-			t.addonCount++
+			t.addonCount += m.counts[k]
 		} else {
 			t.services.cpuCores += cores
 			t.services.memoryBytes += int64(bytes)
-			t.serviceCount++
+			t.serviceCount += m.counts[k]
 		}
 	}
 
@@ -220,6 +431,7 @@ func buildAppRows(
 		row.SetServiceCount(t.serviceCount)
 		row.SetAddonCount(t.addonCount)
 		row.SetStale(!t.sampled)
+		row.SetHistorical(!t.live)
 
 		cluster.cpuCores += total.cpuCores
 		cluster.memoryBytes += total.memoryBytes
@@ -230,23 +442,32 @@ func buildAppRows(
 	return rows, cluster
 }
 
-// appSamples fetches per-sandbox usage for the app rollup.
+// appSamples reads one row per app and kind straight from the store.
 //
-// It groups by sandbox rather than by app, even though the answer is per-app,
-// because the services-versus-addons split has to be made per sandbox and the
-// metric labels do not carry that distinction -- the entity model does. Summing
-// in the query would produce a total that could not be broken apart again.
+// Grouping by app in the query, rather than by sandbox with the rollup done
+// afterwards, is what lets a historical window answer at all: a sandbox that
+// died an hour ago is gone from the entity store within the hour, but its
+// samples are kept for a month, and only a query that never mentions a sandbox
+// id can reach them.
+//
+// The kind rides along in the grouping so the services-versus-addons split
+// survives it. That split used to be made per sandbox because the metric labels
+// were thought not to carry it; miren.kind is now stamped onto every series
+// from the same compute.SandboxKind the entity path uses, so the store can make
+// the same distinction the entity model does.
+//
+// Three queries answer the whole cluster, and none of them grows with the
+// number of sandboxes.
 func (s *Server) appSamples(
 	ctx context.Context,
 	node string,
 	w window,
 	dir *directory,
-) (cpu, memory map[string]float64, warnings []string) {
-	cpu = map[string]float64{}
-	memory = map[string]float64{}
+) (appMetrics, []string) {
+	m := newAppMetrics()
 
 	if s.Reader == nil {
-		return cpu, memory, []string{"no metrics backend configured; usage figures are unavailable"}
+		return m, []string{"no metrics backend configured; usage figures are unavailable"}
 	}
 
 	selector := ""
@@ -257,20 +478,104 @@ func (s *Server) appSamples(
 	}
 
 	dur := w.duration()
+	group := groupKey(labelApp, labelKind)
 
-	if vals, err := s.instantByLabel(ctx, cpuCoresQuery(labelSandbox, selector, dur, w.aggregate), labelSandbox, w.end); err != nil {
-		warnings = append(warnings, "cpu usage unavailable: "+err.Error())
-	} else {
-		cpu = vals
+	var warnings []string
+
+	collect := func(what, query string, store func(appKey, float64)) {
+		rows, err := s.instantRows(ctx, query, w.end)
+		if err != nil {
+			warnings = append(warnings, what+" unavailable: "+err.Error())
+			return
+		}
+		for _, r := range rows {
+			if k, ok := appKeyOf(r.labels); ok {
+				store(k, r.value)
+			}
+		}
 	}
 
-	if vals, err := s.instantByLabel(ctx, memoryBytesQuery(labelSandbox, selector, dur, w.aggregate), labelSandbox, w.end); err != nil {
-		warnings = append(warnings, "memory usage unavailable: "+err.Error())
-	} else {
-		memory = vals
+	collect("cpu usage", cpuCoresQuery(group, selector, dur, w.aggregate),
+		func(k appKey, v float64) { m.cpu[k] = v })
+
+	collect("memory usage", memoryBytesQuery(group, selector, dur, w.aggregate),
+		func(k appKey, v float64) { m.memory[k] = v })
+
+	// The counts say what a row is made of, so "1.5 cores of addon" can be
+	// attributed to something. Their absence degrades a column rather than the
+	// answer, which is why this is a warning and not a failure.
+	collect("sandbox counts", sandboxCountQuery(selector, dur),
+		func(k appKey, v float64) { m.counts[k] = int64(v) })
+
+	return m, warnings
+}
+
+// appSeries fetches an app's CPU and memory over time, summed across every
+// sandbox that belongs to it.
+//
+// It groups by kind as well as by app and sums here rather than in the query,
+// because a caller may have excluded addons and a query that had already added
+// them in could not be taken apart again. The selector pins one app, so at most
+// two series come back per metric.
+//
+// That summing is what sandboxSeries does not do: it flattens every returned
+// series into one list of points, which is only safe because its selector pins
+// a single sandbox. Flattening here would concatenate an app's services and the
+// database behind it into one undifferentiated run.
+func (s *Server) appSeries(
+	ctx context.Context,
+	selector string,
+	w window,
+	step time.Duration,
+	includeAddons bool,
+) ([]*usage_v1alpha.UsageSeries, []string) {
+	if s.Reader == nil {
+		return nil, nil
 	}
 
-	return cpu, memory, warnings
+	group := groupKey(labelApp, labelKind)
+
+	queries := []struct {
+		metric string
+		query  string
+	}{
+		{"cpu_cores", cpuCoresQuery(group, selector, step, aggregateAvg)},
+		{"memory_bytes", memoryBytesQuery(group, selector, step, aggregateLast)},
+	}
+
+	var out []*usage_v1alpha.UsageSeries
+	var warnings []string
+
+	for _, q := range queries {
+		result, err := s.Reader.RangeQuery(ctx, q.query, w.start, w.end, promDuration(step))
+		if err != nil {
+			warnings = append(warnings, q.metric+" history unavailable: "+err.Error())
+			continue
+		}
+
+		// Every returned series is evaluated at the same step, so adding by
+		// timestamp lines the kinds up without any interpolation.
+		byTime := map[int64]float64{}
+		for _, r := range result.Data.Result {
+			if !includeAddons && r.Metric[labelKind] == string(compute.KindAddon) {
+				continue
+			}
+			for _, v := range r.Values {
+				at, val, ok := parseSample(v)
+				if !ok {
+					continue
+				}
+				byTime[at] += val
+			}
+		}
+
+		var series usage_v1alpha.UsageSeries
+		series.SetMetric(q.metric)
+		series.SetPoints(pointsInOrder(byTime))
+		out = append(out, &series)
+	}
+
+	return out, warnings
 }
 
 func sortApps(rows []*usage_v1alpha.AppUsage, ord ordering) {

--- a/servers/usage/apps.go
+++ b/servers/usage/apps.go
@@ -45,7 +45,14 @@ func (s *Server) listApps(ctx context.Context, f filter, w window, ord ordering)
 		return nil, nil, err
 	}
 
-	m, warnings := s.appSamples(ctx, f.node, w, dir)
+	// An unknown node is an empty listing, not the whole cluster. See
+	// nodeSelector.
+	selector, ok := nodeSelector(dir, f.node)
+	if !ok {
+		return &appListing{}, dir, nil
+	}
+
+	m, warnings := s.appSamples(ctx, selector, w)
 
 	rows, cluster := buildAppRows(dir, m, f.app, f.includeAddons)
 
@@ -494,21 +501,13 @@ func buildAppRows(
 // number of sandboxes.
 func (s *Server) appSamples(
 	ctx context.Context,
-	node string,
+	selector string,
 	w window,
-	dir *directory,
 ) (appMetrics, []string) {
 	m := newAppMetrics()
 
 	if s.Reader == nil {
 		return m, []string{"no metrics backend configured; usage figures are unavailable"}
-	}
-
-	selector := ""
-	if node != "" {
-		if n := matchNode(dir.nodes, node); n != nil {
-			selector = labelSelector(map[string]string{labelNode: string(n.id)})
-		}
 	}
 
 	dur := w.duration()

--- a/servers/usage/apps.go
+++ b/servers/usage/apps.go
@@ -30,7 +30,10 @@ type appListing struct {
 // app's database is a separate sandbox with a different label spelling and a
 // different kind. Doing it here means "what is app X using" has one answer that
 // does not depend on the caller reconstructing Miren's model.
-func (s *Server) listApps(ctx context.Context, f filter, w window, ord ordering) (*appListing, error) {
+// The directory is returned alongside the listing because the app detail path
+// needs the same entity view -- to say which contributing sandboxes still exist
+// -- and loading it twice would mean two passes over the entity store per call.
+func (s *Server) listApps(ctx context.Context, f filter, w window, ord ordering) (*appListing, *directory, error) {
 	// The directory is still loaded, but for a narrower job than it used to do.
 	// It no longer supplies the figures -- those come from the store, grouped
 	// by app -- only each app's entity id, and a row for an app that exists but
@@ -39,7 +42,7 @@ func (s *Server) listApps(ctx context.Context, f filter, w window, ord ordering)
 	// were excluded at.
 	dir, err := s.loadDirectory(ctx, filter{node: f.node, includeSystem: true})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	m, warnings := s.appSamples(ctx, f.node, w, dir)
@@ -51,7 +54,7 @@ func (s *Server) listApps(ctx context.Context, f filter, w window, ord ordering)
 	sortApps(rows, ord)
 	out.rows = rows[:ord.truncate(len(rows))]
 
-	return out, nil
+	return out, dir, nil
 }
 
 // ListApps is the RPC surface.
@@ -59,7 +62,7 @@ func (s *Server) ListApps(ctx context.Context, state *usage_v1alpha.ResourceUsag
 	args := state.Args()
 	w := windowFrom(args.Window())
 
-	listing, err := s.listApps(ctx, selectorToFilter(args.Selector()), w, orderingFrom(args.Ordering()))
+	listing, _, err := s.listApps(ctx, selectorToFilter(args.Selector()), w, orderingFrom(args.Ordering()))
 	if err != nil {
 		return err
 	}
@@ -83,7 +86,7 @@ func (s *Server) HttpListApps(ctx context.Context, state *usage_v1alpha.Resource
 	f := filter{node: args.Node(), includeAddons: !args.HasAddons() || args.Addons()}
 	ord := ordering{sort: args.Sort(), order: args.Order(), limit: int(args.Limit())}
 
-	listing, err := s.listApps(ctx, f, w, ord)
+	listing, _, err := s.listApps(ctx, f, w, ord)
 	if err != nil {
 		return err
 	}
@@ -101,18 +104,21 @@ func (s *Server) HttpListApps(ctx context.Context, state *usage_v1alpha.Resource
 
 // appDetailOptions is what a caller wants alongside one app's usage.
 type appDetailOptions struct {
-	series        bool
-	includeAddons bool
-	step          time.Duration
+	series            bool
+	includeAddons     bool
+	step              time.Duration
+	contributors      bool
+	contributorSeries bool
 }
 
 // appDetailResult is what the core produces, before either surface shapes it
 // into its own generated result type. Those types are write-only, so the core
 // cannot hand one to the other -- it returns plain values instead.
 type appDetailResult struct {
-	usage    *usage_v1alpha.AppUsage
-	series   []*usage_v1alpha.UsageSeries
-	warnings []string
+	usage        *usage_v1alpha.AppUsage
+	series       []*usage_v1alpha.UsageSeries
+	contributors []*usage_v1alpha.AppContributor
+	warnings     []string
 
 	// step is the resolution the series were rendered at, zero when none were
 	// asked for.
@@ -123,6 +129,7 @@ type appDetailResult struct {
 type appDetailSetter interface {
 	SetUsage(*usage_v1alpha.AppUsage)
 	SetSeries([]*usage_v1alpha.UsageSeries)
+	SetContributors([]*usage_v1alpha.AppContributor)
 	SetWindow(*usage_v1alpha.UsageWindow)
 	SetWarnings([]string)
 }
@@ -130,6 +137,7 @@ type appDetailSetter interface {
 func (d *appDetailResult) apply(set appDetailSetter, w window) {
 	set.SetUsage(d.usage)
 	set.SetSeries(d.series)
+	set.SetContributors(d.contributors)
 
 	// The window reports the step the series actually used, not the one asked
 	// for: an unset or too-fine request is resolved server-side.
@@ -154,7 +162,14 @@ func (s *Server) appDetail(
 		return nil, fmt.Errorf("an app name is required")
 	}
 
-	listing, err := s.listApps(ctx, filter{app: name, includeAddons: opts.includeAddons}, w, ordering{})
+	// Asking for contributor histories is asking for contributors. Requiring
+	// both flags would only be a way to get the combination wrong and receive
+	// an empty list.
+	if opts.contributorSeries {
+		opts.contributors = true
+	}
+
+	listing, dir, err := s.listApps(ctx, filter{app: name, includeAddons: opts.includeAddons}, w, ordering{})
 	if err != nil {
 		return nil, err
 	}
@@ -169,12 +184,27 @@ func (s *Server) appDetail(
 
 	out := &appDetailResult{usage: listing.rows[0], warnings: listing.warnings}
 
-	if opts.series {
-		out.step = resolveStep(w, opts.step)
+	sel := labelSelector(map[string]string{labelApp: name})
 
-		sel := labelSelector(map[string]string{labelApp: name})
+	if opts.series || opts.contributorSeries {
+		out.step = resolveStep(w, opts.step)
+	}
+
+	if opts.series {
 		series, warnings := s.appSeries(ctx, sel, w, out.step, opts.includeAddons)
 		out.series = series
+		out.warnings = append(out.warnings, warnings...)
+	}
+
+	if opts.contributors {
+		// The step the contributor histories use is the one already resolved
+		// above, so a stacked chart lines up with the app series rather than
+		// being sampled at its own resolution.
+		withStep := opts
+		withStep.step = out.step
+
+		contributors, warnings := s.appContributors(ctx, sel, w, withStep, dir)
+		out.contributors = contributors
 		out.warnings = append(out.warnings, warnings...)
 	}
 
@@ -193,6 +223,8 @@ func (s *Server) GetApp(ctx context.Context, state *usage_v1alpha.ResourceUsageG
 		opts.series = o.IncludeSeries()
 		opts.includeAddons = !o.HasIncludeAddons() || o.IncludeAddons()
 		opts.step = time.Duration(o.StepSeconds()) * time.Second
+		opts.contributors = o.IncludeContributors()
+		opts.contributorSeries = o.ContributorSeries()
 	}
 
 	w := windowFrom(args.Window())
@@ -212,8 +244,10 @@ func (s *Server) HttpGetApp(ctx context.Context, state *usage_v1alpha.ResourceUs
 	args := state.Args()
 
 	opts := appDetailOptions{
-		series:        args.Series(),
-		includeAddons: !args.HasAddons() || args.Addons(),
+		series:            args.Series(),
+		includeAddons:     !args.HasAddons() || args.Addons(),
+		contributors:      args.Contributors(),
+		contributorSeries: args.ContributorSeries(),
 	}
 	if d, ok := parseRESTDuration(args.Step()); ok {
 		opts.step = d

--- a/servers/usage/apps_test.go
+++ b/servers/usage/apps_test.go
@@ -17,6 +17,7 @@ import (
 	"miren.dev/runtime/api/compute"
 	"miren.dev/runtime/api/usage/usage_v1alpha"
 	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/pkg/entity"
 )
 
 // row builds one directory entry. The ref is what the entity pass would have
@@ -442,4 +443,32 @@ func (s *instantStub) reader(t *testing.T) *metrics.VictoriaMetricsReader {
 	t.Cleanup(srv.Close)
 
 	return metrics.NewVictoriaMetricsReader(slog.New(slog.DiscardHandler), srv.URL, 5*time.Second)
+}
+
+// An unknown node is an empty listing, not the whole cluster.
+//
+// While the rows came from the entity pass this held for free: loadDirectory
+// returns an empty directory for a node it cannot match, and an empty directory
+// meant no rows. Sourcing the figures from the store added a second resolution
+// that decided the selector, and an unmatched node there left it unconstrained,
+// so a mistyped --runner would query the whole cluster and report every app on
+// it as historical.
+func TestUnknownNodeSelectsNothingRatherThanEverything(t *testing.T) {
+	dir := &directory{nodes: map[entity.Id]*nodeInfo{
+		"node/real": {id: "node/real", name: "real"},
+	}}
+
+	sel, ok := nodeSelector(dir, "real")
+	require.True(t, ok)
+	assert.Equal(t, `{miren_node="node/real"}`, sel)
+
+	// The empty selector and "not found" have to be tellable apart, because
+	// they mean opposite things: everything, and nothing.
+	sel, ok = nodeSelector(dir, "typo")
+	assert.False(t, ok, "an unmatched node must not read as unconstrained")
+	assert.Equal(t, "", sel)
+
+	sel, ok = nodeSelector(dir, "")
+	assert.True(t, ok, "naming no node is unconstrained, which is not the same thing")
+	assert.Equal(t, "", sel)
 }

--- a/servers/usage/apps_test.go
+++ b/servers/usage/apps_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -404,4 +405,41 @@ func TestWindowReportsTheStepItsSeriesUsed(t *testing.T) {
 	// No collector here samples faster than once a second.
 	w.step = resolveStep(w, time.Millisecond)
 	assert.Equal(t, int64(1), w.encode().StepSeconds())
+}
+
+// instantStub answers instant queries, failing the ones whose text matches any
+// of fail. It exists to exercise the paths where one query answers and another
+// does not, which is where two query sets can disagree about what exists.
+type instantStub struct {
+	fail   []string
+	series []metrics.Result
+}
+
+func (s *instantStub) reader(t *testing.T) *metrics.VictoriaMetricsReader {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q, err := url.ParseQuery(r.URL.RawQuery)
+		require.NoError(t, err)
+
+		query := q.Get("query")
+		for _, bad := range s.fail {
+			if strings.Contains(query, bad) {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+
+		body, err := json.Marshal(metrics.QueryResult{
+			Status: "success",
+			Data:   metrics.Data{ResultType: "vector", Result: s.series},
+		})
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	return metrics.NewVictoriaMetricsReader(slog.New(slog.DiscardHandler), srv.URL, 5*time.Second)
 }

--- a/servers/usage/apps_test.go
+++ b/servers/usage/apps_test.go
@@ -1,17 +1,26 @@
 package usage
 
 import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"miren.dev/runtime/api/compute"
 	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/metrics"
 )
 
 // row builds one directory entry. The ref is what the entity pass would have
-// produced; the sample maps are keyed by the same sandbox id.
+// produced. It no longer carries usage: the figures come from the store now,
+// and the entity pass says only which apps exist.
 func row(sandbox, app, kind string) sandboxRow {
 	var ref usage_v1alpha.SandboxRef
 	ref.SetSandbox(sandbox)
@@ -19,6 +28,27 @@ func row(sandbox, app, kind string) sandboxRow {
 	ref.SetAppId("app/" + app)
 	ref.SetKind(kind)
 	return sandboxRow{ref: &ref}
+}
+
+// sample is one group as the store returns it: an app, a kind, and what that
+// slice of the app measured.
+type sample struct {
+	app   string
+	kind  string
+	cores float64
+	bytes float64
+	count int64
+}
+
+func storeSaw(samples ...sample) appMetrics {
+	m := newAppMetrics()
+	for _, s := range samples {
+		k := appKey{app: s.app, kind: s.kind}
+		m.cpu[k] = s.cores
+		m.memory[k] = s.bytes
+		m.counts[k] = s.count
+	}
+	return m
 }
 
 func findApp(rows []*usage_v1alpha.AppUsage, name string) *usage_v1alpha.AppUsage {
@@ -38,10 +68,13 @@ func TestAppRowsSumServicesAndAddons(t *testing.T) {
 		row("sb/web2", "shop", string(compute.KindApp)),
 		row("sb/pg", "shop", string(compute.KindAddon)),
 	}}
-	cpu := map[string]float64{"sb/web1": 0.5, "sb/web2": 0.25, "sb/pg": 1.5}
-	mem := map[string]float64{"sb/web1": 100, "sb/web2": 100, "sb/pg": 800}
 
-	rows, cluster := buildAppRows(dir, cpu, mem, "", true)
+	m := storeSaw(
+		sample{app: "shop", kind: string(compute.KindApp), cores: 0.75, bytes: 200, count: 2},
+		sample{app: "shop", kind: string(compute.KindAddon), cores: 1.5, bytes: 800, count: 1},
+	)
+
+	rows, cluster := buildAppRows(dir, m, "", true)
 	require.Len(t, rows, 1)
 
 	shop := rows[0]
@@ -67,9 +100,13 @@ func TestAppRowsCanExcludeAddons(t *testing.T) {
 		row("sb/web", "shop", string(compute.KindApp)),
 		row("sb/pg", "shop", string(compute.KindAddon)),
 	}}
-	cpu := map[string]float64{"sb/web": 0.5, "sb/pg": 1.5}
 
-	rows, _ := buildAppRows(dir, cpu, nil, "", false)
+	m := storeSaw(
+		sample{app: "shop", kind: string(compute.KindApp), cores: 0.5, count: 1},
+		sample{app: "shop", kind: string(compute.KindAddon), cores: 1.5, count: 1},
+	)
+
+	rows, _ := buildAppRows(dir, m, "", false)
 	require.Len(t, rows, 1)
 
 	assert.InDelta(t, 0.5, rows[0].Total().CpuCores(), 0.001)
@@ -84,9 +121,14 @@ func TestAppRowsSeparateApps(t *testing.T) {
 		row("sb/b", "blog", string(compute.KindApp)),
 		row("sb/c", "blog", string(compute.KindAddon)),
 	}}
-	cpu := map[string]float64{"sb/a": 1, "sb/b": 2, "sb/c": 3}
 
-	rows, _ := buildAppRows(dir, cpu, nil, "", true)
+	m := storeSaw(
+		sample{app: "shop", kind: string(compute.KindApp), cores: 1, count: 1},
+		sample{app: "blog", kind: string(compute.KindApp), cores: 2, count: 1},
+		sample{app: "blog", kind: string(compute.KindAddon), cores: 3, count: 1},
+	)
+
+	rows, _ := buildAppRows(dir, m, "", true)
 	require.Len(t, rows, 2)
 
 	assert.InDelta(t, 1.0, findApp(rows, "shop").Total().CpuCores(), 0.001)
@@ -94,19 +136,91 @@ func TestAppRowsSeparateApps(t *testing.T) {
 }
 
 // An app whose sandboxes have all gone quiet is a finding. Dropping the row
-// would make a broken telemetry pipeline look like an idle cluster.
+// would make a broken telemetry pipeline look like an idle cluster, which is
+// the whole reason the entity pass still contributes rows.
 func TestAppRowsReportSilentAppsAsStale(t *testing.T) {
 	dir := &directory{sandboxes: []sandboxRow{
 		row("sb/quiet", "shop", string(compute.KindApp)),
 		row("sb/busy", "blog", string(compute.KindApp)),
 	}}
-	cpu := map[string]float64{"sb/busy": 1}
 
-	rows, _ := buildAppRows(dir, cpu, nil, "", true)
+	m := storeSaw(sample{app: "blog", kind: string(compute.KindApp), cores: 1, count: 1})
+
+	rows, _ := buildAppRows(dir, m, "", true)
 	require.Len(t, rows, 2, "an app with no samples still gets a row")
 
-	assert.True(t, findApp(rows, "shop").Stale())
+	quiet := findApp(rows, "shop")
+	assert.True(t, quiet.Stale())
+	assert.False(t, quiet.Historical(), "it still exists; it is just not reporting")
+
 	assert.False(t, findApp(rows, "blog").Stale())
+}
+
+// The reason for sourcing rows from the store: a sandbox is swept from the
+// entity store about an hour after it dies, and its samples are kept for a
+// month. A window reaching past that hour can only be answered by the store.
+func TestAppRowsIncludeAppsOnlyTheStoreRemembers(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/live", "blog", string(compute.KindApp)),
+	}}
+
+	m := storeSaw(
+		sample{app: "blog", kind: string(compute.KindApp), cores: 1, count: 1},
+		sample{app: "shop", kind: string(compute.KindApp), cores: 4, bytes: 500, count: 2},
+	)
+
+	rows, cluster := buildAppRows(dir, m, "", true)
+	require.Len(t, rows, 2)
+
+	gone := findApp(rows, "shop")
+	require.NotNil(t, gone, "an app the entity store has forgotten still has usage to report")
+	assert.True(t, gone.Historical())
+	assert.False(t, gone.Stale(), "it reported; it just no longer exists")
+	assert.InDelta(t, 4.0, gone.Total().CpuCores(), 0.001)
+	assert.Equal(t, "", gone.AppId(), "there is no entity left to take an id from")
+
+	assert.False(t, findApp(rows, "blog").Historical())
+	assert.InDelta(t, 5.0, cluster.cpuCores, 0.001)
+}
+
+// Live apps keep the order the entity pass gave them; only the historical ones
+// are appended, and in a fixed order, so two identical calls agree.
+func TestAppRowsPlaceLiveAppsBeforeHistoricalOnes(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/live", "zebra", string(compute.KindApp)),
+	}}
+
+	m := storeSaw(
+		sample{app: "zebra", kind: string(compute.KindApp), cores: 1, count: 1},
+		sample{app: "beta", kind: string(compute.KindApp), cores: 1, count: 1},
+		sample{app: "alpha", kind: string(compute.KindApp), cores: 1, count: 1},
+	)
+
+	rows, _ := buildAppRows(dir, m, "", true)
+
+	names := make([]string, 0, len(rows))
+	for _, r := range rows {
+		names = append(names, r.App())
+	}
+	assert.Equal(t, []string{"zebra", "alpha", "beta"}, names)
+}
+
+// The counts now mean "sandboxes that reported", which is what the store can
+// actually say. They no longer come from the entity pass at all.
+func TestAppRowsCountReportingSandboxesNotEntities(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{
+		row("sb/web1", "shop", string(compute.KindApp)),
+		row("sb/web2", "shop", string(compute.KindApp)),
+	}}
+
+	// Only one of the two ever reported.
+	m := storeSaw(sample{app: "shop", kind: string(compute.KindApp), cores: 1, count: 1})
+
+	rows, _ := buildAppRows(dir, m, "", true)
+	require.Len(t, rows, 1)
+
+	assert.Equal(t, int64(1), rows[0].SandboxCount())
+	assert.Equal(t, int64(1), rows[0].ServiceCount())
 }
 
 // A sandbox belonging to no app -- a shared addon server -- has nothing to roll
@@ -116,14 +230,26 @@ func TestAppRowsSkipSandboxesWithNoApp(t *testing.T) {
 		row("sb/shared", "", string(compute.KindAddon)),
 		row("sb/web", "shop", string(compute.KindApp)),
 	}}
-	cpu := map[string]float64{"sb/shared": 9, "sb/web": 1}
 
-	rows, cluster := buildAppRows(dir, cpu, nil, "", true)
+	m := storeSaw(sample{app: "shop", kind: string(compute.KindApp), cores: 1, count: 1})
+
+	rows, cluster := buildAppRows(dir, m, "", true)
 
 	require.Len(t, rows, 1)
 	assert.Equal(t, "shop", rows[0].App())
 	assert.InDelta(t, 1.0, cluster.cpuCores, 0.001,
 		"an unattributable sandbox must not inflate the cluster total")
+}
+
+// The same rule on the metrics side, where it is enforced: a series with no app
+// label never becomes a group.
+func TestAppKeyOfRejectsUnattributableSeries(t *testing.T) {
+	_, ok := appKeyOf(map[string]string{labelSandbox: "sb/shared"})
+	assert.False(t, ok, "a series with no app label has nothing to roll up into")
+
+	k, ok := appKeyOf(map[string]string{labelApp: "shop", labelKind: "addon"})
+	require.True(t, ok)
+	assert.Equal(t, appKey{app: "shop", kind: "addon"}, k)
 }
 
 func TestAppRowsFilterByApp(t *testing.T) {
@@ -132,8 +258,150 @@ func TestAppRowsFilterByApp(t *testing.T) {
 		row("sb/b", "blog", string(compute.KindApp)),
 	}}
 
-	rows, _ := buildAppRows(dir, map[string]float64{"sb/a": 1, "sb/b": 2}, nil, "shop", true)
+	m := storeSaw(
+		sample{app: "shop", kind: string(compute.KindApp), cores: 1, count: 1},
+		sample{app: "blog", kind: string(compute.KindApp), cores: 2, count: 1},
+	)
+
+	rows, _ := buildAppRows(dir, m, "shop", true)
 
 	require.Len(t, rows, 1)
 	assert.Equal(t, "shop", rows[0].App())
+}
+
+// --- series ---
+
+// rangeStub answers query_range with one series per kind, recording what was
+// asked for.
+type rangeStub struct {
+	queries []string
+	step    string
+	series  []metrics.Result
+}
+
+func (s *rangeStub) reader(t *testing.T) *metrics.VictoriaMetricsReader {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q, err := url.ParseQuery(r.URL.RawQuery)
+		require.NoError(t, err)
+
+		s.queries = append(s.queries, q.Get("query"))
+		s.step = q.Get("step")
+
+		body, err := json.Marshal(metrics.QueryResult{
+			Status: "success",
+			Data:   metrics.Data{ResultType: "matrix", Result: s.series},
+		})
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	return metrics.NewVictoriaMetricsReader(slog.New(slog.DiscardHandler), srv.URL, 5*time.Second)
+}
+
+func kindSeries(kind string, samples ...[]any) metrics.Result {
+	return metrics.Result{
+		Metric: map[string]string{labelApp: "shop", labelKind: kind},
+		Values: samples,
+	}
+}
+
+func at(ts int64, value string) []any { return []any{float64(ts), value} }
+
+func seriesNamed(out []*usage_v1alpha.UsageSeries, metric string) *usage_v1alpha.UsageSeries {
+	for _, s := range out {
+		if s.Metric() == metric {
+			return s
+		}
+	}
+	return nil
+}
+
+// An app's services and the database behind it are separate series in the
+// store. A chart wants one line, so they are added at each timestamp -- not
+// concatenated, which is what flattening them would do.
+func TestAppSeriesSumsKindsPerTimestamp(t *testing.T) {
+	stub := &rangeStub{series: []metrics.Result{
+		kindSeries(string(compute.KindApp), at(100, "1"), at(160, "2")),
+		kindSeries(string(compute.KindAddon), at(100, "0.5"), at(160, "0.25")),
+	}}
+
+	s := &Server{Reader: stub.reader(t)}
+	w := window{start: time.Unix(100, 0), end: time.Unix(160, 0), aggregate: aggregateAvg}
+
+	out, warnings := s.appSeries(context.Background(), "", w, time.Minute, true)
+	require.Empty(t, warnings)
+	require.Len(t, out, 2)
+
+	cpu := seriesNamed(out, "cpu_cores")
+	require.NotNil(t, cpu)
+
+	points := cpu.Points()
+	require.Len(t, points, 2, "two kinds at two timestamps is two points, not four")
+
+	assert.InDelta(t, 1.5, points[0].Value(), 0.001)
+	assert.InDelta(t, 2.25, points[1].Value(), 0.001)
+
+	// Oldest first. A chart handed points out of order draws a scribble.
+	assert.Equal(t, int64(100), points[0].At().Seconds())
+	assert.Equal(t, int64(160), points[1].At().Seconds())
+}
+
+func TestAppSeriesDropsAddonsWhenExcluded(t *testing.T) {
+	stub := &rangeStub{series: []metrics.Result{
+		kindSeries(string(compute.KindApp), at(100, "1")),
+		kindSeries(string(compute.KindAddon), at(100, "9")),
+	}}
+
+	s := &Server{Reader: stub.reader(t)}
+	w := window{start: time.Unix(100, 0), end: time.Unix(160, 0), aggregate: aggregateAvg}
+
+	out, _ := s.appSeries(context.Background(), "", w, time.Minute, false)
+
+	cpu := seriesNamed(out, "cpu_cores")
+	require.NotNil(t, cpu)
+	require.Len(t, cpu.Points(), 1)
+	assert.InDelta(t, 1.0, cpu.Points()[0].Value(), 0.001,
+		"the addon's 9 cores must not reach a services-only series")
+}
+
+// Grouping by kind is not optional: it is what lets the addon exclusion above
+// happen after the query rather than in it.
+func TestAppSeriesGroupsByAppAndKind(t *testing.T) {
+	stub := &rangeStub{}
+
+	s := &Server{Reader: stub.reader(t)}
+	w := window{start: time.Unix(100, 0), end: time.Unix(160, 0), aggregate: aggregateAvg}
+
+	_, _ = s.appSeries(context.Background(), "", w, 30*time.Second, true)
+
+	require.Len(t, stub.queries, 2)
+	for _, q := range stub.queries {
+		assert.Contains(t, q, "by (miren_app, miren_kind)")
+	}
+	assert.Equal(t, "30s", stub.step)
+}
+
+// step_seconds is what tells a charting client the resolution it was given.
+// It stays unset when no series was drawn, so a caller cannot read a resolution
+// into points it never received.
+func TestWindowReportsTheStepItsSeriesUsed(t *testing.T) {
+	w := window{start: time.Unix(0, 0), end: time.Unix(600, 0), aggregate: aggregateAvg}
+
+	assert.Equal(t, int64(0), w.encode().StepSeconds())
+
+	w.step = resolveStep(w, 0)
+	assert.Equal(t, int64(10), w.encode().StepSeconds(),
+		"ten minutes at the default point count is a ten-second step")
+
+	w.step = resolveStep(w, 90*time.Second)
+	assert.Equal(t, int64(90), w.encode().StepSeconds(), "an explicit step wins")
+
+	// No collector here samples faster than once a second.
+	w.step = resolveStep(w, time.Millisecond)
+	assert.Equal(t, int64(1), w.encode().StepSeconds())
 }

--- a/servers/usage/contributors.go
+++ b/servers/usage/contributors.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	"miren.dev/runtime/api/compute"
 	"miren.dev/runtime/api/usage/usage_v1alpha"
 	"miren.dev/runtime/pkg/rpc/standard"
 )
@@ -134,9 +135,20 @@ func (s *Server) appContributors(
 			return
 		}
 		for _, r := range rows {
-			if id, ok := identityOf(r.labels); ok {
-				store(tally(id), r.value)
+			id, ok := identityOf(r.labels)
+			if !ok {
+				continue
 			}
+
+			// A caller that excluded addons from the row excluded them from
+			// the breakdown too. Leaving them in would list sandboxes the row
+			// above does not count, and their cpu_seconds would no longer sum
+			// to it -- which is the one property that field promises.
+			if !opts.includeAddons && id.kind == string(compute.KindAddon) {
+				continue
+			}
+
+			store(tally(id), r.value)
 		}
 	}
 

--- a/servers/usage/contributors.go
+++ b/servers/usage/contributors.go
@@ -1,0 +1,323 @@
+package usage
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// This file answers "which sandboxes made up that number".
+//
+// An app-level figure cannot say it, and over any window longer than one
+// deployment the answer is mostly sandboxes that no longer exist -- a dead one
+// is swept from the entity store within the hour, while its samples are kept
+// for a month. So the breakdown is read from the metric labels, which carry the
+// service, version, node and kind alongside the sandbox id and outlive the
+// entity by two orders of magnitude.
+
+// contributorIdentity is what the labels say a sandbox was. It is the map key
+// as well as the row, because the aggregate queries group by all of it at once
+// and the two have to line up.
+type contributorIdentity struct {
+	sandbox string
+	service string
+	version string
+	node    string
+	kind    string
+}
+
+func identityOf(labels map[string]string) (contributorIdentity, bool) {
+	sandbox := labels[labelSandbox]
+	if sandbox == "" {
+		return contributorIdentity{}, false
+	}
+
+	return contributorIdentity{
+		sandbox: sandbox,
+		service: labels[labelService],
+		version: labels[labelVersion],
+		node:    labels[labelNode],
+		kind:    labels[labelKind],
+	}, true
+}
+
+// contributorTally accumulates one sandbox before it becomes a row.
+type contributorTally struct {
+	id contributorIdentity
+
+	// cpuSeconds is how much CPU time this sandbox consumed in the window.
+	// Cores is derived from it and the active span rather than queried, because
+	// a rate averaged across a window the sandbox did not live through is not a
+	// figure anyone wants.
+	cpuSeconds float64
+	bytes      float64
+
+	first  time.Time
+	last   time.Time
+	series []*usage_v1alpha.UsageSeries
+}
+
+// activeSeconds is how long this sandbox was reporting inside the window.
+//
+// Floored at one second so a sandbox seen exactly once still divides. The
+// collectors sample about once a second, so a span shorter than that means one
+// sample, not an instantaneous sandbox.
+func (t *contributorTally) activeSeconds() float64 {
+	if t.first.IsZero() || t.last.IsZero() {
+		return 0
+	}
+
+	span := t.last.Sub(t.first).Seconds()
+	if span < 1 {
+		return 1
+	}
+
+	return span
+}
+
+// cores is the average cores this sandbox used while it was running.
+func (t *contributorTally) cores() float64 {
+	active := t.activeSeconds()
+	if active <= 0 {
+		return 0
+	}
+
+	return t.cpuSeconds / active
+}
+
+// contributorGrouping is the identity the aggregate queries group by. Every
+// label here is one the sandbox controller stamps on every series, so grouping
+// by them costs no extra cardinality: they are functionally dependent on the
+// sandbox id.
+func contributorGrouping() string {
+	return groupKey(labelSandbox, labelService, labelVersion, labelNode, labelKind)
+}
+
+// appContributors breaks an app's usage down by the sandboxes that produced it.
+//
+// Four instant queries regardless of how many sandboxes come back, plus two
+// range queries when histories are asked for. None of them grows with the
+// number of sandboxes, which is what makes a week-long question affordable.
+func (s *Server) appContributors(
+	ctx context.Context,
+	selector string,
+	w window,
+	opts appDetailOptions,
+	dir *directory,
+) ([]*usage_v1alpha.AppContributor, []string) {
+	if s.Reader == nil {
+		return nil, nil
+	}
+
+	dur := w.duration()
+	group := contributorGrouping()
+
+	tallies := map[string]*contributorTally{}
+	var warnings []string
+
+	tally := func(id contributorIdentity) *contributorTally {
+		t, ok := tallies[id.sandbox]
+		if !ok {
+			t = &contributorTally{id: id}
+			tallies[id.sandbox] = t
+		}
+		return t
+	}
+
+	collect := func(what, query string, store func(*contributorTally, float64)) {
+		rows, err := s.instantRows(ctx, query, w.end)
+		if err != nil {
+			warnings = append(warnings, what+" unavailable: "+err.Error())
+			return
+		}
+		for _, r := range rows {
+			if id, ok := identityOf(r.labels); ok {
+				store(tally(id), r.value)
+			}
+		}
+	}
+
+	collect("contributor cpu", contributorCPUSecondsQuery(group, selector, dur),
+		func(t *contributorTally, v float64) { t.cpuSeconds = v })
+
+	collect("contributor memory", contributorMemoryQuery(group, selector, dur, w.aggregate),
+		func(t *contributorTally, v float64) { t.bytes = v })
+
+	// The seen queries group by sandbox alone, so their rows carry no service,
+	// version or kind. They only ever update a tally the aggregates already
+	// created: a row built from a sample time alone would name nothing and
+	// report nothing, which is an id rather than a contributor. That matters
+	// when the aggregates fail and these succeed, which is the one case where
+	// the two query sets disagree about who exists.
+	updateSeen := func(what, query string, store func(*contributorTally, float64)) {
+		rows, err := s.instantRows(ctx, query, w.end)
+		if err != nil {
+			warnings = append(warnings, what+" unavailable: "+err.Error())
+			return
+		}
+		for _, r := range rows {
+			if t := tallies[r.labels[labelSandbox]]; t != nil {
+				store(t, r.value)
+			}
+		}
+	}
+
+	updateSeen("contributor start times", firstSeenQuery(selector, dur),
+		func(t *contributorTally, v float64) { t.first = time.Unix(int64(v), 0) })
+
+	updateSeen("contributor end times", lastSeenQuery(selector, dur),
+		func(t *contributorTally, v float64) { t.last = time.Unix(int64(v), 0) })
+
+	if opts.contributorSeries {
+		seriesWarnings := s.attachContributorSeries(ctx, selector, w, opts.step, tallies)
+		warnings = append(warnings, seriesWarnings...)
+	}
+
+	return buildContributorRows(tallies, dir), warnings
+}
+
+// attachContributorSeries fetches every contributor's history in two range
+// queries -- one per metric -- rather than two per sandbox, by grouping on the
+// sandbox label and splitting the result afterwards.
+func (s *Server) attachContributorSeries(
+	ctx context.Context,
+	selector string,
+	w window,
+	step time.Duration,
+	tallies map[string]*contributorTally,
+) []string {
+	var warnings []string
+
+	queries := []struct {
+		metric string
+		query  string
+	}{
+		{"cpu_cores", cpuCoresQuery(labelSandbox, selector, step, aggregateAvg)},
+		{"memory_bytes", memoryBytesQuery(labelSandbox, selector, step, aggregateLast)},
+	}
+
+	for _, q := range queries {
+		result, err := s.Reader.RangeQuery(ctx, q.query, w.start, w.end, promDuration(step))
+		if err != nil {
+			warnings = append(warnings, q.metric+" history unavailable: "+err.Error())
+			continue
+		}
+
+		for _, r := range result.Data.Result {
+			t := tallies[r.Metric[labelSandbox]]
+			if t == nil {
+				// A sandbox with a history but no aggregate has no row to hang
+				// it on. Inventing one here would contradict the totals.
+				continue
+			}
+
+			byTime := map[int64]float64{}
+			for _, v := range r.Values {
+				at, val, ok := parseSample(v)
+				if !ok {
+					continue
+				}
+				byTime[at] = val
+			}
+
+			var series usage_v1alpha.UsageSeries
+			series.SetMetric(q.metric)
+			series.SetPoints(pointsInOrder(byTime))
+			t.series = append(t.series, &series)
+		}
+	}
+
+	return warnings
+}
+
+// buildContributorRows turns the tallies into rows, busiest first.
+//
+// The directory is consulted only for what the labels cannot say: whether the
+// sandbox still exists, and the short ids someone could type. A short id is
+// allocated and stored on the entity rather than derived from its id
+// (pkg/entity/shortid.go), so once the entity is swept there is nothing left to
+// recover it from -- those fields stay empty and alive reports why.
+func buildContributorRows(
+	tallies map[string]*contributorTally,
+	dir *directory,
+) []*usage_v1alpha.AppContributor {
+	live := map[string]*usage_v1alpha.SandboxRef{}
+	versions := map[string]*appInfo{}
+	if dir != nil {
+		for _, sb := range dir.sandboxes {
+			live[sb.ref.Sandbox()] = sb.ref
+		}
+		versions = dir.versions
+	}
+
+	rows := make([]*usage_v1alpha.AppContributor, 0, len(tallies))
+
+	for _, t := range tallies {
+		var c usage_v1alpha.AppContributor
+		c.SetSandbox(t.id.sandbox)
+		c.SetService(t.id.service)
+		c.SetVersion(t.id.version)
+		c.SetNode(t.id.node)
+		c.SetKind(t.id.kind)
+
+		var cpu usage_v1alpha.CpuUsage
+		cpu.SetCores(t.cores())
+		c.SetCpu(&cpu)
+		c.SetCpuSeconds(t.cpuSeconds)
+
+		var mem usage_v1alpha.MemoryUsage
+		mem.SetBytes(int64(t.bytes))
+		c.SetMemory(&mem)
+
+		if !t.first.IsZero() {
+			c.SetFirstSeen(standard.ToTimestamp(t.first))
+		}
+		if !t.last.IsZero() {
+			c.SetLastSeen(standard.ToTimestamp(t.last))
+		}
+
+		if ref := live[t.id.sandbox]; ref != nil {
+			c.SetAlive(true)
+			c.SetSandboxShortId(ref.SandboxShortId())
+		}
+
+		// The version short id comes from the version rather than from the
+		// sandbox, so a replaced deployment still names one. App versions are
+		// not swept when they stop running, which makes this the one identifier
+		// a gone contributor can still offer.
+		if v := versions[t.id.version]; v != nil {
+			c.SetVersionShortId(v.shortID)
+		}
+
+		c.SetSeries(t.series)
+
+		rows = append(rows, &c)
+	}
+
+	sortContributors(rows)
+
+	return rows
+}
+
+// sortContributors puts the busiest first, so the sandbox that explains a spike
+// is the row someone reads rather than one they scroll to. Ties break on the
+// sandbox id so two identical calls agree.
+func sortContributors(rows []*usage_v1alpha.AppContributor) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		// Ordered by CPU time consumed rather than by cores, because that is
+		// the figure that compares across sandboxes with different lifetimes:
+		// a ten-minute sandbox at two cores contributed far less than an
+		// all-week one at half a core.
+		if a.CpuSeconds() != b.CpuSeconds() {
+			return a.CpuSeconds() > b.CpuSeconds()
+		}
+		if a.Memory().Bytes() != b.Memory().Bytes() {
+			return a.Memory().Bytes() > b.Memory().Bytes()
+		}
+		return a.Sandbox() < b.Sandbox()
+	})
+}

--- a/servers/usage/contributors_test.go
+++ b/servers/usage/contributors_test.go
@@ -1,0 +1,328 @@
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/compute"
+	"miren.dev/runtime/api/usage/usage_v1alpha"
+	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// tallyOf builds a contributor that reported cpuSeconds of CPU time and bytes
+// of memory across a one-minute active span, so cores works out to cpuSeconds
+// per minute.
+func tallyOf(sandbox, service, version string, cpuSeconds, bytes float64) *contributorTally {
+	start := time.Unix(1_700_000_000, 0)
+
+	return &contributorTally{
+		id: contributorIdentity{
+			sandbox: sandbox,
+			service: service,
+			version: version,
+			node:    "node/miren",
+			kind:    string(compute.KindApp),
+		},
+		cpuSeconds: cpuSeconds,
+		bytes:      bytes,
+		first:      start,
+		last:       start.Add(time.Minute),
+	}
+}
+
+func findContributor(rows []*usage_v1alpha.AppContributor, sandbox string) *usage_v1alpha.AppContributor {
+	for _, r := range rows {
+		if r.Sandbox() == sandbox {
+			return r
+		}
+	}
+	return nil
+}
+
+// Everything that identifies a contributor is read off the metric labels, which
+// is the whole point: the sandbox entity that used to hold this is swept within
+// the hour, and the samples are kept for a month.
+func TestContributorIdentityComesFromLabels(t *testing.T) {
+	id, ok := identityOf(map[string]string{
+		labelSandbox: "sandbox/shop-web-abc",
+		labelService: "web",
+		labelVersion: "app_version/shop-v1",
+		labelNode:    "node/miren",
+		labelKind:    string(compute.KindApp),
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, "web", id.service)
+	assert.Equal(t, "app_version/shop-v1", id.version)
+	assert.Equal(t, "node/miren", id.node)
+
+	// A series with no sandbox label identifies no contributor.
+	_, ok = identityOf(map[string]string{labelApp: "shop"})
+	assert.False(t, ok)
+}
+
+// The reason this exists: a week's worth of contributors is mostly sandboxes
+// the entity store has already forgotten, and they still have to account for
+// themselves.
+func TestContributorRowsIncludeSweptSandboxes(t *testing.T) {
+	dir := &directory{sandboxes: []sandboxRow{row("sandbox/live", "shop", string(compute.KindApp))}}
+
+	tallies := map[string]*contributorTally{
+		"sandbox/live": tallyOf("sandbox/live", "web", "app_version/v2", 0.5, 100),
+		"sandbox/gone": tallyOf("sandbox/gone", "web", "app_version/v1", 2.0, 900),
+	}
+
+	rows := buildContributorRows(tallies, dir)
+	require.Len(t, rows, 2)
+
+	gone := findContributor(rows, "sandbox/gone")
+	require.NotNil(t, gone)
+	assert.False(t, gone.Alive())
+	assert.InDelta(t, 2.0, gone.CpuSeconds(), 0.001)
+	assert.Equal(t, "web", gone.Service(), "the labels still say what it was")
+	assert.Equal(t, "app_version/v1", gone.Version())
+
+	// A short id is allocated onto the entity, not derived from its id, so a
+	// swept sandbox has nothing left to recover one from. Reporting a guess
+	// would hand someone an identifier that resolves to nothing.
+	assert.Equal(t, "", gone.SandboxShortId())
+
+	assert.True(t, findContributor(rows, "sandbox/live").Alive())
+}
+
+// The busiest row is the one someone is looking for, so it must not be the one
+// they have to scroll to.
+func TestContributorRowsAreBusiestFirst(t *testing.T) {
+	tallies := map[string]*contributorTally{
+		"sandbox/quiet": tallyOf("sandbox/quiet", "web", "v1", 0.1, 100),
+		"sandbox/busy":  tallyOf("sandbox/busy", "web", "v1", 3.0, 100),
+		"sandbox/mid":   tallyOf("sandbox/mid", "worker", "v1", 1.0, 100),
+	}
+
+	rows := buildContributorRows(tallies, nil)
+
+	order := make([]string, 0, len(rows))
+	for _, r := range rows {
+		order = append(order, r.Sandbox())
+	}
+	assert.Equal(t, []string{"sandbox/busy", "sandbox/mid", "sandbox/quiet"}, order)
+}
+
+// Two sandboxes at the same CPU must not swap places between identical calls;
+// a row that moved would read as a change in the cluster.
+func TestContributorOrderIsStableOnTies(t *testing.T) {
+	tallies := map[string]*contributorTally{
+		"sandbox/b": tallyOf("sandbox/b", "web", "v1", 1.0, 500),
+		"sandbox/a": tallyOf("sandbox/a", "web", "v1", 1.0, 500),
+	}
+
+	first := buildContributorRows(tallies, nil)
+	second := buildContributorRows(tallies, nil)
+
+	require.Len(t, first, 2)
+	assert.Equal(t, "sandbox/a", first[0].Sandbox())
+	assert.Equal(t, first[0].Sandbox(), second[0].Sandbox())
+}
+
+// Memory breaks a CPU tie, so two idle sandboxes still sort by what they held.
+func TestContributorMemoryBreaksACpuTie(t *testing.T) {
+	tallies := map[string]*contributorTally{
+		"sandbox/small": tallyOf("sandbox/small", "web", "v1", 0, 100),
+		"sandbox/large": tallyOf("sandbox/large", "web", "v1", 0, 900),
+	}
+
+	rows := buildContributorRows(tallies, nil)
+	assert.Equal(t, "sandbox/large", rows[0].Sandbox())
+}
+
+// first_seen and last_seen are what turn a week of contributors into a sequence
+// of deployments rather than an undated pile.
+func TestContributorRowsCarryTheirWindow(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	end := start.Add(90 * time.Minute)
+
+	tally := tallyOf("sandbox/a", "web", "v1", 1, 100)
+	tally.first = start
+	tally.last = end
+
+	rows := buildContributorRows(map[string]*contributorTally{"sandbox/a": tally}, nil)
+	require.Len(t, rows, 1)
+
+	assert.Equal(t, start.Unix(), standard.FromTimestamp(rows[0].FirstSeen()).Unix())
+	assert.Equal(t, end.Unix(), standard.FromTimestamp(rows[0].LastSeen()).Unix())
+}
+
+// A sandbox whose sample times are unknown reports no window rather than the
+// epoch, which would read as having run in 1970.
+func TestContributorRowsOmitAnUnknownWindow(t *testing.T) {
+	tally := tallyOf("sandbox/a", "web", "v1", 1, 100)
+	tally.first = time.Time{}
+	tally.last = time.Time{}
+
+	rows := buildContributorRows(map[string]*contributorTally{"sandbox/a": tally}, nil)
+
+	require.Len(t, rows, 1)
+	assert.False(t, rows[0].HasFirstSeen())
+	assert.False(t, rows[0].HasLastSeen())
+	assert.InDelta(t, 0, rows[0].Cpu().Cores(), 0.001,
+		"with no span there is nothing to divide by, and a guess would be worse than zero")
+}
+
+// Grouping by the identity labels costs no extra cardinality -- every one of
+// them is functionally dependent on the sandbox id -- and it is what lets a
+// contributor name its service and version without an entity lookup.
+func TestContributorGroupingCarriesTheIdentityLabels(t *testing.T) {
+	g := contributorGrouping()
+
+	for _, label := range []string{labelSandbox, labelService, labelVersion, labelNode, labelKind} {
+		assert.Contains(t, g, label)
+	}
+	assert.NotContains(t, g, "miren.", "a dotted label silently matches nothing")
+}
+
+// Each contributor's history is split out of one query per metric, not fetched
+// per sandbox. Getting the split wrong would give every sandbox every other
+// sandbox's points.
+func TestContributorSeriesAreSplitBySandbox(t *testing.T) {
+	stub := &rangeStub{series: []metrics.Result{
+		{
+			Metric: map[string]string{labelSandbox: "sandbox/a"},
+			Values: [][]any{at(100, "1"), at(160, "2")},
+		},
+		{
+			Metric: map[string]string{labelSandbox: "sandbox/b"},
+			Values: [][]any{at(100, "9")},
+		},
+		{
+			// A sandbox with a history but no aggregate has no row to hang it
+			// on; inventing one would contradict the totals.
+			Metric: map[string]string{labelSandbox: "sandbox/unknown"},
+			Values: [][]any{at(100, "5")},
+		},
+	}}
+
+	s := &Server{Reader: stub.reader(t)}
+	w := window{start: time.Unix(100, 0), end: time.Unix(160, 0), aggregate: aggregateAvg}
+
+	tallies := map[string]*contributorTally{
+		"sandbox/a": tallyOf("sandbox/a", "web", "v1", 1, 100),
+		"sandbox/b": tallyOf("sandbox/b", "web", "v1", 1, 100),
+	}
+
+	warnings := s.attachContributorSeries(context.Background(), "", w, time.Minute, tallies)
+	require.Empty(t, warnings)
+
+	// Two range queries answer every sandbox, not two per sandbox.
+	require.Len(t, stub.queries, 2)
+	for _, q := range stub.queries {
+		assert.Contains(t, q, "by (miren_sandbox)")
+	}
+
+	a := tallies["sandbox/a"]
+	require.Len(t, a.series, 2, "one series per metric")
+	assert.Len(t, a.series[0].Points(), 2)
+
+	b := tallies["sandbox/b"]
+	require.Len(t, b.series, 2)
+	require.Len(t, b.series[0].Points(), 1)
+	assert.InDelta(t, 9.0, b.series[0].Points()[0].Value(), 0.001,
+		"sandbox b must not inherit sandbox a's points")
+
+	_, ok := tallies["sandbox/unknown"]
+	assert.False(t, ok, "a history with no aggregate creates no contributor")
+}
+
+// A version is not swept when it stops running, so a contributor whose sandbox
+// is long gone can still name a version someone can type. That makes it the one
+// actionable identifier on a historical row.
+func TestContributorVersionShortIdSurvivesTheSandbox(t *testing.T) {
+	dir := &directory{
+		versions: map[string]*appInfo{
+			"app_version/shop-v1": {id: "app/shop", version: "v1", shortID: "e8v"},
+		},
+	}
+
+	tallies := map[string]*contributorTally{
+		"sandbox/gone": tallyOf("sandbox/gone", "web", "app_version/shop-v1", 1, 100),
+	}
+
+	rows := buildContributorRows(tallies, dir)
+	require.Len(t, rows, 1)
+
+	assert.False(t, rows[0].Alive())
+	assert.Equal(t, "", rows[0].SandboxShortId(), "the sandbox entity is gone")
+	assert.Equal(t, "e8v", rows[0].VersionShortId(), "the version entity is not")
+}
+
+// The reason contributors are measured against their own lifetime rather than
+// the window: a sandbox that ran hot for ten minutes of a week did not use
+// "almost nothing", it used two cores and then stopped.
+func TestContributorCoresDescribeTheSandboxNotTheWindow(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+
+	tally := tallyOf("sandbox/burst", "web", "v1", 0, 100)
+	tally.first = start
+	tally.last = start.Add(10 * time.Minute)
+	tally.cpuSeconds = 1200 // two cores for ten minutes
+
+	rows := buildContributorRows(map[string]*contributorTally{"sandbox/burst": tally}, nil)
+	require.Len(t, rows, 1)
+
+	assert.InDelta(t, 2.0, rows[0].Cpu().Cores(), 0.001,
+		"two cores while running, not 1200s averaged across a week")
+	assert.InDelta(t, 1200, rows[0].CpuSeconds(), 0.001,
+		"seconds are the figure that still adds up")
+}
+
+// Ordering follows CPU time consumed, not the rate, because a rate cannot be
+// compared between sandboxes that ran for different lengths of time.
+func TestContributorOrderFollowsConsumptionNotRate(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+
+	brief := tallyOf("sandbox/brief", "web", "v1", 0, 100)
+	brief.first, brief.last = start, start.Add(time.Minute)
+	brief.cpuSeconds = 120 // two cores, but only for a minute
+
+	sustained := tallyOf("sandbox/sustained", "web", "v1", 0, 100)
+	sustained.first, sustained.last = start, start.Add(10*time.Hour)
+	sustained.cpuSeconds = 18000 // half a core all day
+
+	rows := buildContributorRows(map[string]*contributorTally{
+		"sandbox/brief":     brief,
+		"sandbox/sustained": sustained,
+	}, nil)
+
+	assert.InDelta(t, 2.0, findContributor(rows, "sandbox/brief").Cpu().Cores(), 0.01)
+	assert.InDelta(t, 0.5, findContributor(rows, "sandbox/sustained").Cpu().Cores(), 0.01)
+
+	assert.Equal(t, "sandbox/sustained", rows[0].Sandbox(),
+		"the one that actually consumed the app's CPU comes first")
+}
+
+// The seen queries group by sandbox alone, so a row of theirs names no service,
+// version or kind. If the usage queries have failed and these have not, the two
+// disagree about who exists, and building a contributor from a sample time
+// alone would put a bare id in the breakdown with zeroes beside it.
+func TestSeenTimesNeverInventAContributor(t *testing.T) {
+	stub := &instantStub{
+		// Usage fails; only the sample-time queries answer.
+		fail: []string{metricCPUSeconds, "sum by (miren_sandbox, miren_service"},
+		series: []metrics.Result{{
+			Metric: map[string]string{labelSandbox: "sandbox/ghost"},
+			Value:  at(1_700_000_000, "1700000000"),
+		}},
+	}
+
+	s := &Server{Reader: stub.reader(t)}
+	w := window{start: time.Unix(0, 0), end: time.Unix(3600, 0), aggregate: aggregateAvg}
+
+	rows, warnings := s.appContributors(context.Background(), "", w, appDetailOptions{}, nil)
+
+	assert.Empty(t, rows, "a sample time with no usage is an id, not a contributor")
+	assert.NotEmpty(t, warnings, "the failed usage queries are still reported")
+}

--- a/servers/usage/contributors_test.go
+++ b/servers/usage/contributors_test.go
@@ -326,3 +326,41 @@ func TestSeenTimesNeverInventAContributor(t *testing.T) {
 	assert.Empty(t, rows, "a sample time with no usage is an id, not a contributor")
 	assert.NotEmpty(t, warnings, "the failed usage queries are still reported")
 }
+
+// A caller that excluded addons from the row excluded them from the breakdown
+// too. Listing them here would name sandboxes the row does not count, and their
+// cpu_seconds would stop summing to it, which is the property that field
+// promises.
+func TestContributorsHonourExcludedAddons(t *testing.T) {
+	series := []metrics.Result{
+		{
+			Metric: map[string]string{
+				labelSandbox: "sandbox/web", labelService: "web",
+				labelKind: string(compute.KindApp),
+			},
+			Value: at(1_700_000_000, "1"),
+		},
+		{
+			Metric: map[string]string{
+				labelSandbox: "sandbox/pg", labelService: "pg",
+				labelKind: string(compute.KindAddon),
+			},
+			Value: at(1_700_000_000, "9"),
+		},
+	}
+
+	w := window{start: time.Unix(0, 0), end: time.Unix(3600, 0), aggregate: aggregateAvg}
+
+	withAddons := &Server{Reader: (&instantStub{series: series}).reader(t)}
+	rows, _ := withAddons.appContributors(context.Background(), "", w,
+		appDetailOptions{includeAddons: true}, nil)
+	assert.Len(t, rows, 2)
+
+	withoutAddons := &Server{Reader: (&instantStub{series: series}).reader(t)}
+	rows, _ = withoutAddons.appContributors(context.Background(), "", w,
+		appDetailOptions{includeAddons: false}, nil)
+
+	require.Len(t, rows, 1)
+	assert.Equal(t, "sandbox/web", rows[0].Sandbox(),
+		"the database is not part of a services-only answer")
+}

--- a/servers/usage/directory.go
+++ b/servers/usage/directory.go
@@ -32,6 +32,13 @@ type sandboxRow struct {
 type directory struct {
 	sandboxes []sandboxRow
 	nodes     map[entity.Id]*nodeInfo
+
+	// versions is every app version in the store, keyed by version id. Unlike
+	// sandboxes these are not swept when they stop running, so this is the one
+	// entity view that still describes a replaced deployment -- which is what
+	// lets a contributor that no longer exists still name a version someone can
+	// type.
+	versions map[string]*appInfo
 }
 
 type nodeInfo struct {
@@ -151,7 +158,7 @@ func (s *Server) loadDirectory(ctx context.Context, f filter) (*directory, error
 		return nil, err
 	}
 
-	dir := &directory{nodes: nodes}
+	dir := &directory{nodes: nodes, versions: apps}
 
 	for sandboxes.Next() {
 		var sb computev1.Sandbox

--- a/servers/usage/directory.go
+++ b/servers/usage/directory.go
@@ -201,6 +201,32 @@ func (s *Server) loadDirectory(ctx context.Context, f filter) (*directory, error
 	return dir, nil
 }
 
+// nodeSelector resolves a caller's node name into a metric selector.
+//
+// ok reports whether a node that was named was actually found. A caller that
+// named one and got false has to answer with an empty listing rather than
+// querying cluster-wide.
+//
+// That distinction used to take care of itself. loadDirectory returns an empty
+// directory for a node it cannot match, and while the rows were built from that
+// directory an empty one meant no rows. Once the figures came from the metrics
+// store instead, a second resolution decided the selector, and an unmatched
+// node there simply left it unconstrained: a mistyped --runner would query the
+// whole cluster and report every app on it as historical. One resolution, whose
+// failure the caller has to handle, is what keeps the two from disagreeing.
+func nodeSelector(dir *directory, node string) (selector string, ok bool) {
+	if node == "" {
+		return "", true
+	}
+
+	n := matchNode(dir.nodes, node)
+	if n == nil {
+		return "", false
+	}
+
+	return labelSelector(map[string]string{labelNode: string(n.id)}), true
+}
+
 // buildRef assembles one sandbox's identity from the several entities that
 // each hold a piece of it.
 func (s *Server) buildRef(

--- a/servers/usage/query.go
+++ b/servers/usage/query.go
@@ -81,15 +81,38 @@ func resolveAggregate(s string) string {
 	}
 }
 
-// promDuration renders a duration the way MetricsQL wants it. Sub-second
-// precision is dropped because no collector here samples that fast, and a "0s"
-// range would match nothing.
-func promDuration(d time.Duration) string {
+// promSeconds renders a duration the way MetricsQL wants it and reports the
+// number of seconds it actually wrote. A caller dividing by the range has to
+// divide by what went into the query rather than by what it asked for, or a
+// floored sub-second range would scale the answer.
+//
+// Sub-second precision is dropped because no collector here samples that fast,
+// and a "0s" range would match nothing.
+func promSeconds(d time.Duration) (string, int64) {
 	if d < time.Second {
 		d = time.Second
 	}
-	return fmt.Sprintf("%ds", int64(d.Seconds()))
+	secs := int64(d.Seconds())
+	return fmt.Sprintf("%ds", secs), secs
 }
+
+func promDuration(d time.Duration) string {
+	rendered, _ := promSeconds(d)
+	return rendered
+}
+
+// sampleStaleness bounds how long one sandbox's last sample stays current.
+//
+// It exists because a bare selector inside a subquery inherits the subquery's
+// step as its lookbehind, and that step grows with the window: at a day it is
+// over an hour, at a week over eight. A sandbox that died keeps being counted
+// for that long, so across a redeploy two generations are summed and an app
+// reads as twice its size. Pinning the lookbehind bounds the overlap to about
+// one scrape at any window length.
+//
+// Twelve times the writer's five-second flush period, so a runner that batches
+// slowly still reports rather than leaving a hole in the series.
+const sampleStaleness = time.Minute
 
 // cpuCoresQuery builds the CPU query for one grouping label.
 //
@@ -116,16 +139,36 @@ func cpuCoresQuery(groupBy string, selector string, window time.Duration, aggreg
 		rateWindow = minRateWindow
 	}
 
-	inner := fmt.Sprintf("sum by (%s) (rate(%s%s[%s]))",
-		groupBy, metricCPUSeconds, selector, promDuration(rateWindow))
+	rangeStr, rangeSecs := promSeconds(rateWindow)
+
+	// Consumption divided by the range, rather than rate(), because the two
+	// disagree the moment more than one series is summed.
+	//
+	// rate(m[d]) is measured over the samples the series itself has, not over
+	// d. One sandbox cannot double itself, so per sandbox the distinction never
+	// showed. Summed across sandboxes it does: a sandbox that died inside the
+	// window keeps contributing the rate it ran at while alive, for as long as
+	// the window still holds its samples, so an app that redeployed reads as
+	// two apps. Measured against a steady one-core app half an hour after a
+	// redeploy, sum(rate()) answered 2.0 cores.
+	//
+	// increase() over the range, divided by the range, is time-weighted instead
+	// -- what each sandbox actually consumed, spread across the window it was
+	// asked about. VictoriaMetrics rewrites sum(rate()) into exactly this at
+	// ranges of three hours or more, which is why long windows looked right and
+	// short ones did not, and why a range query never looked right at all. It
+	// is spelled out here so the answer does not depend on that rewrite.
+	inner := fmt.Sprintf("(sum by (%s) (increase(%s%s[%s])) / %d)",
+		groupBy, metricCPUSeconds, selector, rangeStr, rangeSecs)
 
 	switch aggregate {
 	case aggregateMax, aggregateMin:
 		return fmt.Sprintf("%s_over_time(%s[%s:%s])",
-			aggregate, inner, promDuration(window), promDuration(rateWindow))
+			aggregate, inner, promDuration(window), rangeStr)
 	default:
-		// avg and last both collapse to the plain rate: a rate over the whole
-		// window IS its average, and there is no cheaper "last" for a counter.
+		// avg and last both collapse to the plain figure: consumption across
+		// the whole window already is that window's average, and there is no
+		// cheaper "last" for a counter.
 		return inner
 	}
 }
@@ -135,7 +178,11 @@ func cpuCoresQuery(groupBy string, selector string, window time.Duration, aggreg
 // Memory is a gauge, so unlike CPU it needs an explicit over_time collapse for
 // every aggregate except last.
 func memoryBytesQuery(groupBy string, selector string, window time.Duration, aggregate string) string {
-	inner := fmt.Sprintf("sum by (%s) (%s%s)", groupBy, metricMemoryUsed, selector)
+	// last_over_time rather than the bare selector: see sampleStaleness. Without
+	// it the lookbehind follows the subquery step, and a dead sandbox is summed
+	// alongside the one that replaced it for hours.
+	inner := fmt.Sprintf("sum by (%s) (last_over_time(%s%s[%s]))",
+		groupBy, metricMemoryUsed, selector, promDuration(sampleStaleness))
 
 	if aggregate == aggregateLast {
 		return inner

--- a/servers/usage/query.go
+++ b/servers/usage/query.go
@@ -32,6 +32,8 @@ const (
 	labelRunner  = "miren_runner"
 	labelApp     = "miren_app"
 	labelKind    = "miren_kind"
+	labelService = "miren_service"
+	labelVersion = "miren_version"
 )
 
 // groupKey renders several labels as one grouping clause.
@@ -159,6 +161,64 @@ func sandboxCountQuery(selector string, window time.Duration) string {
 		groupKey(labelApp, labelKind, labelSandbox), metricMemoryUsed, selector, promDuration(window))
 
 	return fmt.Sprintf("count by (%s) (%s)", groupKey(labelApp, labelKind), perSandbox)
+}
+
+// contributorMemoryQuery and contributorCPUSecondsQuery read what one sandbox
+// used while it was running.
+//
+// Neither uses a subquery, and that is the whole point. Every other collapse
+// here evaluates a fixed number of points across the window (see overTime), so
+// the resolution degrades as the window grows: at a week the step is over eight
+// hours, and a sandbox that lived ten minutes falls between two evaluation
+// points and reports nothing at all. It still appears in the breakdown, with
+// zeroes beside it, which reads as "used nothing" rather than "not measured".
+//
+// Applied straight to a raw metric these functions scan the samples themselves,
+// so they are exact at any window length and describe the sandbox's own
+// lifetime rather than the window's. A ten-minute sandbox reports the memory it
+// actually held for those ten minutes.
+//
+// The sum is what collapses a sandbox's several containers into one figure.
+func contributorMemoryQuery(groupBy, selector string, window time.Duration, aggregate string) string {
+	return fmt.Sprintf("sum by (%s) (%s_over_time(%s%s[%s]))",
+		groupBy, aggregate, metricMemoryUsed, selector, promDuration(window))
+}
+
+// contributorCPUSecondsQuery reads how much CPU time each sandbox consumed.
+//
+// Seconds rather than cores because seconds are what add up. Cores is a rate,
+// and two sandboxes that ran for different lengths of time cannot be compared
+// by it; the caller divides by the sandbox's own active span to recover a rate
+// that means something.
+func contributorCPUSecondsQuery(groupBy, selector string, window time.Duration) string {
+	return fmt.Sprintf("sum by (%s) (increase(%s%s[%s]))",
+		groupBy, metricCPUSeconds, selector, promDuration(window))
+}
+
+// firstSeenQuery and lastSeenQuery report when a sandbox's samples start and
+// stop inside the window.
+//
+// Together they are the span a sandbox accounted for, which is what turns a
+// week's worth of contributors from an undated pile into a sequence of
+// deployments. Nothing else can supply it: the sandbox entity that knew its own
+// start and exit times is swept about an hour after it dies.
+//
+// tfirst_over_time and tlast_over_time are the right functions and tmin/tmax
+// are not, though the names suggest otherwise. tmin_over_time returns the
+// timestamp of the smallest *value*, not the earliest sample, so a sandbox
+// whose memory dipped at the end would report having started then.
+//
+// Memory is what they ask about because it is a gauge: every live sandbox has a
+// current value, where a CPU counter that has not advanced yields no rate and
+// would read as a sandbox that was never there.
+func firstSeenQuery(selector string, window time.Duration) string {
+	return fmt.Sprintf("min by (%s) (tfirst_over_time(%s%s[%s]))",
+		labelSandbox, metricMemoryUsed, selector, promDuration(window))
+}
+
+func lastSeenQuery(selector string, window time.Duration) string {
+	return fmt.Sprintf("max by (%s) (tlast_over_time(%s%s[%s]))",
+		labelSandbox, metricMemoryUsed, selector, promDuration(window))
 }
 
 // nodeGaugeQuery reads one node-level gauge, collapsed over the window.

--- a/servers/usage/query.go
+++ b/servers/usage/query.go
@@ -30,7 +30,19 @@ const (
 	labelSandbox = "miren_sandbox"
 	labelNode    = "miren_node"
 	labelRunner  = "miren_runner"
+	labelApp     = "miren_app"
+	labelKind    = "miren_kind"
 )
+
+// groupKey renders several labels as one grouping clause.
+//
+// The query builders take the grouping as a single string because most callers
+// group by one label. An app rollup needs two -- the app and the kind, so an
+// app's own services stay separable from the addons it owns -- and this is what
+// keeps the joining spelled in one place rather than at each call site.
+func groupKey(labels ...string) string {
+	return strings.Join(labels, ", ")
+}
 
 // Aggregates a caller may ask for.
 const (
@@ -128,6 +140,25 @@ func memoryBytesQuery(groupBy string, selector string, window time.Duration, agg
 	}
 
 	return overTime(aggregate, inner, window)
+}
+
+// sandboxCountQuery counts the sandboxes that reported, per group.
+//
+// This is how many sandboxes a row is made of, sourced from the store rather
+// than from the entity pass so that a historical window can still say. It
+// counts *reporting* sandboxes, which is not the same as scheduled ones: a
+// sandbox that was never able to start never reports and so is never counted.
+//
+// The nesting is what makes it a sandbox count rather than a series count. A
+// sandbox writes one memory series per container, so the inner count collapses
+// each sandbox to one before the outer one counts them. Memory is the metric to
+// count on because it is a gauge -- every live sandbox has a current value,
+// where a CPU counter that has not advanced in the window yields no rate.
+func sandboxCountQuery(selector string, window time.Duration) string {
+	perSandbox := fmt.Sprintf("count by (%s) (last_over_time(%s%s[%s]))",
+		groupKey(labelApp, labelKind, labelSandbox), metricMemoryUsed, selector, promDuration(window))
+
+	return fmt.Sprintf("count by (%s) (%s)", groupKey(labelApp, labelKind), perSandbox)
 }
 
 // nodeGaugeQuery reads one node-level gauge, collapsed over the window.

--- a/servers/usage/query_test.go
+++ b/servers/usage/query_test.go
@@ -56,10 +56,10 @@ func TestQueriesNeverGroupByEntity(t *testing.T) {
 func TestCPUCoresQueryAggregates(t *testing.T) {
 	r := require.New(t)
 
-	// A rate over the whole window already is the window's average, so avg
-	// needs no subquery wrapper.
+	// Consumption across the whole window already is the window's average, so
+	// avg needs no subquery wrapper.
 	avg := cpuCoresQuery(labelSandbox, "", 5*time.Minute, aggregateAvg)
-	r.Equal("sum by (miren_sandbox) (rate(cpu_usage_seconds_total[300s]))", avg)
+	r.Equal("(sum by (miren_sandbox) (increase(cpu_usage_seconds_total[300s])) / 300)", avg)
 
 	// max does need one, or a spike that has already passed averages away into
 	// nothing -- which is the entire reason to ask for max.
@@ -70,10 +70,29 @@ func TestCPUCoresQueryAggregates(t *testing.T) {
 
 func TestCPUCoresQueryFloorsTheRateWindow(t *testing.T) {
 	// A one-second range holds at most one sample of a one-second counter, and
-	// a rate needs two. Asking for it returns nothing rather than erroring, so
-	// the floor is what keeps a short window from reading as an idle cluster.
+	// an increase needs two. Asking for it returns nothing rather than
+	// erroring, so the floor is what keeps a short window from reading as an
+	// idle cluster.
 	q := cpuCoresQuery(labelSandbox, "", time.Second, aggregateAvg)
 	require.Contains(t, q, "[15s]")
+
+	// The divisor has to be the range that was actually written, not the one
+	// that was asked for, or the floor would scale the answer by fifteen.
+	require.Contains(t, q, "/ 15")
+}
+
+// rate(m[d]) measures a series over its own samples rather than over d, so
+// summing two sandboxes double-counts one that died inside the window: an app
+// that redeployed reads as two apps. Measured against a steady one-core app,
+// sum(rate()) answered 2.0 cores half an hour after a redeploy.
+func TestCPUCoresQueryIsTimeWeightedAcrossSandboxes(t *testing.T) {
+	r := require.New(t)
+
+	for _, agg := range []string{aggregateAvg, aggregateMax, aggregateMin, aggregateLast} {
+		q := cpuCoresQuery(groupKey(labelApp, labelKind), "", time.Hour, agg)
+		r.NotContains(q, "rate(", "rate() is not time-weighted once summed: %s", q)
+		r.Contains(q, "increase(", "%s", q)
+	}
 }
 
 func TestMemoryQueryCollapsesGauge(t *testing.T) {
@@ -81,12 +100,26 @@ func TestMemoryQueryCollapsesGauge(t *testing.T) {
 
 	// Memory is a gauge, so unlike CPU every aggregate needs an explicit
 	// over_time; the bare selector would return one point, not a window.
-	r.Equal("avg_over_time(sum by (miren_sandbox) (memory_usage_bytes)[60s:3s])",
+	r.Equal("avg_over_time(sum by (miren_sandbox) (last_over_time(memory_usage_bytes[60s]))[60s:3s])",
 		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateAvg))
-	r.Equal("max_over_time(sum by (miren_sandbox) (memory_usage_bytes)[60s:3s])",
+	r.Equal("max_over_time(sum by (miren_sandbox) (last_over_time(memory_usage_bytes[60s]))[60s:3s])",
 		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateMax))
-	r.Equal("sum by (miren_sandbox) (memory_usage_bytes)",
+	r.Equal("sum by (miren_sandbox) (last_over_time(memory_usage_bytes[60s]))",
 		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateLast))
+}
+
+// A bare selector inside a subquery inherits the subquery's step as its
+// lookbehind, and that step grows with the window: over an hour at a day, over
+// eight at a week. A sandbox that died keeps being summed alongside the one
+// that replaced it for that long, so a steady 100 MiB app read as 200 MiB.
+func TestMemoryQueryPinsItsLookbehind(t *testing.T) {
+	r := require.New(t)
+
+	for _, w := range []time.Duration{time.Minute, 24 * time.Hour, 168 * time.Hour} {
+		q := memoryBytesQuery(groupKey(labelApp, labelKind), "", w, aggregateMax)
+		r.Contains(q, "last_over_time(memory_usage_bytes[60s])",
+			"the lookbehind must not follow the window: %s", q)
+	}
 }
 
 // An app rollup groups by two labels at once, which is the only reason the
@@ -193,22 +226,22 @@ func TestCollapsedQueriesAlwaysCarryASubqueryStep(t *testing.T) {
 	}
 }
 
-// A max is asked for precisely to find a burst an average would hide. Taking
-// the rate over the whole window would flatten that burst into the window's
-// mean, making max and avg identical and the flag useless.
+// A max is asked for precisely to find a burst an average would hide. Measuring
+// consumption across the whole window would flatten that burst into the
+// window's mean, making max and avg identical and the flag useless.
 func TestMaxUsesAShortRateWindowSteppedAcrossTheWindow(t *testing.T) {
 	r := require.New(t)
 
 	q := cpuCoresQuery(labelSandbox, "", time.Hour, aggregateMax)
 
-	r.Contains(q, "rate(cpu_usage_seconds_total[180s])",
-		"the rate must cover a slice of the window, not all of it: %s", q)
+	r.Contains(q, "increase(cpu_usage_seconds_total[180s])",
+		"the range must cover a slice of the window, not all of it: %s", q)
 	r.Contains(q, "[3600s:180s]", "the subquery must step across the window: %s", q)
 
-	// The average is the one case where a full-window rate is right, and it
-	// needs no subquery at all.
+	// The average is the one case where measuring across the whole window is
+	// right, and it needs no subquery at all.
 	avg := cpuCoresQuery(labelSandbox, "", time.Hour, aggregateAvg)
-	r.Equal("sum by (miren_sandbox) (rate(cpu_usage_seconds_total[3600s]))", avg)
+	r.Equal("(sum by (miren_sandbox) (increase(cpu_usage_seconds_total[3600s])) / 3600)", avg)
 }
 
 // An explicit order always wins; otherwise the comparator's own default

--- a/servers/usage/query_test.go
+++ b/servers/usage/query_test.go
@@ -25,8 +25,11 @@ func TestQueriesUseStoredLabelSpelling(t *testing.T) {
 		cpuCoresQuery(appKind, "", time.Hour, aggregateAvg),
 		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateAvg),
 		memoryBytesQuery(appKind, "", time.Hour, aggregateLast),
+		cpuCoresQuery(groupKey(labelSandbox, labelService, labelVersion, labelNode, labelKind), "", time.Hour, aggregateAvg),
 		nodeGaugeQuery(metricNodeCPUCoresTotal, "", time.Minute, aggregateLast),
 		sandboxCountQuery("", time.Hour),
+		firstSeenQuery("", time.Hour),
+		lastSeenQuery("", time.Hour),
 	}
 
 	for _, q := range queries {
@@ -110,6 +113,29 @@ func TestSandboxCountQueryCountsSandboxesNotSeries(t *testing.T) {
 		`count by (miren_app, miren_kind) (count by (miren_app, miren_kind, miren_sandbox) `+
 			`(last_over_time(memory_usage_bytes{miren_app="shop"}[3600s])))`,
 		q)
+}
+
+// tmin_over_time and tmax_over_time name the timestamp of the smallest and
+// largest value, not the first and last sample. Using them here would report a
+// sandbox as having started whenever its memory happened to dip, so the
+// distinction is worth pinning down.
+func TestSeenQueriesAskForSampleTimesNotValueExtremes(t *testing.T) {
+	r := require.New(t)
+
+	sel := labelSelector(map[string]string{labelApp: "shop"})
+
+	r.Equal(
+		`min by (miren_sandbox) (tfirst_over_time(memory_usage_bytes{miren_app="shop"}[3600s]))`,
+		firstSeenQuery(sel, time.Hour))
+
+	r.Equal(
+		`max by (miren_sandbox) (tlast_over_time(memory_usage_bytes{miren_app="shop"}[3600s]))`,
+		lastSeenQuery(sel, time.Hour))
+
+	for _, q := range []string{firstSeenQuery(sel, time.Hour), lastSeenQuery(sel, time.Hour)} {
+		r.NotContains(q, "tmin_over_time")
+		r.NotContains(q, "tmax_over_time")
+	}
 }
 
 func TestLabelSelector(t *testing.T) {

--- a/servers/usage/query_test.go
+++ b/servers/usage/query_test.go
@@ -17,11 +17,16 @@ import (
 func TestQueriesUseStoredLabelSpelling(t *testing.T) {
 	r := require.New(t)
 
+	appKind := groupKey(labelApp, labelKind)
+
 	queries := []string{
 		cpuCoresQuery(labelSandbox, "", time.Minute, aggregateAvg),
 		cpuCoresQuery(labelNode, "", time.Hour, aggregateMax),
+		cpuCoresQuery(appKind, "", time.Hour, aggregateAvg),
 		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateAvg),
+		memoryBytesQuery(appKind, "", time.Hour, aggregateLast),
 		nodeGaugeQuery(metricNodeCPUCoresTotal, "", time.Minute, aggregateLast),
+		sandboxCountQuery("", time.Hour),
 	}
 
 	for _, q := range queries {
@@ -79,6 +84,32 @@ func TestMemoryQueryCollapsesGauge(t *testing.T) {
 		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateMax))
 	r.Equal("sum by (miren_sandbox) (memory_usage_bytes)",
 		memoryBytesQuery(labelSandbox, "", time.Minute, aggregateLast))
+}
+
+// An app rollup groups by two labels at once, which is the only reason the
+// grouping is built rather than named directly.
+func TestGroupKeyJoinsLabels(t *testing.T) {
+	r := require.New(t)
+
+	r.Equal("miren_app", groupKey(labelApp))
+	r.Equal("miren_app, miren_kind", groupKey(labelApp, labelKind))
+
+	q := cpuCoresQuery(groupKey(labelApp, labelKind), "", time.Hour, aggregateAvg)
+	r.Contains(q, "sum by (miren_app, miren_kind)")
+}
+
+// A sandbox writes one memory series per container, so counting series would
+// report a sandbox with a sidecar as two. The nesting is what makes this a
+// count of sandboxes.
+func TestSandboxCountQueryCountsSandboxesNotSeries(t *testing.T) {
+	r := require.New(t)
+
+	q := sandboxCountQuery(labelSelector(map[string]string{labelApp: "shop"}), time.Hour)
+
+	r.Equal(
+		`count by (miren_app, miren_kind) (count by (miren_app, miren_kind, miren_sandbox) `+
+			`(last_over_time(memory_usage_bytes{miren_app="shop"}[3600s])))`,
+		q)
 }
 
 func TestLabelSelector(t *testing.T) {

--- a/servers/usage/sandbox.go
+++ b/servers/usage/sandbox.go
@@ -3,7 +3,6 @@ package usage
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	computev1 "miren.dev/runtime/api/compute/compute_v1alpha"
@@ -36,6 +35,12 @@ type sandboxDetailResult struct {
 	image         string
 	restartPolicy string
 	warnings      []string
+
+	// step is the resolution the series were rendered at, zero when none were
+	// asked for. It reaches the response through the window, so a charting
+	// client can learn what it was given rather than inferring it from the
+	// gaps between points.
+	step time.Duration
 }
 
 // apply writes the result into an RPC results type. Both surfaces have the same
@@ -52,6 +57,11 @@ func (d *sandboxDetailResult) apply(set sandboxDetailSetter, w window) {
 	}
 	set.SetImage(d.image)
 	set.SetRestartPolicy(d.restartPolicy)
+
+	// The window is stamped with the step the series actually used, not the
+	// one the caller asked for: an unset or too-fine request is resolved
+	// server-side, and reporting the request would misdescribe the answer.
+	w.step = d.step
 	set.SetWindow(w.encode())
 	set.SetWarnings(d.warnings)
 }
@@ -135,7 +145,8 @@ func (s *Server) sandboxDetail(
 	row.SetStale(cores == 0 && bytes == 0)
 
 	if opts.series {
-		series, seriesWarnings := s.sandboxSeries(ctx, sel, w, opts.step)
+		out.step = resolveStep(w, opts.step)
+		series, seriesWarnings := s.sandboxSeries(ctx, sel, w, out.step)
 		out.warnings = append(out.warnings, seriesWarnings...)
 		out.series = series
 	}
@@ -229,20 +240,11 @@ func (s *Server) singleSandboxSamples(ctx context.Context, selector string, w wi
 	return cores, bytes, warnings
 }
 
-// sandboxSeries fetches CPU and memory over time for charting.
+// sandboxSeries fetches CPU and memory over time for charting. step is already
+// resolved by the caller, which is also what reports it on the window.
 func (s *Server) sandboxSeries(ctx context.Context, selector string, w window, step time.Duration) ([]*usage_v1alpha.UsageSeries, []string) {
 	if s.Reader == nil {
 		return nil, nil
-	}
-
-	if step <= 0 {
-		// Derive a step that yields roughly defaultSeriesPoints points, so the
-		// resolution matches the window instead of returning either three
-		// points for an hour or thousands for a day.
-		step = w.duration() / defaultSeriesPoints
-	}
-	if step < time.Second {
-		step = time.Second
 	}
 
 	var out []*usage_v1alpha.UsageSeries
@@ -266,30 +268,21 @@ func (s *Server) sandboxSeries(ctx context.Context, selector string, w window, s
 		var series usage_v1alpha.UsageSeries
 		series.SetMetric(q.metric)
 
-		var points []*usage_v1alpha.UsagePoint
+		// The selector pins one sandbox, so every returned series describes the
+		// same subject and collapsing them into one line is safe. An app cannot
+		// do this -- see appSeries.
+		byTime := map[int64]float64{}
 		for _, r := range result.Data.Result {
 			for _, v := range r.Values {
-				if len(v) < 2 {
-					continue
-				}
-				ts, _ := v[0].(float64)
-				raw, ok := v[1].(string)
+				at, val, ok := parseSample(v)
 				if !ok {
 					continue
 				}
-				val, err := strconv.ParseFloat(raw, 64)
-				if err != nil {
-					continue
-				}
-
-				var p usage_v1alpha.UsagePoint
-				p.SetAt(standard.ToTimestamp(time.Unix(int64(ts), 0)))
-				p.SetValue(val)
-				points = append(points, &p)
+				byTime[at] = val
 			}
 		}
 
-		series.SetPoints(points)
+		series.SetPoints(pointsInOrder(byTime))
 		out = append(out, &series)
 	}
 

--- a/servers/usage/usage.go
+++ b/servers/usage/usage.go
@@ -12,6 +12,7 @@ package usage
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -49,6 +50,11 @@ type window struct {
 	start     time.Time
 	end       time.Time
 	aggregate string
+
+	// step is the resolution any returned series was rendered at. Zero until a
+	// caller asks for a series, because a response that reported a step without
+	// having drawn one would tell a chart it had points it never received.
+	step time.Duration
 }
 
 func (w window) duration() time.Duration {
@@ -64,7 +70,28 @@ func (w window) encode() *usage_v1alpha.UsageWindow {
 	uw.SetStart(standard.ToTimestamp(w.start))
 	uw.SetEnd(standard.ToTimestamp(w.end))
 	uw.SetAggregate(w.aggregate)
+	if w.step > 0 {
+		uw.SetStepSeconds(int64(w.step.Seconds()))
+	}
 	return &uw
+}
+
+// resolveStep settles the resolution a series is rendered at.
+//
+// A caller that names one gets it. Otherwise the step is derived from the
+// window so that a one-minute span and a day-long one both come back at a
+// resolution a chart can draw, rather than three points for an hour or
+// thousands for a day. The floor is one second because no collector here
+// samples faster than that.
+func resolveStep(w window, requested time.Duration) time.Duration {
+	step := requested
+	if step <= 0 {
+		step = w.duration() / defaultSeriesPoints
+	}
+	if step < time.Second {
+		step = time.Second
+	}
+	return step
 }
 
 // resolveWindow turns a caller's bounds into a measured span.
@@ -273,17 +300,29 @@ func (s *Server) sandboxSamples(
 	return cpu, memory, nodeCores, warnings
 }
 
-// instantByLabel runs one instant query and indexes the result by a label.
-func (s *Server) instantByLabel(ctx context.Context, query, label string, at time.Time) (map[string]float64, error) {
+// labeledValue is one row of an instant query: the labels that identify it and
+// the number it carries.
+type labeledValue struct {
+	labels map[string]string
+	value  float64
+}
+
+// instantRows runs one instant query and returns its rows with their labels
+// intact.
+//
+// Most callers group by a single label and want a map, which instantByLabel
+// gives them. An app rollup groups by two at once and cannot, so the decoding
+// -- which silently drops a row whose value is missing or unparseable rather
+// than failing a diagnostic call -- lives here and is shared.
+func (s *Server) instantRows(ctx context.Context, query string, at time.Time) ([]labeledValue, error) {
 	result, err := s.Reader.InstantQuery(ctx, query, at)
 	if err != nil {
 		return nil, err
 	}
 
-	out := make(map[string]float64, len(result.Data.Result))
+	out := make([]labeledValue, 0, len(result.Data.Result))
 	for _, r := range result.Data.Result {
-		key := r.Metric[label]
-		if key == "" || len(r.Value) < 2 {
+		if len(r.Value) < 2 {
 			continue
 		}
 		raw, ok := r.Value[1].(string)
@@ -294,10 +333,75 @@ func (s *Server) instantByLabel(ctx context.Context, query, label string, at tim
 		if err != nil {
 			continue
 		}
-		out[key] = v
+		out = append(out, labeledValue{labels: r.Metric, value: v})
 	}
 
 	return out, nil
+}
+
+// instantByLabel runs one instant query and indexes the result by a label.
+func (s *Server) instantByLabel(ctx context.Context, query, label string, at time.Time) (map[string]float64, error) {
+	rows, err := s.instantRows(ctx, query, at)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]float64, len(rows))
+	for _, r := range rows {
+		key := r.labels[label]
+		if key == "" {
+			continue
+		}
+		out[key] = r.value
+	}
+
+	return out, nil
+}
+
+// parseSample decodes one [timestamp, "value"] pair as a range query returns
+// them. A malformed pair is dropped rather than failing the call: one bad point
+// should not cost a caller the rest of the history.
+func parseSample(v []any) (at int64, value float64, ok bool) {
+	if len(v) < 2 {
+		return 0, 0, false
+	}
+
+	ts, ok := v[0].(float64)
+	if !ok {
+		return 0, 0, false
+	}
+
+	raw, ok := v[1].(string)
+	if !ok {
+		return 0, 0, false
+	}
+
+	parsed, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return int64(ts), parsed, true
+}
+
+// pointsInOrder turns samples collected by timestamp into points, oldest first.
+// A map has no order, and a chart handed points out of order draws a scribble.
+func pointsInOrder(byTime map[int64]float64) []*usage_v1alpha.UsagePoint {
+	times := make([]int64, 0, len(byTime))
+	for at := range byTime {
+		times = append(times, at)
+	}
+	slices.Sort(times)
+
+	points := make([]*usage_v1alpha.UsagePoint, 0, len(times))
+	for _, at := range times {
+		var p usage_v1alpha.UsagePoint
+		p.SetAt(standard.ToTimestamp(time.Unix(at, 0)))
+		p.SetValue(byTime[at])
+		points = append(points, &p)
+	}
+
+	return points
 }
 
 // totals accumulates a rolled-up slice of usage.


### PR DESCRIPTION
Asking "what has this app been using?" over anything longer than the current deployment didn't really work. Only `getSandbox` could return a time series at all; the app views collapsed the window into a single number, and they built their rows from the sandboxes that happened to be alive at that moment. A question about last week, for an app redeployed on Tuesday, could only ever cover since Tuesday.

The odd part is that the data was never missing. A dead sandbox's *entity* gets collected about an hour after it dies, but its samples sit in VictoriaMetrics for a month, and every one of them already carries `miren_app`, `miren_kind`, the service, the version and the node. The only thing in the way was that the queries were keyed on sandbox ids, which is precisely the thing that disappears.

The first commit moves app rows and totals onto `sum by (miren_app, miren_kind)` and adds a `getApp` RPC method that mirrors `getSandbox` and carries a series. The entity store still has a job: it supplies each app's id, and it keeps a row for an app that exists but has gone quiet, so a broken telemetry pipeline still looks broken instead of looking like an idle cluster. Two behaviour changes come with that, both deliberate. An app with nothing left running now appears for as long as the window reaches its samples (marked `historical`, and `(gone)` in the table), and the three count fields now mean "sandboxes that reported" rather than "sandboxes that were scheduled".

The second commit answers the obvious follow-up, which is which sandboxes actually made up that number. Over a week that's mostly sandboxes nobody can look up any more, so each one is reconstructed from its own metric labels, plus the span it was reporting for. That span is what makes a week's worth readable as a sequence of deployments rather than a pile of ids.

Worth calling out, because I got it wrong first: measuring contributors the way everything else here measures things reported zero for every sandbox over a week. Every collapse in this package evaluates a fixed twenty points across the window, so at seven days the step lands at over eight hours, and a sandbox that lived ten minutes falls between two evaluation points. It still appears in the breakdown, with zeroes beside it, which reads as "used nothing" rather than "not measured". Applied straight to the raw metric instead, `avg_over_time` and `increase` scan the samples themselves, so they're exact at any window length and describe the ten minutes the sandbox was actually up. That's also where `cpu_seconds` comes from. Cores is a rate, so it can't be compared between sandboxes that ran for different durations, but seconds add up and they sum to the app's consumption.

Since the dev cluster only ever holds minutes of history, I checked the week path by backfilling seven days of samples across three deployment generations. The series came back with 60 points spanning the week, and the per-sandbox cores and memory matched what I'd synthesized, with `cpu_seconds` summing exactly to the expected total.

On the cardinality question from the issue: it turns out to be a non-issue. There are two series per sandbox, total. The `instance` label that would have multiplied them is never actually written, because `Setup()` is never called on the sandbox collectors, so it stays empty and an empty label value doesn't exist as far as the store is concerned.

Two small things fell out along the way. App versions outlive the sandboxes that ran them, so the directory now holds on to the version map it was already loading and a departed sandbox can still name a version you can type. And `formatDuration` never rolls up past minutes (fine for a download ETA, less good for a week, which it rendered as `10080m0s`), so these views got a formatter whose unit follows the number.

```
miren top --apps --app shop --since 168h --series --contributors
```

Closes MIR-1829
